### PR TITLE
Return diff in helm check mode

### DIFF
--- a/changelogs/fragments/290-returns-diff-in-check-mode.yaml
+++ b/changelogs/fragments/290-returns-diff-in-check-mode.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - helm - when ansible is executed in check mode, return the diff between what's deployed and what will be deployed.

--- a/molecule/default/roles/helm/tasks/tests_helm_diff.yml
+++ b/molecule/default/roles/helm/tasks/tests_helm_diff.yml
@@ -40,6 +40,33 @@
           data:
             foo: {{ .Values.foo | default "bar" }}
 
+    - name: Test helm diff in check mode
+      helm:
+        binary_path: "{{ helm_binary }}"
+        name: test-chart
+        namespace: "{{ helm_namespace }}"
+        chart_ref: "{{ test_chart_ref }}"
+      check_mode: yes
+      diff: yes
+      register: diff_result
+
+    - name: Check if helm diff check is correct
+      vars:
+        expected: "\u001b[0;33mhelm, test-chart-another-configmap, ConfigMap (v1) has been added:\u001b[0m\n\
+          \u001b[0;31m- \u001b[0m\n\
+          \u001b[0;32m+ # Source: test-chart/templates/anothermap.yaml\u001b[0m\n\
+          \u001b[0;32m+ # BEGIN ANSIBLE MANAGED BLOCK\u001b[0m\n\
+          \u001b[0;32m+ apiVersion: v1\u001b[0m\n\
+          \u001b[0;32m+ kind: ConfigMap\u001b[0m\n\
+          \u001b[0;32m+ metadata:\u001b[0m\n\
+          \u001b[0;32m+   name: test-chart-another-configmap\u001b[0m\n\
+          \u001b[0;32m+ data:\u001b[0m\n\
+          \u001b[0;32m+   foo: bar\u001b[0m\n\
+          \u001b[0;32m+ # END ANSIBLE MANAGED BLOCK\u001b[0m"
+      assert:
+        that:
+          - expected == diff_result.diff.prepared
+
     - name: Upgrade local chart with modifications
       helm:
         binary_path: "{{ helm_binary }}"
@@ -51,6 +78,21 @@
     - assert:
         that:
           - install is changed
+
+    - name: No diff in check mode when no change
+      helm:
+        binary_path: "{{ helm_binary }}"
+        name: test-chart
+        namespace: "{{ helm_namespace }}"
+        chart_ref: "{{ test_chart_ref }}"
+      check_mode: yes
+      diff: yes
+      register: diff_result
+
+    - name: Check if no diff in check mode when no change
+      assert:
+        that:
+          - '"diff" not in diff_result'
 
     - name: Upgrade modified local chart idempotency check
       helm:

--- a/plugins/modules/helm.py
+++ b/plugins/modules/helm.py
@@ -537,7 +537,7 @@ def helmdiff_check(
             cmd += " -f=" + values_file
 
     rc, out, err = run_helm(module, cmd)
-    return len(out.strip()) > 0
+    return (len(out.strip()) > 0, out.strip())
 
 
 def default_check(release_status, chart_info, values=None, values_files=None):
@@ -725,7 +725,7 @@ def main():
         else:
 
             if has_plugin(helm_cmd_common, "diff") and not chart_repo_url:
-                would_change = helmdiff_check(
+                (would_change, prepared) = helmdiff_check(
                     module,
                     helm_cmd_common,
                     release_name,
@@ -735,6 +735,8 @@ def main():
                     chart_version,
                     replace,
                 )
+                if would_change and module._diff:
+                    opt_result["diff"] = {"prepared": prepared}
             else:
                 module.warn(
                     "The default idempotency check can fail to report changes in certain cases. "


### PR DESCRIPTION
When the helm module is executed in check mode with the helm diff plugin
installed, it now returns the diff.

##### SUMMARY
When the helm module is executed in check mode with the helm diff plugin
installed, it now returns the diff.

##### COMPONENT NAME
helm

##### ADDITIONAL INFORMATION
