### PR TITLE
``helm_plugin`` and ``helm_plugin_info`` remove unused parameter ``release_namespace``

### DIFF
--- a/changelogs/fragments/85_helm_plugin.yaml
+++ b/changelogs/fragments/85_helm_plugin.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+- helm_plugin - remove unused ``release_namespace`` parameter.
+- helm_plugin_info - remove unused ``release_namespace`` parameter.

--- a/changelogs/fragments/85_helm_plugin.yaml
+++ b/changelogs/fragments/85_helm_plugin.yaml
@@ -1,3 +1,3 @@
-minor_changes:
+breaking_changes:
 - helm_plugin - remove unused ``release_namespace`` parameter.
 - helm_plugin_info - remove unused ``release_namespace`` parameter.

--- a/molecule/default/roles/helm/tasks/tests_helm_diff.yml
+++ b/molecule/default/roles/helm/tasks/tests_helm_diff.yml
@@ -6,7 +6,6 @@
   block:
     - name: Install helm diff
       helm_plugin:
-        namespace: "{{ helm_namespace }}"
         state: present
         plugin_path: https://github.com/databus23/helm-diff
 
@@ -137,7 +136,6 @@
 
     - name: Uninstall helm diff
       helm_plugin:
-        namespace: "{{ helm_namespace }}"
         state: absent
         plugin_name: diff
       ignore_errors: yes

--- a/plugins/modules/helm_plugin.py
+++ b/plugins/modules/helm_plugin.py
@@ -20,13 +20,6 @@ requirements:
 description:
   -  Manages Helm plugins.
 options:
-  # TODO: (akasurde) Remove this in version 2.0
-  release_namespace:
-    description:
-      - Kubernetes namespace where the helm plugin should be installed.
-    type: str
-    aliases: [ namespace ]
-
 #Helm options
   state:
     description:
@@ -108,7 +101,6 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             binary_path=dict(type='path'),
-            release_namespace=dict(type='str', aliases=['namespace']),
             state=dict(type='str', default='present', choices=['present', 'absent']),
             plugin_path=dict(type='str',),
             plugin_name=dict(type='str',),

--- a/plugins/modules/helm_plugin_info.py
+++ b/plugins/modules/helm_plugin_info.py
@@ -20,13 +20,6 @@ requirements:
 description:
   -  Gather information about Helm plugins installed in namespace.
 options:
-  # TODO: (akasurde) Remove this in version 2.0
-  release_namespace:
-    description:
-      - Kubernetes namespace where the helm plugins are installed.
-    type: str
-    aliases: [ namespace ]
-
 #Helm options
   plugin_name:
     description:
@@ -88,7 +81,6 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             binary_path=dict(type='path'),
-            release_namespace=dict(type='str', aliases=['namespace']),
             plugin_name=dict(type='str',),
             # Helm options
             context=dict(type='str', aliases=['kube_context'], fallback=(env_fallback, ['K8S_AUTH_CONTEXT'])),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
``release_namespace`` was make unused in release ``1.0.0`` now it is removed on modules
``helm_plugin`` and ``helm_plugin_info`` for release ``2.0.0``
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request
