### PR TITLE
Fix k8s_drain failing when pod has local storage

### DIFF
--- a/changelogs/fragments/295-fix-k8s-drain-variable-declaration.yaml
+++ b/changelogs/fragments/295-fix-k8s-drain-variable-declaration.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - k8s_drain - fix error caused by accessing an undefined variable when pods have local storage (https://github.com/ansible-collections/kubernetes.core/issues/292).

--- a/plugins/modules/k8s_drain.py
+++ b/plugins/modules/k8s_drain.py
@@ -197,6 +197,7 @@ def filter_pods(pods, force, ignore_daemonset):
 
     # local storage
     if localStorage:
+        pod_names = ",".join([pod[0] + "/" + pod[1] for pod in localStorage])
         errors.append("cannot delete Pods with local storage: {0}.".format(pod_names))
 
     # DaemonSet managed Pods


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The module fails to define the pod_names variable before using it for
pods with local storage.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #292 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
k8s_drain

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
