### PR TITLE
tests: add dep on coverage

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,2 @@
+coverage==4.5.4
 kubernetes-validate


### PR DESCRIPTION
##### SUMMARY

We run `ansible-test units --coverage --python 3.7 -vvvv` in the CI, we
need to install the `coverage` package first.


<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

tests