### PR TITLE
Add sinceSeconds parameter to k8s_logs

### DIFF
--- a/changelogs/fragments/142-add-sinceseconds-param-for-logs.yaml
+++ b/changelogs/fragments/142-add-sinceseconds-param-for-logs.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - k8s_log - Add since-seconds parameter to the k8s_log module (https://github.com/ansible-collections/kubernetes.core/pull/142).

--- a/docs/kubernetes.core.k8s_log_module.rst
+++ b/docs/kubernetes.core.k8s_log_module.rst
@@ -147,21 +147,6 @@ Parameters
             <tr>
                 <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>since_seconds</b>
-                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
-                    <div style="font-size: small">
-                        <span style="color: purple">string</span>
-                    </div>
-                </td>
-                <td>
-                </td>
-                <td>
-                        <div>A relative time in seconds before the current time from which to show logs.</div>
-                </td>
-            </tr>
-            <tr>
-                <td colspan="2">
-                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>context</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -472,7 +457,6 @@ Examples
         kind: Deployment
         namespace: testing
         name: example
-        sinceSeconds: "4000"
       register: log
 
     # This will get the log from a single Pod managed by this DeploymentConfig

--- a/docs/kubernetes.core.k8s_log_module.rst
+++ b/docs/kubernetes.core.k8s_log_module.rst
@@ -147,6 +147,21 @@ Parameters
             <tr>
                 <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>since_seconds</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>A relative time in seconds before the current time from which to show logs.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>context</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -457,6 +472,7 @@ Examples
         kind: Deployment
         namespace: testing
         name: example
+        sinceSeconds: "4000"
       register: log
 
     # This will get the log from a single Pod managed by this DeploymentConfig

--- a/plugins/modules/k8s_log.py
+++ b/plugins/modules/k8s_log.py
@@ -54,6 +54,11 @@ options:
     - If there is more than one container, this option is required.
     required: no
     type: str
+  since_seconds:
+    description:
+    - A relative time in seconds before the current time from which to show logs.
+    required: no
+    type: str
 
 requirements:
   - "python >= 3.6"
@@ -124,6 +129,7 @@ def argspec():
         dict(
             kind=dict(type='str', default='Pod'),
             container=dict(),
+            since_seconds=dict(),
             label_selectors=dict(type='list', elements='str', default=[]),
         )
     )
@@ -158,6 +164,12 @@ def execute_module(module, k8s_ansible_mixin):
     kwargs = {}
     if module.params.get('container'):
         kwargs['query_params'] = dict(container=module.params['container'])
+
+    if self.params.get('since_seconds'):
+        if not kwargs['query_params']:
+          kwargs['query_params'] = dict(sinceSeconds=self.params['since_seconds'])
+        else:
+          kwargs['query_params'].update(dict(sinceSeconds=self.params['since_seconds']))
 
     log = serialize_log(resource.log.get(
         name=name,

--- a/plugins/modules/k8s_log.py
+++ b/plugins/modules/k8s_log.py
@@ -167,11 +167,11 @@ def execute_module(module, k8s_ansible_mixin):
     if module.params.get('container'):
         kwargs['query_params'] = dict(container=module.params['container'])
 
-    if self.params.get('since_seconds'):
+    if module.params.get('since_seconds'):
         if not kwargs['query_params']:
-          kwargs['query_params'] = dict(sinceSeconds=self.params['since_seconds'])
+            kwargs['query_params'] = dict(sinceSeconds=module.params['since_seconds'])
         else:
-          kwargs['query_params'].update(dict(sinceSeconds=self.params['since_seconds']))
+            kwargs['query_params'].update(dict(sinceSeconds=module.params['since_seconds']))
 
     log = serialize_log(resource.log.get(
         name=name,

--- a/plugins/modules/k8s_log.py
+++ b/plugins/modules/k8s_log.py
@@ -59,6 +59,7 @@ options:
     - A relative time in seconds before the current time from which to show logs.
     required: no
     type: str
+    version_added: '2.1.0'
 
 requirements:
   - "python >= 3.6"

--- a/plugins/modules/k8s_log.py
+++ b/plugins/modules/k8s_log.py
@@ -59,7 +59,7 @@ options:
     - A relative time in seconds before the current time from which to show logs.
     required: no
     type: str
-    version_added: '2.1.0'
+    version_added: '2.2.0'
 
 requirements:
   - "python >= 3.6"
@@ -169,7 +169,6 @@ def execute_module(module, k8s_ansible_mixin):
 
     if module.params.get('since_seconds'):
         kwargs.setdefault('query_params', {}).update({'sinceSeconds': module.params['since_seconds']})
-
 
     log = serialize_log(resource.log.get(
         name=name,

--- a/plugins/modules/k8s_log.py
+++ b/plugins/modules/k8s_log.py
@@ -89,6 +89,7 @@ EXAMPLES = r'''
     kind: Deployment
     namespace: testing
     name: example
+    since_seconds: "4000"
   register: log
 
 # This will get the log from a single Pod managed by this DeploymentConfig

--- a/plugins/modules/k8s_log.py
+++ b/plugins/modules/k8s_log.py
@@ -168,10 +168,8 @@ def execute_module(module, k8s_ansible_mixin):
         kwargs['query_params'] = dict(container=module.params['container'])
 
     if module.params.get('since_seconds'):
-        if not kwargs['query_params']:
-            kwargs['query_params'] = dict(sinceSeconds=module.params['since_seconds'])
-        else:
-            kwargs['query_params'].update(dict(sinceSeconds=module.params['since_seconds']))
+        kwargs.setdefault('query_params', {}).update({'sinceSeconds': module.params['since_seconds']})
+
 
     log = serialize_log(resource.log.get(
         name=name,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This simple PR aims to add the sinceSeconds API's parameter to the k8s_log module so we can limit the output since it can be huge in some cases.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

k8s_log

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
