### PR TITLE
Support template param in other collections

### DIFF
--- a/changelogs/fragments/154-template-param-support.yaml
+++ b/changelogs/fragments/154-template-param-support.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - support the ``template`` param in all collections depending on kubernetes.core (https://github.com/ansible-collections/kubernetes.core/pull/154).

--- a/molecule/default/tasks/template.yml
+++ b/molecule/default/tasks/template.yml
@@ -22,7 +22,7 @@
       assert:
         that:
           - r.failed
-          - "'is only supported parameter for' in r.msg"
+          - "'is only a supported parameter for' in r.msg"
 
     - name: Specify both definition and template
       kubernetes.core.k8s:

--- a/plugins/action/k8s_info.py
+++ b/plugins/action/k8s_info.py
@@ -126,8 +126,8 @@ class ActionModule(ActionBase):
 
     def load_template(self, template, new_module_args, task_vars):
         # template is only supported by k8s module.
-        if self._task.action not in ('k8s', 'kubernetes.core.k8s', 'community.okd.k8s'):
-            raise AnsibleActionFail("'template' is only supported parameter for 'k8s' module.")
+        if self._task.action not in ('k8s', 'kubernetes.core.k8s', 'community.okd.k8s', 'redhat.openshift.k8s', 'community.kubernetes.k8s'):
+            raise AnsibleActionFail("'template' is only a supported parameter for the 'k8s' module.")
 
         template_params = []
         if isinstance(template, string_types) or isinstance(template, dict):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The action plugin for k8s does a collection name check for the template
param, but it's missing redhat.openshift and community.kubernetes.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
