### PR TITLE
Update kubeconfig file location in docs

### DIFF
--- a/changelogs/fragments/53_kubeconfig_docs.yml
+++ b/changelogs/fragments/53_kubeconfig_docs.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- kubeconfig - update ``kubeconfig`` file location in the documentation (https://github.com/ansible-collections/kubernetes.core/issues/53).

--- a/docs/kubernetes.core.k8s_cluster_info_module.rst
+++ b/docs/kubernetes.core.k8s_cluster_info_module.rst
@@ -167,7 +167,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Path to an existing Kubernetes config file. If not provided, and no other connection options are provided, the openshift client will attempt to load the default configuration file from <em>~/.kube/config.json</em>. Can also be specified via K8S_AUTH_KUBECONFIG environment variable.</div>
+                        <div>Path to an existing Kubernetes config file. If not provided, and no other connection options are provided, the openshift client will attempt to load the default configuration file from <em>~/.kube/config</em>. Can also be specified via K8S_AUTH_KUBECONFIG environment variable.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/kubernetes.core.k8s_exec_module.rst
+++ b/docs/kubernetes.core.k8s_exec_module.rst
@@ -178,7 +178,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Path to an existing Kubernetes config file. If not provided, and no other connection options are provided, the openshift client will attempt to load the default configuration file from <em>~/.kube/config.json</em>. Can also be specified via K8S_AUTH_KUBECONFIG environment variable.</div>
+                        <div>Path to an existing Kubernetes config file. If not provided, and no other connection options are provided, the openshift client will attempt to load the default configuration file from <em>~/.kube/config</em>. Can also be specified via K8S_AUTH_KUBECONFIG environment variable.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/kubernetes.core.k8s_info_module.rst
+++ b/docs/kubernetes.core.k8s_info_module.rst
@@ -204,7 +204,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Path to an existing Kubernetes config file. If not provided, and no other connection options are provided, the openshift client will attempt to load the default configuration file from <em>~/.kube/config.json</em>. Can also be specified via K8S_AUTH_KUBECONFIG environment variable.</div>
+                        <div>Path to an existing Kubernetes config file. If not provided, and no other connection options are provided, the openshift client will attempt to load the default configuration file from <em>~/.kube/config</em>. Can also be specified via K8S_AUTH_KUBECONFIG environment variable.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/kubernetes.core.k8s_inventory.rst
+++ b/docs/kubernetes.core.k8s_inventory.rst
@@ -187,7 +187,7 @@ Parameters
                     <td>
                     </td>
                 <td>
-                        <div>Path to an existing Kubernetes config file. If not provided, and no other connection options are provided, the OpenShift client will attempt to load the default configuration file from <em>~/.kube/config.json</em>. Can also be specified via K8S_AUTH_KUBECONFIG environment variable.</div>
+                        <div>Path to an existing Kubernetes config file. If not provided, and no other connection options are provided, the OpenShift client will attempt to load the default configuration file from <em>~/.kube/config</em>. Can also be specified via K8S_AUTH_KUBECONFIG environment variable.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/kubernetes.core.k8s_log_module.rst
+++ b/docs/kubernetes.core.k8s_log_module.rst
@@ -204,7 +204,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Path to an existing Kubernetes config file. If not provided, and no other connection options are provided, the openshift client will attempt to load the default configuration file from <em>~/.kube/config.json</em>. Can also be specified via K8S_AUTH_KUBECONFIG environment variable.</div>
+                        <div>Path to an existing Kubernetes config file. If not provided, and no other connection options are provided, the openshift client will attempt to load the default configuration file from <em>~/.kube/config</em>. Can also be specified via K8S_AUTH_KUBECONFIG environment variable.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/kubernetes.core.k8s_lookup.rst
+++ b/docs/kubernetes.core.k8s_lookup.rst
@@ -232,7 +232,7 @@ Parameters
                     <td>
                     </td>
                 <td>
-                        <div>Path to an existing Kubernetes config file. If not provided, and no other connection options are provided, the openshift client will attempt to load the default configuration file from <em>~/.kube/config.json</em>. Can also be specified via K8S_AUTH_KUBECONFIG environment variable.</div>
+                        <div>Path to an existing Kubernetes config file. If not provided, and no other connection options are provided, the openshift client will attempt to load the default configuration file from <em>~/.kube/config</em>. Can also be specified via K8S_AUTH_KUBECONFIG environment variable.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/kubernetes.core.k8s_module.rst
+++ b/docs/kubernetes.core.k8s_module.rst
@@ -361,7 +361,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Path to an existing Kubernetes config file. If not provided, and no other connection options are provided, the openshift client will attempt to load the default configuration file from <em>~/.kube/config.json</em>. Can also be specified via K8S_AUTH_KUBECONFIG environment variable.</div>
+                        <div>Path to an existing Kubernetes config file. If not provided, and no other connection options are provided, the openshift client will attempt to load the default configuration file from <em>~/.kube/config</em>. Can also be specified via K8S_AUTH_KUBECONFIG environment variable.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/kubernetes.core.k8s_rollback_module.rst
+++ b/docs/kubernetes.core.k8s_rollback_module.rst
@@ -202,7 +202,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Path to an existing Kubernetes config file. If not provided, and no other connection options are provided, the openshift client will attempt to load the default configuration file from <em>~/.kube/config.json</em>. Can also be specified via K8S_AUTH_KUBECONFIG environment variable.</div>
+                        <div>Path to an existing Kubernetes config file. If not provided, and no other connection options are provided, the openshift client will attempt to load the default configuration file from <em>~/.kube/config</em>. Can also be specified via K8S_AUTH_KUBECONFIG environment variable.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/kubernetes.core.k8s_scale_module.rst
+++ b/docs/kubernetes.core.k8s_scale_module.rst
@@ -198,7 +198,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Path to an existing Kubernetes config file. If not provided, and no other connection options are provided, the openshift client will attempt to load the default configuration file from <em>~/.kube/config.json</em>. Can also be specified via K8S_AUTH_KUBECONFIG environment variable.</div>
+                        <div>Path to an existing Kubernetes config file. If not provided, and no other connection options are provided, the openshift client will attempt to load the default configuration file from <em>~/.kube/config</em>. Can also be specified via K8S_AUTH_KUBECONFIG environment variable.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/kubernetes.core.k8s_service_module.rst
+++ b/docs/kubernetes.core.k8s_service_module.rst
@@ -184,7 +184,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Path to an existing Kubernetes config file. If not provided, and no other connection options are provided, the openshift client will attempt to load the default configuration file from <em>~/.kube/config.json</em>. Can also be specified via K8S_AUTH_KUBECONFIG environment variable.</div>
+                        <div>Path to an existing Kubernetes config file. If not provided, and no other connection options are provided, the openshift client will attempt to load the default configuration file from <em>~/.kube/config</em>. Can also be specified via K8S_AUTH_KUBECONFIG environment variable.</div>
                 </td>
             </tr>
             <tr>

--- a/plugins/doc_fragments/k8s_auth_options.py
+++ b/plugins/doc_fragments/k8s_auth_options.py
@@ -25,7 +25,7 @@ options:
     description:
     - Path to an existing Kubernetes config file. If not provided, and no other connection
       options are provided, the openshift client will attempt to load the default
-      configuration file from I(~/.kube/config.json). Can also be specified via K8S_AUTH_KUBECONFIG environment
+      configuration file from I(~/.kube/config). Can also be specified via K8S_AUTH_KUBECONFIG environment
       variable.
     type: path
   context:

--- a/plugins/inventory/k8s.py
+++ b/plugins/inventory/k8s.py
@@ -38,7 +38,7 @@ DOCUMENTATION = '''
                   description:
                   - Path to an existing Kubernetes config file. If not provided, and no other connection
                     options are provided, the OpenShift client will attempt to load the default
-                    configuration file from I(~/.kube/config.json). Can also be specified via K8S_AUTH_KUBECONFIG
+                    configuration file from I(~/.kube/config). Can also be specified via K8S_AUTH_KUBECONFIG
                     environment variable.
               context:
                   description:

--- a/plugins/lookup/k8s.py
+++ b/plugins/lookup/k8s.py
@@ -86,7 +86,7 @@ DOCUMENTATION = '''
         description:
         - Path to an existing Kubernetes config file. If not provided, and no other connection
           options are provided, the openshift client will attempt to load the default
-          configuration file from I(~/.kube/config.json). Can also be specified via K8S_AUTH_KUBECONFIG environment
+          configuration file from I(~/.kube/config). Can also be specified via K8S_AUTH_KUBECONFIG environment
           variable.
       context:
         description:


### PR DESCRIPTION
##### SUMMARY

Fixes: #53

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelogs/fragments/53_kubeconfig_docs.yml
docs/kubernetes.core.k8s_cluster_info_module.rst
docs/kubernetes.core.k8s_exec_module.rst
docs/kubernetes.core.k8s_info_module.rst
docs/kubernetes.core.k8s_inventory.rst
docs/kubernetes.core.k8s_log_module.rst
docs/kubernetes.core.k8s_lookup.rst
docs/kubernetes.core.k8s_module.rst
docs/kubernetes.core.k8s_rollback_module.rst
docs/kubernetes.core.k8s_scale_module.rst
docs/kubernetes.core.k8s_service_module.rst
plugins/doc_fragments/k8s_auth_options.py
plugins/inventory/k8s.py
plugins/lookup/k8s.py
