### PR TITLE
[connection plugin] add missing information from censored command

### DIFF
--- a/changelogs/fragments/188_kubectl.yaml
+++ b/changelogs/fragments/188_kubectl.yaml
@@ -1,3 +1,0 @@
----
-minor_changes:
-- connection plugin - add missing information into censored command. (https://github.com/ansible-collections/kubernetes.core/issues/147).

--- a/changelogs/fragments/188_kubectl.yaml
+++ b/changelogs/fragments/188_kubectl.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- connection plugin - add missing information into censored command. (https://github.com/ansible-collections/kubernetes.core/issues/147).

--- a/changelogs/fragments/196_kubectl.yaml
+++ b/changelogs/fragments/196_kubectl.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- connection plugin - add arguments information into censored command. (https://github.com/ansible-collections/kubernetes.core/issues/147).

--- a/changelogs/fragments/196_kubectl.yaml
+++ b/changelogs/fragments/196_kubectl.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-- connection plugin - add arguments information into censored command.
+- connection plugin - add arguments information into censored command (https://github.com/ansible-collections/kubernetes.core/pull/196).

--- a/changelogs/fragments/196_kubectl.yaml
+++ b/changelogs/fragments/196_kubectl.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-- connection plugin - add arguments information into censored command. (https://github.com/ansible-collections/kubernetes.core/issues/147).
+- connection plugin - add arguments information into censored command.

--- a/plugins/connection/kubectl.py
+++ b/plugins/connection/kubectl.py
@@ -245,6 +245,8 @@ class Connection(ConnectionBase):
                 # Redact password and token from console log
                 if key.endswith(('_token', '_password')):
                     censored_local_cmd += [cmd_arg, '********']
+                else:
+                    censored_local_cmd += [cmd_arg, self.get_option(key)]
 
         extra_args_name = u'{0}_extra_args'.format(self.transport)
         if self.get_option(extra_args_name):


### PR DESCRIPTION
##### SUMMARY
when running playbook with ``vvv`` option, the censored command display is not reflecting the execution

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request