### PR TITLE
lookup: return list even if single item found

### DIFF
--- a/changelogs/fragments/9_lookup_k8s.yml
+++ b/changelogs/fragments/9_lookup_k8s.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- k8s - lookup should return list even if single item is found (https://github.com/ansible-collections/kubernetes.core/issues/9).

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -156,6 +156,14 @@
       tags:
         - always
 
+    - name: Include lookup_k8s.yml
+      include_tasks:
+        file: tasks/lookup_k8s.yml
+        apply:
+          tags: [ lookup, k8s ]
+      tags:
+        - always
+
   roles:
     - role: helm
       tags:

--- a/molecule/default/tasks/lookup_k8s.yml
+++ b/molecule/default/tasks/lookup_k8s.yml
@@ -1,0 +1,54 @@
+---
+- block:
+    # https://github.com/ansible-collections/kubernetes.core/issues/9
+    - name: Create a namespace with label
+      kubernetes.core.k8s:
+        definition:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: "app-development-one"
+            labels:
+              namespace_label: "app_development"
+
+    - set_fact:
+        namespace_info: "{{ lookup('kubernetes.core.k8s', kind='Namespace', label_selector='namespace_label=app_development') }}"
+
+    - name: Check if the returned value is list with a single element
+      assert:
+        that:
+          - namespace_info is iterable
+          - not namespace_info is string
+          - not namespace_info is mapping
+          - namespace_info | length == 1
+
+    - name: Create another namespace with label
+      kubernetes.core.k8s:
+        definition:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: "app-development-two"
+            labels:
+              namespace_label: "app_development"
+
+    - set_fact:
+        namespace_info: "{{ lookup('kubernetes.core.k8s', kind='Namespace', label_selector='namespace_label=app_development') }}"
+
+    - name: Check if the returned value is list with 2 elements
+      assert:
+        that:
+          - namespace_info is iterable
+          - not namespace_info is string
+          - not namespace_info is mapping
+          - namespace_info | length == 2
+
+  always:
+    - name: Ensure that namespace is removed
+      k8s:
+        kind: Namespace
+        name: "{{ item }}"
+        state: absent
+      with_items:
+        - app-development-one
+        - app-development-two

--- a/plugins/lookup/k8s.py
+++ b/plugins/lookup/k8s.py
@@ -1,20 +1,7 @@
 #
 #  Copyright 2018 Red Hat | Ansible
 #
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import (absolute_import, division, print_function)
 
@@ -277,7 +264,7 @@ class KubernetesLookup(K8sAnsibleMixin):
         if self.name:
             return [k8s_obj.to_dict()]
 
-        return k8s_obj.to_dict().get('items')
+        return [k8s_obj.to_dict().get('items')]
 
 
 class LookupModule(LookupBase):


### PR DESCRIPTION
##### SUMMARY

Always return list from k8s lookup plugin

Fixes: #9

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/9_lookup_k8s.yml
molecule/default/converge.yml
molecule/default/tasks/lookup_k8s.yml
plugins/lookup/k8s.py
