### PR TITLE
tests: disable in-memory kubeconfig tests

### DIFF
--- a/molecule/default/tasks/validate.yml
+++ b/molecule/default/tasks/validate.yml
@@ -180,40 +180,44 @@
       vars:
         ansible_python_interpreter: "{{ virtualenv_interpreter }}"
 
-    - name: stat default kube config
-      stat:
-        path: "~/.kube/config"
-      register: _stat
+        # NOTE: Un-indent and uncomment once test is fixed.
+        # - name: stat default kube config
+        #   stat:
+        #     path: "~/.kube/config"
+        #   register: _stat
 
-    - name: validate that in-memory kubeconfig authentication failed for kubernetes < 17.17.0
-      block:
-        - set_fact:
-            virtualenv_kubeconfig: "{{ remote_tmp_dir }}/kubeconfig"
+        # - name: validate that in-memory kubeconfig authentication failed for kubernetes < 17.17.0
+        #   block:
+        #     - set_fact:
+        #         virtualenv_kubeconfig: "{{ remote_tmp_dir }}/kubeconfig"
 
-        - pip:
-            name:
-              - "kubernetes<17.17.0"
-            virtualenv: "{{ virtualenv_kubeconfig }}"
-            virtualenv_command: "{{ virtualenv_command }}"
-            virtualenv_site_packages: false
+        #     - pip:
+        #         name:
+        #           - "kubernetes<17.17.0"
+        #         virtualenv: "{{ virtualenv_kubeconfig }}"
+        #         virtualenv_command: "{{ virtualenv_command }}"
+        #         virtualenv_site_packages: false
 
-        - name: list namespace using in-memory kubeconfig
-          k8s_info:
-            kind: Namespace
-            kubeconfig: "{{ lookup('file', '~/.kube/config') | from_yaml }}"
-          register: _result
-          ignore_errors: true
-          vars:
-            ansible_python_interpreter: "{{ virtualenv_kubeconfig }}/bin/python"
+        #     - name: list namespace using in-memory kubeconfig
+        #       k8s_info:
+        #         kind: Namespace
+        #         kubeconfig: "{{ lookup('file', '~/.kube/config') | from_yaml }}"
+        #       register: _result
+        #       ignore_errors: true
+        #       vars:
+        #         ansible_python_interpreter: "{{ virtualenv_kubeconfig }}/bin/python"
 
-        - name: assert that task failed with proper message
-          assert:
-            that:
-              - '"kubernetes >= 17.17.0 is required" in _result.msg'
-      when:
-        - _stat.stat.exists
-        - _stat.stat.readable
-        - _stat.stat.isreg
+        #     - debug:
+        #         msg: "{{ _result }}"
+
+        #     - name: assert that task failed with proper message
+        #       assert:
+        #         that:
+        #           - '"kubernetes >= 17.17.0 is required" in _result.msg'
+        #   when:
+        #     - _stat.stat.exists
+        #     - _stat.stat.readable
+        #     - _stat.stat.isreg
   always:
     - name: Remove temp directory
       file:


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1074

##### SUMMARY

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
molecule/default/tasks/validate.yml
