### PR TITLE
Account for updated pods when waiting on DaemonSet

### DIFF
--- a/changelogs/fragments/102-wait-updated-daemonset-pods.yaml
+++ b/changelogs/fragments/102-wait-updated-daemonset-pods.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - k8s - wait for all pods to update when rolling out daemonset changes (https://github.com/ansible-collections/kubernetes.core/pull/102).

--- a/molecule/default/tasks/waiter.yml
+++ b/molecule/default/tasks/waiter.yml
@@ -54,6 +54,9 @@
       vars:
         k8s_pod_name: wait-ds
         k8s_pod_image: gcr.io/kuar-demo/kuard-amd64:1
+        k8s_pod_command:
+          - sleep
+          - "600"
       register: ds
 
     - name: Check that daemonset wait worked
@@ -82,6 +85,9 @@
       vars:
         k8s_pod_name: wait-ds
         k8s_pod_image: gcr.io/kuar-demo/kuard-amd64:2
+        k8s_pod_command:
+          - sleep
+          - "600"
       register: update_ds_check_mode
       check_mode: yes
 
@@ -112,6 +118,9 @@
       vars:
         k8s_pod_name: wait-ds
         k8s_pod_image: gcr.io/kuar-demo/kuard-amd64:3
+        k8s_pod_command:
+          - sleep
+          - "600"
       register: ds
 
     - name: Get updated pods

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -403,6 +403,7 @@ class K8sAnsibleMixin(object):
 
         def _daemonset_ready(daemonset):
             return (daemonset.status and daemonset.status.desiredNumberScheduled is not None
+                    and daemonset.status.updatedNumberScheduled == daemonset.status.desiredNumberScheduled
                     and daemonset.status.numberReady == daemonset.status.desiredNumberScheduled
                     and daemonset.status.observedGeneration == daemonset.metadata.generation
                     and not daemonset.status.unavailableReplicas)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
We have been seeing infrequent CI failures recently during the DaemonSet tests in the waiter test suite. The problem can be reliably reproduced by using a container that ignores SIGTERM and forces the replacement cycle to run out the grace period for termination. The logic we're using to determine when a DaemonSet is ready checks whether the number of nodes that should be running the daemon pod is the same as the number nodes currently running a daemon pod. In this case, however, the pod is the old pod that just hasn't been replaced, yet. This change makes sure the number of nodes that should be running the daemon pod is the same as the number of nodes currently running _the updated daemon pod_.

From what I can tell, this follows the same logic used by kubectl when waiting on a rollout:
https://github.com/kubernetes/kubectl/blob/ac49920c0ccb0dd0899d5300fc43713ee2dfcdc9/pkg/polymorphichelpers/rollout_status.go#L107-L115.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
k8s

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
