### PR TITLE
Fix client regression from turbo mode refactor

### DIFF
--- a/molecule/default/tasks/full.yml
+++ b/molecule/default/tasks/full.yml
@@ -24,6 +24,38 @@
         that:
           - output is failed
 
+    - block:
+        - name: Copy default kubeconfig
+          copy:
+            remote_src: yes
+            src: ~/.kube/config
+            dest: ~/.kube/customconfig
+
+        - name: Delete default kubeconfig
+          file:
+            path: ~/.kube/config
+            state: absent
+
+        - name: Using custom config location should succeed
+          kubernetes.core.k8s:
+            name: testing
+            kind: Namespace
+            kubeconfig: ~/.kube/customconfig
+
+      always:
+        - name: Return kubeconfig
+          copy:
+            remote_src: yes
+            src: ~/.kube/customconfig
+            dest: ~/.kube/config
+          ignore_errors: yes
+
+        - name: Delete custom config
+          file:
+            path: ~/.kube/customconfig
+            state: absent
+          ignore_errors: yes
+
     - name: Ensure k8s_info works with empty resources
       k8s_info:
         kind: Deployment

--- a/plugins/lookup/k8s.py
+++ b/plugins/lookup/k8s.py
@@ -239,7 +239,7 @@ class KubernetesLookup(K8sAnsibleMixin):
 
     def run(self, terms, variables=None, **kwargs):
         self.params = kwargs
-        self.client = get_api_client()
+        self.client = get_api_client(**kwargs)
 
         cluster_info = kwargs.get('cluster_info')
         if cluster_info == 'version':

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -498,7 +498,7 @@ class K8sAnsibleMixin(object):
         changed = False
         results = []
         try:
-            self.client = get_api_client()
+            self.client = get_api_client(self.module)
         # Hopefully the kubernetes client will provide its own exception class one day
         except (urllib3.exceptions.RequestError) as e:
             self.fail_json(msg="Couldn't connect to Kubernetes: %s" % str(e))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The turbo mode refactoring introduced a regression where the kubernetes
client can fail to find the kubeconfig. This happens because
get_api_client is called twice and the second time it is called without
the module being passed as an argument. Without this, the configuration
will use defaults. This will be a problem if the user has specified a
location for the kubeconfig that's different from default, for example.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #78 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
