### PR TITLE
Remove empty docstring in filter plugin

### DIFF
--- a/plugins/filter/k8s.py
+++ b/plugins/filter/k8s.py
@@ -22,9 +22,6 @@ def k8s_config_resource_name(resource):
 
 # ---- Ansible filters ----
 class FilterModule(object):
-    """
-
-    """
 
     def filters(self):
         return {


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
A recent change somewhere upstream broke the sanity tests. This
partially reverts 0eb1559cc7347398a66bcb6586e37d594d094106 to remove the
empty docstring on the filter plugin. The reason the empty docstring was
added in the first place was to fix a problem with the doc generation
script. However, a recent change to the collection_prep project fixed
that issue so we no longer need the empty docstring.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
