### PR TITLE
k8s: handle ``fail_json`` API from inventory plugin

### DIFF
--- a/changelogs/fragments/fail_json.yml
+++ b/changelogs/fragments/fail_json.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- k8s - handle ``fail_json`` API from inventory plugin (https://github.com/ansible-collections/kubernetes.core/issues/57).

--- a/plugins/inventory/k8s.py
+++ b/plugins/inventory/k8s.py
@@ -117,8 +117,11 @@ connections:
 import json
 
 from ansible.errors import AnsibleError
-from ansible_collections.community.kubernetes.plugins.module_utils.common import K8sAnsibleMixin, HAS_K8S_MODULE_HELPER, k8s_import_exception
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
+from ansible_collections.community.kubernetes.plugins.module_utils.common import (
+    K8sAnsibleMixin, HAS_K8S_MODULE_HELPER, k8s_import_exception
+)
+from ansible_collections.community.kubernetes.plugins.module_utils.exceptions import K8sInventoryException
 
 try:
     from openshift.dynamic.exceptions import DynamicApiError
@@ -135,10 +138,6 @@ def format_dynamic_api_exc(exc):
         return exc.body
     else:
         return '%s Reason: %s' % (exc.status, exc.reason)
-
-
-class K8sInventoryException(Exception):
-    pass
 
 
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable, K8sAnsibleMixin):

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -26,12 +26,12 @@ import sys
 from datetime import datetime
 from distutils.version import LooseVersion
 
-
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.six import iteritems, string_types
 from ansible.module_utils._text import to_native, to_bytes, to_text
 from ansible.module_utils.common.dict_transformations import dict_merge
 from ansible.module_utils.parsing.convert_bool import boolean
+from ansible_collections.community.kubernetes.plugins.module_utils.exceptions import K8sInventoryException
 
 
 K8S_IMP_ERR = None
@@ -425,7 +425,9 @@ class K8sAnsibleMixin(object):
         return True, result
 
     def fail(self, msg=None):
-        self.fail_json(msg=msg)
+        if hasattr(self, 'fail_json'):
+            self.fail_json(msg=msg)
+        raise K8sInventoryException(msg)
 
     def _wait_for(self, resource, name, namespace, predicate, sleep, timeout, state):
         start = datetime.now()

--- a/plugins/module_utils/exceptions.py
+++ b/plugins/module_utils/exceptions.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2021, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+class K8sInventoryException(Exception):
+    pass


### PR DESCRIPTION
##### SUMMARY

* inventory plugin does not have module object so fail_json
  will not work. Use AnsibleError instead of ``fail_json``

Fixes: #57

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/fail_json.yml
plugins/inventory/k8s.py
plugins/module_utils/common.py
plugins/module_utils/exceptions.py
