### PR TITLE
Correct helm_info return type docs for app_version

### DIFF
--- a/docs/kubernetes.core.helm_info_module.rst
+++ b/docs/kubernetes.core.helm_info_module.rst
@@ -242,7 +242,7 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                     <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="return-"></div>
-                    <b>appversion</b>
+                    <b>app_version</b>
                     <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
                     <div style="font-size: small">
                       <span style="color: purple">string</span>

--- a/plugins/modules/helm_info.py
+++ b/plugins/modules/helm_info.py
@@ -55,7 +55,7 @@ status:
   description: A dictionary of status output
   returned: only when release exists
   contains:
-    appversion:
+    app_version:
       type: str
       returned: always
       description: Version of app deployed


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Previously the helm_info docs showed that the app version was returned as `appversion`.
Upon running this locally, it seems the return key is actually `app_version`. Corrected
documentation accordingly.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`kubernetes.core.helm_info` (I think, this is my first time using ansible).

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
To reproduce the issue you'll need a kubernetes cluster (be it minikube, full k8s, or similar) with a helm chart installed. This ansible will return an error stating the key `appversion` does not exist.

```
---
- name: Get info on helm chart
  hosts: localhost
  gather_facts: false
  connection: local
  vars:
    container_tag: latest

  tasks:
    - name: Get info on application helm chart
      kubernetes.core.helm_info:
        name: <Helm chart name here>
        namespace: default
      register: r
    - name: Print chart info
      debug:
        msg: "{{ r.status.appversion }}"
```

Replacing `"{{ r.status.appversion }}"` on the last line with `"{{ r.status.app_version }}"` works, which shows that the documentation is slightly incorrect.