### PR TITLE
[backport/2.2] turn network-ee-sanity-tests non-voting

### DIFF
--- a/.zuul.d/network-ee-sanity-tests_non-voting.yaml
+++ b/.zuul.d/network-ee-sanity-tests_non-voting.yaml
@@ -1,0 +1,10 @@
+- project:
+    name: github.com/ansible-collections/kubernetes.core
+    check:
+      jobs:
+        - network-ee-sanity-tests:
+            voting: false
+    gate:
+      jobs:
+        - network-ee-sanity-tests:
+            voting: false


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
turn network-ee-sanity-tests non-voting

Reviewed-by: Mike Graves <mgraves@redhat.com>
Reviewed-by: None <None>
(cherry picked from commit b0f1501cd4a96ab1ae8b55548d4108b666fde4f5)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
