### PR TITLE
Add support for tags to molecule tests

### DIFF
--- a/changelogs/fragments/62-molecule-tags.yaml
+++ b/changelogs/fragments/62-molecule-tags.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - add support for using tags when running molecule test suite (https://github.com/ansible-collections/kubernetes.core/pull/62).

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -20,20 +20,123 @@
       assert:
         that: (pod_list.resources | count) > 5
 
-    - include_tasks: tasks/delete.yml
-    - include_tasks: tasks/scale.yml
-    - include_tasks: tasks/apply.yml
-    - include_tasks: tasks/waiter.yml
-    - include_tasks: tasks/full.yml
-    - include_tasks: tasks/exec.yml
-    - include_tasks: tasks/log.yml
-    - include_tasks: tasks/cluster_info.yml
-    - include_tasks: tasks/access_review.yml
-    - include_tasks: tasks/rollback.yml
-    - include_tasks: tasks/gc.yml
+    - name: Include access_review.yml
+      include_tasks:
+        file: tasks/access_review.yml
+        apply:
+          tags: [ access_review, k8s ]
+      tags:
+        - always
+    - name: Include append_hash.yml
+      include_tasks:
+        file: tasks/append_hash.yml
+        apply:
+          tags: [ append_hash, k8s ]
+      tags:
+        - always
+    - name: Include apply.yml
+      include_tasks:
+        file: tasks/apply.yml
+        apply:
+          tags: [ apply, k8s ]
+      tags:
+        - always
+    - name: Include cluster_info.yml
+      include_tasks:
+        file: tasks/cluster_info.yml
+        apply:
+          tags: [ cluster_info, k8s ]
+      tags:
+        - always
+    - name: Include crd.yml
+      include_tasks:
+        file: tasks/crd.yml
+        apply:
+          tags: [ crd, k8s ]
+      tags:
+        - always
+    - name: Include delete.yml
+      include_tasks:
+        file: tasks/delete.yml
+        apply:
+          tags: [ delete, k8s ]
+      tags:
+        - always
+    - name: Include exec.yml
+      include_tasks:
+        file: tasks/exec.yml
+        apply:
+          tags: [ exec, k8s ]
+      tags:
+        - always
+    - name: Include full.yml
+      include_tasks:
+        file: tasks/full.yml
+        apply:
+          tags: [ full, k8s ]
+      tags:
+        - always
+    - name: Include gc.yml
+      include_tasks:
+        file: tasks/gc.yml
+        apply:
+          tags: [ gc, k8s ]
+      tags:
+        - always
+    - name: Include info.yml
+      include_tasks:
+        file: tasks/info.yml
+        apply:
+          tags: [ info, k8s ]
+      tags:
+        - always
+    - name: Include lists.yml
+      include_tasks:
+        file: tasks/lists.yml
+        apply:
+          tags: [ lists, k8s ]
+      tags:
+        - always
+    - name: Include log.yml
+      include_tasks:
+        file: tasks/log.yml
+        apply:
+          tags: [ log, k8s ]
+      tags:
+        - always
+    - name: Include rollback.yml
+      include_tasks:
+        file: tasks/rollback.yml
+        apply:
+          tags: [ rollback, k8s ]
+      tags:
+        - always
+    - name: Include scale.yml
+      include_tasks:
+        file: tasks/scale.yml
+        apply:
+          tags: [ scale, k8s ]
+      tags:
+        - always
+    - name: Include template.yml
+      include_tasks:
+        file: tasks/template.yml
+        apply:
+          tags: [ template, k8s ]
+      tags:
+        - always
+    - name: Include waiter.yml
+      include_tasks:
+        file: tasks/waiter.yml
+        apply:
+          tags: [ waiter, k8s ]
+      tags:
+        - always
 
   roles:
-    - helm
+    - role: helm
+      tags:
+        - helm
 
   post_tasks:
     - name: Ensure namespace exists

--- a/molecule/default/tasks/full.yml
+++ b/molecule/default/tasks/full.yml
@@ -333,10 +333,6 @@
       register: k8s_info_testing6
       failed_when: not k8s_info_testing6.resources or k8s_info_testing6.resources[0].status.phase != "Active"
 
-    - include_tasks: crd.yml
-    - include_tasks: lists.yml
-    - include_tasks: append_hash.yml
-
   always:
     - name: Delete all namespaces
       k8s:

--- a/molecule/default/tasks/info.yml
+++ b/molecule/default/tasks/info.yml
@@ -2,7 +2,6 @@
 - block:
     - set_fact:
         wait_namespace: wait
-        k8s_pod_name: pod-info-1
         multi_pod_one: multi-pod-1
         multi_pod_two: multi-pod-2
 
@@ -199,6 +198,9 @@
       assert:
         that:
           - "{{ lookup('pipe', 'date +%s') }} - {{ start }} > 30"
+
+  vars:
+    k8s_pod_name: pod-info-1
 
   always:
     - name: Remove namespace

--- a/molecule/default/tasks/lists.yml
+++ b/molecule/default/tasks/lists.yml
@@ -1,139 +1,147 @@
 ---
-- name: Ensure testing1 namespace exists
-  k8s:
-    api_version: v1
-    kind: Namespace
-    name: testing1
-
 - block:
-    - name: Create configmaps
+    - name: Ensure testing1 namespace exists
       k8s:
-        namespace: testing1
-        definition:
-          apiVersion: v1
-          kind: ConfigMapList
-          items: '{{ configmaps }}'
-
-    - name: Get ConfigMaps
-      k8s_info:
         api_version: v1
-        kind: ConfigMap
-        namespace: testing1
-        label_selectors:
-          - app=test
-      register: cms
+        kind: Namespace
+        name: testing1
 
-    - name: All three configmaps should exist
-      assert:
-        that: item.data.a is defined
-      with_items: '{{ cms.resources }}'
+    - block:
+        - name: Create configmaps
+          k8s:
+            namespace: testing1
+            definition:
+              apiVersion: v1
+              kind: ConfigMapList
+              items: '{{ configmaps }}'
 
-    - name: Delete configmaps
+        - name: Get ConfigMaps
+          k8s_info:
+            api_version: v1
+            kind: ConfigMap
+            namespace: testing1
+            label_selectors:
+              - app=test
+          register: cms
+
+        - name: All three configmaps should exist
+          assert:
+            that: item.data.a is defined
+          with_items: '{{ cms.resources }}'
+
+        - name: Delete configmaps
+          k8s:
+            state: absent
+            namespace: testing1
+            definition:
+              apiVersion: v1
+              kind: ConfigMapList
+              items: '{{ configmaps }}'
+
+        - name: Get ConfigMaps
+          k8s_info:
+            api_version: v1
+            kind: ConfigMap
+            namespace: testing1
+            label_selectors:
+              - app=test
+          register: cms
+
+        - name: All three configmaps should not exist
+          assert:
+            that: not cms.resources
+      vars:
+        configmaps:
+          - metadata:
+              name: list-example-1
+              labels:
+                app: test
+            data:
+              a: first
+          - metadata:
+              name: list-example-2
+              labels:
+                app: test
+            data:
+              a: second
+          - metadata:
+              name: list-example-3
+              labels:
+                app: test
+            data:
+              a: third
+
+    - block:
+        - name: Create list of arbitrary resources
+          k8s:
+            namespace: testing1
+            definition:
+              apiVersion: v1
+              kind: List
+              namespace: testing1
+              items: '{{ resources }}'
+
+        - name: Get the created resources
+          k8s_info:
+            api_version: '{{ item.apiVersion }}'
+            kind: '{{ item.kind }}'
+            namespace: testing1
+            name: '{{ item.metadata.name }}'
+          register: list_resources
+          with_items: '{{ resources }}'
+
+        - name: All resources should exist
+          assert:
+            that: ((list_resources.results | sum(attribute="resources", start=[])) | length) == (resources | length)
+
+        - name: Delete list of arbitrary resources
+          k8s:
+            state: absent
+            namespace: testing1
+            definition:
+              apiVersion: v1
+              kind: List
+              namespace: testing1
+              items: '{{ resources }}'
+
+        - name: Get the resources
+          k8s_info:
+            api_version: '{{ item.apiVersion }}'
+            kind: '{{ item.kind }}'
+            namespace: testing1
+            name: '{{ item.metadata.name }}'
+          register: list_resources
+          with_items: '{{ resources }}'
+
+        - name: The resources should not exist
+          assert:
+            that: not ((list_resources.results | sum(attribute="resources", start=[])) | length)
+      vars:
+        resources:
+          - apiVersion: v1
+            kind: ConfigMap
+            metadata:
+              name: list-example-4
+            data:
+              key: value
+          - apiVersion: v1
+            kind: Service
+            metadata:
+              name: list-example-svc
+              labels:
+                app: test
+            spec:
+              selector:
+                app: test
+              ports:
+                - protocol: TCP
+                  targetPort: 8000
+                  name: port-8000-tcp
+                  port: 8000
+  always:
+    - name: Remove testing1 namespace
       k8s:
+        kind: Namespace
+        name: testing1
         state: absent
-        namespace: testing1
-        definition:
-          apiVersion: v1
-          kind: ConfigMapList
-          items: '{{ configmaps }}'
-
-    - name: Get ConfigMaps
-      k8s_info:
-        api_version: v1
-        kind: ConfigMap
-        namespace: testing1
-        label_selectors:
-          - app=test
-      register: cms
-
-    - name: All three configmaps should not exist
-      assert:
-        that: not cms.resources
-  vars:
-    configmaps:
-      - metadata:
-          name: list-example-1
-          labels:
-            app: test
-        data:
-          a: first
-      - metadata:
-          name: list-example-2
-          labels:
-            app: test
-        data:
-          a: second
-      - metadata:
-          name: list-example-3
-          labels:
-            app: test
-        data:
-          a: third
-
-- block:
-    - name: Create list of arbitrary resources
-      k8s:
-        namespace: testing1
-        definition:
-          apiVersion: v1
-          kind: List
-          namespace: testing1
-          items: '{{ resources }}'
-
-    - name: Get the created resources
-      k8s_info:
-        api_version: '{{ item.apiVersion }}'
-        kind: '{{ item.kind }}'
-        namespace: testing1
-        name: '{{ item.metadata.name }}'
-      register: list_resources
-      with_items: '{{ resources }}'
-
-    - name: All resources should exist
-      assert:
-        that: ((list_resources.results | sum(attribute="resources", start=[])) | length) == (resources | length)
-
-    - name: Delete list of arbitrary resources
-      k8s:
-        state: absent
-        namespace: testing1
-        definition:
-          apiVersion: v1
-          kind: List
-          namespace: testing1
-          items: '{{ resources }}'
-
-    - name: Get the resources
-      k8s_info:
-        api_version: '{{ item.apiVersion }}'
-        kind: '{{ item.kind }}'
-        namespace: testing1
-        name: '{{ item.metadata.name }}'
-      register: list_resources
-      with_items: '{{ resources }}'
-
-    - name: The resources should not exist
-      assert:
-        that: not ((list_resources.results | sum(attribute="resources", start=[])) | length)
-  vars:
-    resources:
-      - apiVersion: v1
-        kind: ConfigMap
-        metadata:
-          name: list-example-4
-        data:
-          key: value
-      - apiVersion: v1
-        kind: Service
-        metadata:
-          name: list-example-svc
-          labels:
-            app: test
-        spec:
-          selector:
-            app: test
-          ports:
-            - protocol: TCP
-              targetPort: 8000
-              name: port-8000-tcp
-              port: 8000
+      ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Parts of the molecule test suite can now be run selectively using tags.
All the kubernetes related tests are grouped into a tag called `k8s`
while the helm tests are grouped into a tag called `helm`. The k8s tests
are further divided into tags representing the various files in the
tasks folder.

For example, to run only the tests in the waiter.yml file, you can use:
```
  $ molecule converge -- --tags waiter
```

Also, some of k8s tests have not been getting run because they weren't
included anywhere in the test suite. Those are all now included in
converge.yml.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
molecule

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
