### PR TITLE
helm: accept context and validate_certs

### DIFF
--- a/changelogs/fragments/helm_validate_certs_not_exclusive.yaml
+++ b/changelogs/fragments/helm_validate_certs_not_exclusive.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- "helm - Accept ``validate_certs`` with a ``context`` (https://github.com/ansible-collections/kubernetes.core/pull/74)."

--- a/plugins/modules/helm.py
+++ b/plugins/modules/helm.py
@@ -519,9 +519,7 @@ def main():
         ],
         mutually_exclusive=[
             ("context", "ca_cert"),
-            ("context", "validate_certs"),
             ("kubeconfig", "ca_cert"),
-            ("kubeconfig", "validate_certs")
         ],
         supports_check_mode=True,
     )


### PR DESCRIPTION
I've got the following environment variable set:
- `K8S_AUTH_VERIFY_SSL=False`

Helm's `validate_certs` parameter fallback on this environment variable.
Which means, on my system, the `validate_certs` will already be set.

So we cannot make this parameter exclusive wih another one.