### PR TITLE
add diff output when using helmdiff

### DIFF
--- a/changelogs/fragments/236-add-diff-output-to-helm-module.yaml
+++ b/changelogs/fragments/236-add-diff-output-to-helm-module.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - helm - If using module with helmdiff, the module now outputs diff (https://github.com/ansible-collections/kubernetes.core/pull/236).

--- a/plugins/modules/helm.py
+++ b/plugins/modules/helm.py
@@ -565,6 +565,7 @@ def main():
         module.fail_json(msg=missing_required_lib("yaml"), exception=IMP_YAML_ERR)
 
     changed = False
+    diff = ""
 
     bin_path = module.params.get('binary_path')
     chart_ref = module.params.get('chart_ref')

--- a/plugins/modules/helm.py
+++ b/plugins/modules/helm.py
@@ -491,7 +491,7 @@ def helmdiff_check(module, helm_cmd, release_name, chart_ref, release_values,
             cmd += " -f=" + values_file
 
     rc, out, err = run_helm(module, cmd)
-    return len(out.strip()) > 0
+    return len(out.strip()) > 0, out
 
 
 def default_check(release_status, chart_info, values=None, values_files=None):
@@ -628,8 +628,8 @@ def main():
         else:
 
             if has_plugin(helm_cmd_common, "diff") and not chart_repo_url:
-                would_change = helmdiff_check(module, helm_cmd_common, release_name, chart_ref,
-                                              release_values, values_files, chart_version, replace)
+                would_change, diff = helmdiff_check(module, helm_cmd_common, release_name, chart_ref,
+                                                    release_values, values_files, chart_version, replace)
             else:
                 module.warn("The default idempotency check can fail to report changes in certain cases. "
                             "Install helm diff for better results.")
@@ -656,6 +656,7 @@ def main():
         module.exit_json(
             changed=changed,
             command=helm_cmd,
+            diff={'prepared': diff},
             status=check_status,
             stdout='',
             stderr='',
@@ -673,6 +674,7 @@ def main():
 
     module.exit_json(
         changed=changed,
+        diff={'prepared': diff},
         stdout=out,
         stderr=err,
         status=get_release_status(module, helm_cmd_common, release_name),


### PR DESCRIPTION
I have tried it before here: https://github.com/ansible-collections/community.kubernetes/pull/363
copied from my other PR:

> ##### SUMMARY
> In the previous PR https://github.com/ansible-collections/community.kubernetes/pull/355 @Akasurde has implemented optional helm check by the helm plugin diff.
> I was unsure why we would not use this for --diff in Ansible. This would be very useful.
> I have added a gist with a simple module I build which is actually using it.
> ~~Also, I think this PR needs some more love, but first I wanted to gather a little bit of feedback from the original creator @Akasurde and @LucasBoisserie~~
> 
> ##### ISSUE TYPE
> <!--- Pick one below and delete the rest -->
> - Feature Pull Request
> 
> ##### COMPONENT NAME
> <!--- Write the short name of the module, plugin, task or feature below -->
> Helm
> 
> ##### ADDITIONAL INFORMATION
> - 
> 
