### PR TITLE
yamllint and flake8 should ignore .cache

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -14,3 +14,5 @@ rules:
   indentation:
     spaces: 2
     indent-sequences: consistent
+ignore: |
+  .cache

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,4 @@
 [flake8]
 max-line-length = 160
 ignore = W503,E402
+exclude = .cache


### PR DESCRIPTION
The content of .cache is not maintained in this repository. There
is no point raising an error when there is problem in one of these
3rd party dependencies.