### PR TITLE
add support for in-memory kubeconfig

### DIFF
--- a/changelogs/fragments/212-in-memory-kubeconfig.yml
+++ b/changelogs/fragments/212-in-memory-kubeconfig.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - add support for in-memory kubeconfig in addition to file for k8s modules. (https://github.com/ansible-collections/kubernetes.core/pull/212).

--- a/molecule/default/tasks/full.yml
+++ b/molecule/default/tasks/full.yml
@@ -60,6 +60,12 @@
           environment:
             K8S_AUTH_KUBECONFIG: ~/.kube/customconfig
 
+        - name: Using in-memory kubeconfig should succeed
+          kubernetes.core.k8s:
+            name: testing
+            kind: Namespace
+            kubeconfig: "{{ lookup('file', '~/.kube/customconfig') | from_yaml }}"
+
       always:
         - name: Return kubeconfig
           copy:

--- a/molecule/default/tasks/validate.yml
+++ b/molecule/default/tasks/validate.yml
@@ -177,10 +177,43 @@
             that:
               - result is successful
               - "'warnings' in result"
-
-
       vars:
         ansible_python_interpreter: "{{ virtualenv_interpreter }}"
+
+    - name: stat default kube config
+      stat:
+        path: "~/.kube/config"
+      register: _stat
+
+    - name: validate that in-memory kubeconfig authentication failed for kubernetes < 17.17.0
+      block:
+        - set_fact:
+            virtualenv_kubeconfig: "{{ remote_tmp_dir }}/kubeconfig"
+
+        - pip:
+            name:
+              - "kubernetes<17.17.0"
+            virtualenv: "{{ virtualenv_kubeconfig }}"
+            virtualenv_command: "{{ virtualenv_command }}"
+            virtualenv_site_packages: false
+
+        - name: list namespace using in-memory kubeconfig
+          k8s_info:
+            kind: Namespace
+            kubeconfig: "{{ lookup('file', '~/.kube/config') | from_yaml }}"
+          register: _result
+          ignore_errors: true
+          vars:
+            ansible_python_interpreter: "{{ virtualenv_kubeconfig }}/bin/python"
+
+        - name: assert that task failed with proper message
+          assert:
+            that:
+              - '"kubernetes >= 17.17.0 is required" in _result.msg'
+      when:
+        - _stat.stat.exists
+        - _stat.stat.readable
+        - _stat.stat.isreg
   always:
     - name: Remove temp directory
       file:

--- a/plugins/doc_fragments/k8s_auth_options.py
+++ b/plugins/doc_fragments/k8s_auth_options.py
@@ -27,7 +27,8 @@ options:
       options are provided, the Kubernetes client will attempt to load the default
       configuration file from I(~/.kube/config). Can also be specified via K8S_AUTH_KUBECONFIG environment
       variable.
-    type: path
+    - The kubernetes configuration can be provided as dictionary. Added in version 2.2.0.
+    type: raw
   context:
     description:
     - The name of a context found in the config file. Can also be specified via K8S_AUTH_CONTEXT environment variable.

--- a/plugins/doc_fragments/k8s_auth_options.py
+++ b/plugins/doc_fragments/k8s_auth_options.py
@@ -27,7 +27,7 @@ options:
       options are provided, the Kubernetes client will attempt to load the default
       configuration file from I(~/.kube/config). Can also be specified via K8S_AUTH_KUBECONFIG environment
       variable.
-    - The kubernetes configuration can be provided as dictionary. Added in version 2.2.0.
+    - The kubernetes configuration can be provided as dictionary. This feature requires a python kubernetes client version >= 17.17.0. Added in version 2.2.0.
     type: raw
   context:
     description:

--- a/plugins/module_utils/args_common.py
+++ b/plugins/module_utils/args_common.py
@@ -19,7 +19,7 @@ AUTH_PROXY_HEADERS_SPEC = dict(
 
 AUTH_ARG_SPEC = {
     'kubeconfig': {
-        'type': 'path',
+        'type': 'raw',
     },
     'context': {},
     'host': {},

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -122,7 +122,6 @@ def get_api_client(module=None, **kwargs):
         if module:
             module.fail_json(msg % to_native(exc))
         raise exc
-
     # If authorization variables aren't defined, look for them in environment variables
     for true_name, arg_name in AUTH_ARG_MAP.items():
         if module and module.params.get(arg_name) is not None:
@@ -150,6 +149,22 @@ def get_api_client(module=None, **kwargs):
     def auth_set(*names):
         return all(auth.get(name) for name in names)
 
+    def _load_config():
+        kubeconfig = auth.get('kubeconfig')
+        optional_arg = {
+            'context': auth.get('context'),
+            'persist_config': auth.get('persist_config'),
+        }
+        if kubeconfig:
+            if isinstance(kubeconfig, string_types):
+                kubernetes.config.load_kube_config(config_file=kubeconfig, **optional_arg)
+            elif isinstance(kubeconfig, dict):
+                if LooseVersion(kubernetes.__version__) < LooseVersion("17.17"):
+                    _raise_or_fail(Exception("kubernetes >= 17.17.0 is required to use in-memory kubeconfig."), 'Failed to load kubeconfig due to: %s')
+                kubernetes.config.load_kube_config_from_dict(config_dict=kubeconfig, **optional_arg)
+        else:
+            kubernetes.config.load_kube_config(config_file=None, **optional_arg)
+
     if auth_set('host'):
         # Removing trailing slashes if any from hostname
         auth['host'] = auth.get('host').rstrip('/')
@@ -159,7 +174,7 @@ def get_api_client(module=None, **kwargs):
         pass
     elif auth_set('kubeconfig') or auth_set('context'):
         try:
-            kubernetes.config.load_kube_config(auth.get('kubeconfig'), auth.get('context'), persist_config=auth.get('persist_config'))
+            _load_config()
         except Exception as err:
             _raise_or_fail(err, 'Failed to load kubeconfig due to %s')
 
@@ -169,7 +184,7 @@ def get_api_client(module=None, **kwargs):
             kubernetes.config.load_incluster_config()
         except kubernetes.config.ConfigException:
             try:
-                kubernetes.config.load_kube_config(auth.get('kubeconfig'), auth.get('context'), persist_config=auth.get('persist_config'))
+                _load_config()
             except Exception as err:
                 _raise_or_fail(err, 'Failed to load kubeconfig due to %s')
 

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -120,7 +120,7 @@ def get_api_client(module=None, **kwargs):
 
     def _raise_or_fail(exc, msg):
         if module:
-            module.fail_json(msg % to_native(exc))
+            module.fail_json(msg=msg % to_native(exc))
         raise exc
     # If authorization variables aren't defined, look for them in environment variables
     for true_name, arg_name in AUTH_ARG_MAP.items():


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
k8s module support now authentication with ``kubeconfig`` parameter as file and dict.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Closes #139 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
