### PR TITLE
Remove jsonpatch dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
       # The 3.3.0 release of molecule introduced a breaking change. See
       # https://github.com/ansible-community/molecule/issues/3083
       - name: Install molecule and openshift dependencies
-        run: pip install ansible "molecule<3.3.0" yamllint openshift flake8 jsonpatch
+        run: pip install ansible "molecule<3.3.0" yamllint openshift flake8
 
       # The latest release doesn't work with Molecule currently.
       # See: https://github.com/ansible-community/molecule/issues/2757

--- a/changelogs/fragments/92-remove-jsonpatch-dependency.yaml
+++ b/changelogs/fragments/92-remove-jsonpatch-dependency.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - k8s - remove dependency on third party jsonpatch (https://github.com/ansible-collections/kubernetes.core/pull/92).

--- a/molecule/default/tasks/merge_type.yml
+++ b/molecule/default/tasks/merge_type.yml
@@ -185,6 +185,24 @@
       that:
       - describe_pod.resources[0].spec.containers[0].image == 'python:3.8-alpine'
 
+  - name: Apply the same json patch to pod
+    kubernetes.core.k8s:
+      kind: Pod
+      namespace: "{{ k8s_patch_namespace }}"
+      name: "{{ k8s_json }}-pod"
+      merge_type:
+      - json
+      definition:
+      - op: replace
+        path: /spec/containers/0/image
+        value: python:3.8-alpine
+    register: pod_patch
+
+  - name: assert that nothing changed
+    assert:
+      that:
+      - not pod_patch.changed
+
   - name: create a simple nginx deployment
     kubernetes.core.k8s:
       namespace: "{{ k8s_patch_namespace }}"
@@ -224,6 +242,9 @@
       - op: add
         path: '/spec/template/spec/containers/0/args/-'
         value: 'touch /var/log'
+      - op: add
+        path: '/metadata/labels/foo'
+        value: 'bar'
     register: patch_out
 
   - name: assert that patch succeed
@@ -238,10 +259,11 @@
       namespace: "{{ k8s_patch_namespace }}"
     register: describe_depl
 
-  - name: assert that args changed on deployment
+  - name: assert that all patch operations modified the deployment
     assert:
       that:
       - describe_depl.resources[0].spec.template.spec.containers[0].args | length == 4
+      - describe_depl.resources[0].metadata.labels.foo == "bar"
 
   always:
   - name: Ensure namespace has been deleted

--- a/plugins/modules/k8s.py
+++ b/plugins/modules/k8s.py
@@ -136,7 +136,6 @@ requirements:
   - "python >= 2.7"
   - "openshift >= 0.6"
   - "PyYAML >= 3.11"
-  - "jsonpatch"
 '''
 
 EXAMPLES = r'''

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 openshift>=0.6.2
 requests-oauthlib
-jsonpatch


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The recently discovered bug with json patch merge type was initially
addressed by applying the json patch client-side. This change instead
ensures that the json patch is passed through to the kubernetes api
unmodified. As this addresses the root cause of the bug, the jsonpatch
dependency is no longer necessary.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
k8s
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
