### PR TITLE
Increase timeout on scale test

### DIFF
--- a/molecule/default/tasks/scale.yml
+++ b/molecule/default/tasks/scale.yml
@@ -259,6 +259,8 @@
         namespace: "{{ scale_namespace }}"
         label_selectors:
           - app=nginx
+        wait: yes
+        wait_timeout: 60
       register: scale_out
 
     - assert:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This test frequently fails with the default 20s timeout. Bumping up to
60s.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #241 

Depends-on: https://github.com/ansible/ansible-zuul-jobs/pull/1131

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
