### PR TITLE
helm: List all matching releases, regardless of state

### DIFF
--- a/changelogs/fragments/204_helm-list-all.yaml
+++ b/changelogs/fragments/204_helm-list-all.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - helm - lookup and info modules now return all releases regardless of their state (https://github.com/ansible-collections/kubernetes.core/pull/204).

--- a/molecule/default/roles/helm/tasks/tests_chart.yml
+++ b/molecule/default/roles/helm/tasks/tests_chart.yml
@@ -250,7 +250,7 @@
         binary_path: "{{ helm_binary }}"
         state: absent
         name: test-0001
-        purge: False
+        purge: True
         namespace: "{{ helm_namespace }}"
       register: install
 

--- a/plugins/modules/helm.py
+++ b/plugins/modules/helm.py
@@ -330,7 +330,7 @@ def get_release_status(module, command, release_name):
     Get Release state from deployed release
     """
 
-    list_command = command + " list --output=yaml --filter " + release_name
+    list_command = command + " list -a --output=yaml --filter " + release_name
 
     rc, out, err = run_helm(module, list_command)
 

--- a/plugins/modules/helm_info.py
+++ b/plugins/modules/helm_info.py
@@ -113,7 +113,7 @@ def get_release(state, release_name):
 
 # Get Release state from deployed release
 def get_release_status(module, command, release_name):
-    list_command = command + " list --output=yaml --filter " + release_name
+    list_command = command + " list -a --output=yaml --filter " + release_name
 
     rc, out, err = run_helm(module, list_command)
 


### PR DESCRIPTION
##### SUMMARY
There are cases where a `helm list` does not list all
existing releases. One such case is when a release
is in state pending-upgrade, or any other pending state.

Now with this change any use of the lookup or info modules
will now return such releases, so that one can work with them.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`kuberntes.core.helm` and `kubernetes.core.helm_info`

##### ADDITIONAL INFORMATION
Before:
```
➜  kubernetes.core git:(main) helm list -n kube-system --output=yaml --filter release-name                      
[]
```
After:
```
➜  kubernetes.core git:(main) helm list -a -n kube-system --output=yaml --filter release-name                      
- app_version: v1.3.4
  chart: release-name-1.3.9
  name: release-name
  namespace: kube-system
  revision: "47"
  status: pending-upgrade
  updated: 2021-08-16 13:51:18.713253195 +0200 CEST
```

As the output was completely missing before it is now shown
and can be parsed and processed accordingly.