### PR TITLE
integration: use venv instead of virtualenv

### DIFF
--- a/tests/integration/targets/kubernetes/tasks/main.yml
+++ b/tests/integration/targets/kubernetes/tasks/main.yml
@@ -3,13 +3,10 @@
 
 - set_fact:
     virtualenv: "{{ remote_tmp_dir }}/virtualenv"
-    virtualenv_command: "{{ ansible_python_interpreter }} -m virtualenv"
+    virtualenv_command: "{{ ansible_python_interpreter }} -m venv"
 
 - set_fact:
     virtualenv_interpreter: "{{ virtualenv }}/bin/python"
-
-- pip:
-    name: virtualenv
 
 # Test graceful failure for missing kubernetes-validate
 


### PR DESCRIPTION
virtualenv is deprecated since Python3. We use venv instead.