### PR TITLE
Re-enable support for turbo mode

### DIFF
--- a/changelogs/fragments/169-reenable-turbo-mode.yaml
+++ b/changelogs/fragments/169-reenable-turbo-mode.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - re-enable turbo mode for collection (https://github.com/ansible-collections/kubernetes.core/pull/169).

--- a/changelogs/fragments/169-reenable-turbo-mode.yaml
+++ b/changelogs/fragments/169-reenable-turbo-mode.yaml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - re-enable turbo mode for collection (https://github.com/ansible-collections/kubernetes.core/pull/169).
+  - re-enable turbo mode for collection. The default is initially set to off (https://github.com/ansible-collections/kubernetes.core/pull/169).

--- a/molecule/default/tasks/full.yml
+++ b/molecule/default/tasks/full.yml
@@ -36,11 +36,29 @@
             path: ~/.kube/config
             state: absent
 
+        - name: Try to create namespace without default kube config
+          kubernetes.core.k8s:
+            name: testing
+            kind: Namespace
+          ignore_errors: true
+          register: result
+
+        - name: No default kube config should fail
+          assert:
+            that: result is not successful
+
         - name: Using custom config location should succeed
           kubernetes.core.k8s:
             name: testing
             kind: Namespace
             kubeconfig: ~/.kube/customconfig
+
+        - name: Using an env var to set config location should succeed
+          kubernetes.core.k8s:
+            name: testing
+            kind: Namespace
+          environment:
+            K8S_AUTH_KUBECONFIG: ~/.kube/customconfig
 
       always:
         - name: Return kubeconfig
@@ -364,6 +382,37 @@
         name: testing6
       register: k8s_info_testing6
       failed_when: not k8s_info_testing6.resources or k8s_info_testing6.resources[0].status.phase != "Active"
+
+    - set_fact:
+        cmap_data: "{{ lookup('community.general.random_string', length=512000, base64=true) }}"
+
+    - name: Create configmap with large value
+      k8s:
+        definition:
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: testmap
+            namespace: testing
+          data:
+            testkey: "{{ cmap_data }}"
+        wait: true
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+
+    - name: Retrieve configmap
+      k8s_info:
+        kind: ConfigMap
+        namespace: testing
+        name: testmap
+      register: result
+
+    - assert:
+        that:
+          - result.resources[0].data.testkey == "{{ cmap_data }}"
 
   always:
     - name: Delete all namespaces

--- a/molecule/default/tasks/full.yml
+++ b/molecule/default/tasks/full.yml
@@ -383,8 +383,9 @@
       register: k8s_info_testing6
       failed_when: not k8s_info_testing6.resources or k8s_info_testing6.resources[0].status.phase != "Active"
 
-    - set_fact:
-        cmap_data: "{{ lookup('community.general.random_string', length=512000, base64=true) }}"
+    - name: Create large configmap data
+      command: dd if=/dev/urandom bs=500K count=1
+      register: cmap_data
 
     - name: Create configmap with large value
       k8s:
@@ -395,7 +396,7 @@
             name: testmap
             namespace: testing
           data:
-            testkey: "{{ cmap_data }}"
+            testkey: "{{ cmap_data.stdout | b64encode }}"
         wait: true
       register: result
 
@@ -412,7 +413,7 @@
 
     - assert:
         that:
-          - result.resources[0].data.testkey == "{{ cmap_data }}"
+          - result.resources[0].data.testkey == "{{ cmap_data.stdout | b64encode }}"
 
   always:
     - name: Delete all namespaces

--- a/plugins/module_utils/ansiblemodule.py
+++ b/plugins/module_utils/ansiblemodule.py
@@ -3,10 +3,22 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 
+import os
+
+from ansible.module_utils.common.validation import check_type_bool
+
 try:
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
-        AnsibleTurboModule as AnsibleModule,
-    )  # noqa: F401
-    AnsibleModule.collection_name = "kubernetes.core"
-except ImportError:
+    enable_turbo_mode = check_type_bool(os.environ.get("ENABLE_TURBO_MODE"))
+except TypeError:
+    enable_turbo_mode = False
+
+if enable_turbo_mode:
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+            AnsibleTurboModule as AnsibleModule,
+        )  # noqa: F401
+        AnsibleModule.collection_name = "kubernetes.core"
+    except ImportError:
+        from ansible.module_utils.basic import AnsibleModule  # noqa: F401
+else:
     from ansible.module_utils.basic import AnsibleModule  # noqa: F401

--- a/plugins/module_utils/ansiblemodule.py
+++ b/plugins/module_utils/ansiblemodule.py
@@ -3,4 +3,10 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 
-from ansible.module_utils.basic import AnsibleModule  # noqa: F401
+try:
+    from ansible_collections.cloud.common.plugins.module_utils.turbo.module import (
+        AnsibleTurboModule as AnsibleModule,
+    )  # noqa: F401
+    AnsibleModule.collection_name = "kubernetes.core"
+except ImportError:
+    from ansible.module_utils.basic import AnsibleModule  # noqa: F401

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,3 @@
+# Test dependencies
+collections:
+  - community.general

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,3 @@
-# Test dependencies
 collections:
-  - community.general
+  - name: cloud.common
+    version: ">=2.0.4"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This re-enables the ability to add turbo mode. It also adds a few more
tests to cover some cases that had been broken in turbo mode previously.

Testing with turbo mode is not currently enabled, and would fail until https://github.com/ansible-collections/cloud.common/pull/69 can be merged and a new cloud.common release is done. This also does not add cloud.common to the collection dependencies until a decision has been made about how enabling/disabling turbo mode will work when cloud.common is already installed.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
