### PR TITLE
Remove cloud.common dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,9 @@ If upgrading older playbooks which were built prior to Ansible 2.10 and this col
 
 For documentation on how to use individual modules and other content included in this collection, please see the links in the 'Included content' section earlier in this README.
 
-## Ansible Turbo mode
+## Ansible Turbo mode Tech Preview
 
-The ``kubernetes.core`` collection supports Ansible Turbo mode via ``cloud.common`` collection. Please read more about Ansible Turbo mode - [here](https://github.com/ansible-collections/kubernetes.core/blob/main/docs/ansible_turbo_mode.rst).
+The ``kubernetes.core`` collection supports Ansible Turbo mode as a tech preview via the ``cloud.common`` collection. Please read more about Ansible Turbo mode - [here](https://github.com/ansible-collections/kubernetes.core/blob/main/docs/ansible_turbo_mode.rst).
 
 
 ## Testing and Development

--- a/changelogs/fragments/148-remove-cloud-common-dependency.yaml
+++ b/changelogs/fragments/148-remove-cloud-common-dependency.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - remove cloud.common as default dependency (https://github.com/ansible-collections/kubernetes.core/pull/148).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,8 +8,6 @@ authors:
   - willthames (https://github.com/willthames)
   - mmazur (https://github.com/mmazur)
   - jamescassell (https://github.com/jamescassell)
-dependencies:
-  cloud.common: '>=2.0.1'
 description: Kubernetes Collection for Ansible.
 documentation: ''
 homepage: ''

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,2 +1,0 @@
-collections:
-  - cloud.common


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Removes the cloud.common dependency from being installed by default.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
