### PR TITLE
flake8: max-complexity 12

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ deps = yamllint
 
 commands =
   yamllint -s {toxinidir}
-  flake8 {toxinidir}
+  flake8 --max-complexity 12 {toxinidir}
 
 [flake8]
 exclude = .git,.tox,tests/output


### PR DESCRIPTION
Ensure we don't go above a MacCabe code complicity of 12.
See: https://flake8.pycqa.org/en/2.5.5/#quickstart
