### PR TITLE
fix k8s_cp uploading when deployed container's WORKDIR is other than '/'

### DIFF
--- a/changelogs/fragments/223-k8s-cp-uploading.yaml
+++ b/changelogs/fragments/223-k8s-cp-uploading.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - k8s_cp - fix k8s_cp uploading when target container's WORKDIR is not '/' (https://github.com/ansible-collections/kubernetes.core/issues/222).

--- a/plugins/modules/k8s_cp.py
+++ b/plugins/modules/k8s_cp.py
@@ -370,6 +370,9 @@ class K8SCopyToPod(K8SCopy):
             else:
                 tar_command = ['tar', '-xmf', '-']
 
+            if dest_file.startswith("/"):
+                tar_command.extend(['-C', '/'])
+
             response = stream(self.api_instance.connect_get_namespaced_pod_exec,
                               self.name,
                               self.namespace,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
fix #222

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

k8s_cp

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
