### PR TITLE
Add community.kubernetes to inventory plugin param

### DIFF
--- a/changelogs/fragments/128-update-inventory-plugin-param.yaml
+++ b/changelogs/fragments/128-update-inventory-plugin-param.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - inventory - add community.kubernetes to list of plugin choices in k8s inventory (https://github.com/ansible-collections/kubernetes.core/pull/128).

--- a/plugins/inventory/k8s.py
+++ b/plugins/inventory/k8s.py
@@ -23,7 +23,7 @@ DOCUMENTATION = '''
       plugin:
          description: token that ensures this is a source file for the 'k8s' plugin.
          required: True
-         choices: ['kubernetes.core.k8s', 'k8s']
+         choices: ['kubernetes.core.k8s', 'k8s', 'community.kubernetes.k8s']
       connections:
           description:
           - Optional list of cluster connection settings. If no connections are provided, the default


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In order for the community.kubernetes 2.0 redirects to work, the plugin
parameter for the inventory plugin needs to be updated.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
