### PR TITLE
k8s inventory - remove trailing slashes from hostname

### DIFF
--- a/changelogs/fragments/52_inventory.yml
+++ b/changelogs/fragments/52_inventory.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- k8s inventory - remove extra trailing slashes from the hostname (https://github.com/ansible-collections/kubernetes.core/issues/52).

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -124,8 +124,7 @@ def get_api_client(module=None, **kwargs):
     def _raise_or_fail(exc, msg):
         if module:
             module.fail_json(msg % to_native(exc))
-        else:
-            raise exc
+        raise exc
 
     # If authorization variables aren't defined, look for them in environment variables
     for true_name, arg_name in AUTH_ARG_MAP.items():
@@ -142,6 +141,10 @@ def get_api_client(module=None, **kwargs):
 
     def auth_set(*names):
         return all([auth.get(name) for name in names])
+
+    if auth_set('host'):
+        # Removing trailing slashes if any from hostname
+        auth['host'] = auth.get('host').rstrip('/')
 
     if auth_set('username', 'password', 'host') or auth_set('api_key', 'host'):
         # We have enough in the parameters to authenticate, no need to load incluster or kubeconfig


### PR DESCRIPTION
##### SUMMARY

When user provides hostname with trailing slashes like
https://localhost:6443/, the openshift library fails to
enumerate the APIs from the given cluster.

This fix removes any extra trailing slashes before sending it
to the openshift DynamicClient.

Fixes: #52

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/52_inventory.yml
plugins/module_utils/common.py
