### PR TITLE
Add delete_emptydir_data to drain delete_options

### DIFF
--- a/changelogs/fragments/322-Add-delete_emptydir_data-to-drain-delete_options.yaml
+++ b/changelogs/fragments/322-Add-delete_emptydir_data-to-drain-delete_options.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - k8s_drain - Adds ``delete_emptydir_data`` option to ``k8s_drain.delete_options`` to evict pods with an ``emptyDir`` volume attached (https://github.com/ansible-collections/kubernetes.core/pull/322).

--- a/docs/kubernetes.core.k8s_drain_module.rst
+++ b/docs/kubernetes.core.k8s_drain_module.rst
@@ -142,6 +142,26 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>delete_emptydir_data</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                    <li>yes</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Continue even if there are pods using emptyDir (local data that will be deleted when the node is drained)</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>disable_eviction</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/molecule/default/tasks/drain.yml
+++ b/molecule/default/tasks/drain.yml
@@ -5,6 +5,7 @@
       drain_namespace: "drain"
       drain_daemonset_name: "promotheus-dset"
       drain_pod_name: "pod-drain"
+      drain_deployment_emptydir_name: "deployment-emptydir-drain"
 
   - name: Create {{ drain_namespace }} namespace
     k8s:
@@ -99,6 +100,61 @@
             - -c
             - while true;do date;sleep 5; done
 
+  - name: Create Deployment with an emptyDir volume.
+    k8s:
+      namespace: '{{ drain_namespace }}'
+      wait: yes
+      definition:
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: '{{ drain_deployment_emptydir_name }}'
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              drain: emptyDir
+          template:
+            metadata:
+              labels:
+                drain: emptyDir
+            spec:
+              metadata:
+                labels:
+                  drain: emptyDir
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchFields:
+                      - key: metadata.name
+                        operator: In
+                        values:
+                        - '{{ node_to_drain }}'
+              containers:
+              - name: c0
+                image: busybox
+                command:
+                - /bin/sh
+                - -c
+                - while true;do date;sleep 5; done
+                volumeMounts:
+                - mountPath: /emptydir
+                  name: emptydir
+              volumes:
+              - name: emptydir
+                emptyDir: {}
+
+  - name: Register emptyDir Pod name
+    k8s_info:
+      namespace: '{{ drain_namespace }}'
+      kind: Pod
+      label_selectors:
+      - "drain = emptyDir"
+    register: emptydir_pod_result
+    failed_when:
+    - emptydir_pod_result.resources | length != 1
+
   - name: Cordon node
     k8s_drain:
       state: cordon
@@ -167,14 +223,16 @@
       - drain_result is failed
       - '"cannot delete DaemonSet-managed Pods" in drain_result.msg'
       - '"cannot delete Pods not managed by ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet" in drain_result.msg'
+      - '"cannot delete Pods with local storage" in drain_result.msg'
 
-  - name: Drain node using ignore_daemonsets and force options
+  - name: Drain node using ignore_daemonsets, force, and delete_emptydir_data options
     k8s_drain:
       state: drain
       name: '{{ node_to_drain }}'
       delete_options:
         force: true
         ignore_daemonsets: true
+        delete_emptydir_data: true
         wait_timeout: 0
     register: drain_result
 
@@ -192,6 +250,14 @@
     register: _result
     failed_when: _result.resources
 
+  - name: assert that emptyDir pod was deleted
+    k8s_info:
+      namespace: '{{ drain_namespace }}'
+      kind: Pod
+      name: "{{ emptydir_pod_result.resources[0].metadata.name }}"
+    register: _result
+    failed_when: _result.resources | length != 0
+
   - name: Test drain idempotency
     k8s_drain:
       state: drain
@@ -199,6 +265,7 @@
       delete_options:
         force: true
         ignore_daemonsets: true
+        delete_emptydir_data: true
     register: drain_result
 
   - name: Check idempotency


### PR DESCRIPTION
##### SUMMARY
Adds `delete_emptydir_data` option to `k8s_drain.delete_options` to evict pods with an `emptyDir` volume attached.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`k8s_drain`

##### ADDITIONAL INFORMATION
<sub>Be gentle, this is my first pull request 😨 </sub>

Basically adds the ```kubectl drain <node> --delete-emptydir-data``` feature, including tests.