### PR TITLE
kustomize lookup plugin: build_flags

### DIFF
--- a/plugins/lookup/kustomize.py
+++ b/plugins/lookup/kustomize.py
@@ -30,6 +30,9 @@ DOCUMENTATION = """
       opt_dirs:
         description:
         - An optional list of directories to search for the executable in addition to PATH.
+      build_flags:
+        description:
+        - Set additional build flags, like --enable-alpha-plugins
 
     requirements:
       - "python >= 3.6"
@@ -135,6 +138,9 @@ class LookupModule(LookupBase):
                     executable_path
                 )
             )
+
+        if "build_flags" in kwargs:
+            command += [kwargs["build_flags"]]
 
         (out, err) = run_command(command)
         if err:


### PR DESCRIPTION
Allow setting a string of optional build_flags at the end of the
command.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
A string to add some params/options to the end of "kustomize build dir" / "kubectl kustomize dir" command.
This could have been a list, or some other grandiose parsing event, I haven't put much thought into other use-cases.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
kustomize lookup plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
It feels like a one-off kind of thing, where I just need to add "--enable-alpha-plugins" at the end. Maybe someone else will end up in a similar predicament later down the line, and be relieved that they can just build_flags="--all-my great --build-options are-available --yay".