### PR TITLE
add no_proxy support to k8s*

### DIFF
--- a/changelogs/fragments/272-k8s-add-support-no_proxy.yaml
+++ b/changelogs/fragments/272-k8s-add-support-no_proxy.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - k8s - add no_proxy support to k8s* (https://github.com/ansible-collections/kubernetes.core/pull/272).

--- a/plugins/doc_fragments/k8s_auth_options.py
+++ b/plugins/doc_fragments/k8s_auth_options.py
@@ -84,7 +84,7 @@ options:
     - This feature requires kubernetes>=19.15.0. When kubernetes library is less than 19.15.0, it fails even no_proxy set in correct.
     - example value is "localhost,.local,.example.com,127.0.0.1,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
     type: str
-    version_added: 2.2.2
+    version_added: 2.3.0
   proxy_headers:
     description:
     - The Header used for the HTTP proxy.

--- a/plugins/doc_fragments/k8s_auth_options.py
+++ b/plugins/doc_fragments/k8s_auth_options.py
@@ -77,6 +77,14 @@ options:
     - The URL of an HTTP proxy to use for the connection. Can also be specified via K8S_AUTH_PROXY environment variable.
     - Please note that this module does not pick up typical proxy settings from the environment (e.g. HTTP_PROXY).
     type: str
+  no_proxy:
+    description:
+    - The comma separated list of hosts/domains/IP/CIDR that shouldn't go through proxy. Can also be specified via K8S_AUTH_NO_PROXY environment variable.
+    - Please note that this module does not pick up typical proxy settings from the environment (e.g. NO_PROXY).
+    - This feature requires kubernetes>=19.15.0. When kubernetes library is less than 19.15.0, it fails even no_proxy set in correct.
+    - example value is "localhost,.local,.example.com,127.0.0.1,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
+    type: str
+    version_added: 2.2.2
   proxy_headers:
     description:
     - The Header used for the HTTP proxy.

--- a/plugins/module_utils/args_common.py
+++ b/plugins/module_utils/args_common.py
@@ -29,6 +29,7 @@ AUTH_ARG_SPEC = {
     "client_cert": {"type": "path", "aliases": ["cert_file"]},
     "client_key": {"type": "path", "aliases": ["key_file"]},
     "proxy": {"type": "str"},
+    "no_proxy": {"type": "str"},
     "proxy_headers": {"type": "dict", "options": AUTH_PROXY_HEADERS_SPEC},
     "persist_config": {"type": "bool"},
 }
@@ -61,6 +62,7 @@ AUTH_ARG_MAP = {
     "cert_file": "client_cert",
     "key_file": "client_key",
     "proxy": "proxy",
+    "no_proxy": "no_proxy",
     "proxy_headers": "proxy_headers",
     "persist_config": "persist_config",
 }

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -212,6 +212,13 @@ def get_api_client(module=None, **kwargs):
         # Removing trailing slashes if any from hostname
         auth["host"] = auth.get("host").rstrip("/")
 
+    if auth_set("no_proxy"):
+        if LooseVersion(kubernetes.__version__) < LooseVersion("19.15.0"):
+            _raise_or_fail(
+                Exception("kubernetes >= 19.15.0 is required to use no_proxy feature."),
+                "Failed to set no_proxy due to: %s",
+            )
+
     if auth_set("username", "password", "host") or auth_set("api_key", "host"):
         # We have enough in the parameters to authenticate, no need to load incluster or kubeconfig
         pass


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

close #271

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

plugins/module_utils/args_common.py
plugins/modules/k8s*

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

It requires latest kubernetes library(>=19.15.0) to use this feature.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

pip install kubernetes>=19.15.0
then, use following snippet yaml:

  - k8s:
      state: present
      src: "deployment.yaml"
      proxy:      "http://proxy.yourdomain.com:8080/"
      no_proxy:   "localhost,.yourdomain.com,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192,168.0.0/16"

or use environment variable K8S_AUTH_NO_PROXY as well as K8S_AUTH_PROXY.
```
