### PR TITLE
py3: remove py2 compat code

### DIFF
--- a/plugins/module_utils/args_common.py
+++ b/plugins/module_utils/args_common.py
@@ -1,12 +1,5 @@
-from __future__ import (absolute_import, division, print_function)
-
-from ansible.module_utils.six import string_types
-
-__metaclass__ = type
-
-
 def list_dict_str(value):
-    if isinstance(value, (list, dict, string_types)):
+    if isinstance(value, (list, dict, str)):
         return value
     raise TypeError
 


### PR DESCRIPTION
##### SUMMARY

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1074

- we don't need __metaclass__ and __future__
- use the py3 str type
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
