### PR TITLE
[backport/2.2] Remove molecule dependencies (#261)

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -33,7 +33,3 @@ scenario:
     - prepare
     - converge
     - verify
-dependency:
-  name: galaxy
-  options:
-    requirements-file: requirements.yml

--- a/molecule/default/tasks/drain.yml
+++ b/molecule/default/tasks/drain.yml
@@ -11,6 +11,17 @@
       kind: Namespace
       name: '{{ drain_namespace }}'
 
+  # It seems that the default ServiceAccount can take a bit to be created
+  # right after a cluster is brought up. This can lead to the ServiceAccount
+  # admission controller rejecting a Pod creation request because the
+  # ServiceAccount does not yet exist.
+  - name: Wait for default serviceaccount to be created
+    k8s_info:
+      kind: ServiceAccount
+      name: default
+      namespace: "{{ drain_namespace }}"
+      wait: yes
+
   - name: list cluster nodes
     k8s_info:
       kind: node

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,0 @@
-collections:
-  - name: cloud.common
-    version: ">=2.0.4"


### PR DESCRIPTION
Remove molecule dependencies

SUMMARY

Molecule is overwriting the cloud.common dependency installed by zuul,
which is causing issues with the CI job for turbo mode. We still need to
find a way to test against the latest released version of cloud.common.

ISSUE TYPE

Bugfix Pull Request

COMPONENT NAME

ADDITIONAL INFORMATION

Reviewed-by: Gonéri Le Bouder <goneri@lebouder.net>
Reviewed-by: None <None>
(cherry picked from commit ff43353de6a5d24839bca1d44a9bdd0e6f618815)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
