### PR TITLE
common/_wait_for: ensure label_selectors is optional

### DIFF
--- a/changelogs/fragments/_wait_for_label_selector_optional.yaml
+++ b/changelogs/fragments/_wait_for_label_selector_optional.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- common - Ensure the label_selectors parameter of _wait_for method is optional.

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -365,7 +365,7 @@ class K8sAnsibleMixin(object):
     def fail(self, msg=None):
         self.fail_json(msg=msg)
 
-    def _wait_for(self, resource, name, namespace, predicate, sleep, timeout, state, label_selectors):
+    def _wait_for(self, resource, name, namespace, predicate, sleep, timeout, state, label_selectors=None):
         start = datetime.now()
 
         def _wait_for_elapsed():


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1125

The label_selectors is a new parameter for _wait_for that was
introduced in https://github.com/ansible-collections/kubernetes.core/pull/158.

The value is new and it can be set to None to make it optional. It should
not be mandatory a non optional parameter.
