### PR TITLE
Remove turbo mode functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,11 +159,6 @@ If upgrading older playbooks which were built prior to Ansible 2.10 and this col
 
 For documentation on how to use individual modules and other content included in this collection, please see the links in the 'Included content' section earlier in this README.
 
-## Ansible Turbo mode Tech Preview
-
-The ``kubernetes.core`` collection supports Ansible Turbo mode as a tech preview via the ``cloud.common`` collection. Please read more about Ansible Turbo mode - [here](https://github.com/ansible-collections/kubernetes.core/blob/main/docs/ansible_turbo_mode.rst).
-
-
 ## Testing and Development
 
 If you want to develop new content for this collection or improve what's already here, the easiest way to work on the collection is to clone it into one of the configured [`COLLECTIONS_PATHS`](https://docs.ansible.com/ansible/latest/reference_appendices/config.html#collections-paths), and work on it there.

--- a/changelogs/fragments/149-disable-turbo-mode.yaml
+++ b/changelogs/fragments/149-disable-turbo-mode.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - temporarily disable turbo mode (https://github.com/ansible-collections/kubernetes.core/pull/149).

--- a/plugins/module_utils/ansiblemodule.py
+++ b/plugins/module_utils/ansiblemodule.py
@@ -3,4 +3,4 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule  # noqa: F401

--- a/plugins/module_utils/ansiblemodule.py
+++ b/plugins/module_utils/ansiblemodule.py
@@ -3,10 +3,4 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 
-try:
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )  # noqa: F401
-    AnsibleModule.collection_name = "kubernetes.core"
-except ImportError:
-    from ansible.module_utils.basic import AnsibleModule  # noqa: F401
+from ansible.module_utils.basic import AnsibleModule


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Temporarily disable turbo mode. This is being done to ensure collection will work properly in the EE, until we can find a better fix for making this optional.