### PR TITLE
Add openshift-clients to bindep.txt

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,1 +1,2 @@
 kubernetes-client [platform:fedora]
+openshift-clients [platform:rhel-8]


### PR DESCRIPTION
For RHEL8 builds, we use openshift-clients RPM to install both kubectl /
oc clients.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>