### PR TITLE
Remove deprecated k8s_facts

### DIFF
--- a/changelogs/fragments/125-remove-k8s-facts-alias.yaml
+++ b/changelogs/fragments/125-remove-k8s-facts-alias.yaml
@@ -1,0 +1,3 @@
+---
+breaking_changes:
+  - k8s_facts - remove the deprecated alias from k8s_facts to k8s_info (https://github.com/ansible-collections/kubernetes.core/pull/125).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -49,10 +49,8 @@ plugin_routing:
   modules:
     k8s_auth:
       redirect: community.okd.k8s_auth
-    # k8s_facts was originally slated for removal in Ansible 2.13.
     k8s_facts:
-      redirect: kubernetes.core.k8s_info
-      deprecation:
+      tombstone:
         removal_version: 2.0.0
         warning_text: Use kubernetes.core.k8s_info instead.
     k8s_raw:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This removes the k8s_facts alias to k8s_info.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
k8s_facts
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
