### PR TITLE
common: Handle aliases correctly

### DIFF
--- a/changelogs/fragments/honor_aliases.yml
+++ b/changelogs/fragments/honor_aliases.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- common - handle ``aliases`` passed from inventory or module params.

--- a/molecule/default/tasks/full.yml
+++ b/molecule/default/tasks/full.yml
@@ -10,6 +10,20 @@
       debug:
         var: output
 
+    - name: Use aliases and check if those values are picked up
+      k8s:
+        name: testing
+        kind: Namespace
+        validate_certs: yes
+        ssl_ca_cert: /dev/null  # invalid CA certificate
+      ignore_errors: yes
+      register: output
+
+    - name: assert that ssl_ca_cert caused a failure (and therefore was correctly translated to ssl_ca_cert)
+      assert:
+        that:
+          - output is failed
+
     - name: Setting validate_certs to true causes a failure
       k8s:
         name: testing

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -131,6 +131,12 @@ def get_api_client(module=None, **kwargs):
     for true_name, arg_name in AUTH_ARG_MAP.items():
         if module and module.params.get(arg_name):
             auth[true_name] = module.params.get(arg_name)
+        elif module and true_name in module.params and module.params.get(true_name) is not None:
+            # Aliases
+            auth[true_name] = module.params.get(true_name)
+        elif true_name in kwargs and kwargs.get(true_name) is not None:
+            # Aliases
+            auth[true_name] = kwargs.get(true_name)
         elif arg_name in kwargs and kwargs.get(arg_name) is not None:
             auth[true_name] = kwargs.get(arg_name)
         else:


### PR DESCRIPTION
##### SUMMARY

Fixed get_api_client API to handle `aliases` that
are passed via inventory configuration or module parameters.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/honor_aliases.yml
molecule/default/tasks/full.yml
plugins/module_utils/common.py
