### PR TITLE
Disable turbo mode for the validate tests

### DIFF
--- a/molecule/default/tasks/validate.yml
+++ b/molecule/default/tasks/validate.yml
@@ -236,3 +236,5 @@
 
   vars:
     validate_namespace: validate
+  environment:
+    ENABLE_TURBO_MODE: false


### PR DESCRIPTION
Depends-On: ansible/ansible-zuul-jobs#1074

Switching virtualenvs in the test suite does not work so well with turbo
mode enabled because the module may not be executed by the virtualenv
that is specified for that task.