### PR TITLE
[backport/2.2] Use yaml.safe_load in unit tests (#265)

### DIFF
--- a/tests/unit/module_utils/test_helm.py
+++ b/tests/unit/module_utils/test_helm.py
@@ -41,7 +41,7 @@ def test_write_temp_kubeconfig_server_only():
     file_name = write_temp_kubeconfig("ff")
     try:
         with open(file_name, "r") as fd:
-            content = yaml.load(fd)
+            content = yaml.safe_load(fd)
     finally:
         os.remove(file_name)
 
@@ -60,7 +60,7 @@ def test_write_temp_kubeconfig_server_inscure_certs():
     file_name = write_temp_kubeconfig("ff", False, "my-certificate")
     try:
         with open(file_name, "r") as fd:
-            content = yaml.load(fd)
+            content = yaml.safe_load(fd)
     finally:
         os.remove(file_name)
 


### PR DESCRIPTION
Use yaml.safe_load in unit tests

SUMMARY

The function signature in pyyaml 6 for yaml.load changed. Using
safe_load fixes this.

ISSUE TYPE

Bugfix Pull Request

COMPONENT NAME

ADDITIONAL INFORMATION

Reviewed-by: Jill R <None>
Reviewed-by: None <None>
Reviewed-by: Gonéri Le Bouder <goneri@lebouder.net>
(cherry picked from commit 281ff563edf359d0776f2dca63c080adae357f1d)