### PR TITLE
Refactor k8s_exec to use new module_utils code

### DIFF
--- a/plugins/modules/k8s_exec.py
+++ b/plugins/modules/k8s_exec.py
@@ -218,7 +218,7 @@ def main():
     )
 
     client = get_api_client(module)
-    execute_module(module, client)
+    execute_module(module, client.client)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/k8s_exec.py
+++ b/plugins/modules/k8s_exec.py
@@ -130,6 +130,12 @@ from ansible.module_utils._text import to_native
 from ansible_collections.kubernetes.core.plugins.module_utils.common import (
     AUTH_ARG_SPEC,
 )
+from ansible_collections.kubernetes.core.plugins.module_utils.k8s.core import (
+    AnsibleK8SModule,
+)
+from ansible_collections.kubernetes.core.plugins.module_utils.k8s.client import (
+    get_api_client,
+)
 
 try:
     from kubernetes.client.apis import core_v1_api
@@ -148,10 +154,9 @@ def argspec():
     return spec
 
 
-def execute_module(module, k8s_ansible_mixin):
-
+def execute_module(module, client):
     # Load kubernetes.client.Configuration
-    api = core_v1_api.CoreV1Api(k8s_ansible_mixin.client.client)
+    api = core_v1_api.CoreV1Api(client.client)
 
     # hack because passing the container as None breaks things
     optional_kwargs = {}
@@ -205,15 +210,15 @@ def execute_module(module, k8s_ansible_mixin):
 
 
 def main():
-    module = AnsibleModule(argument_spec=argspec(), supports_check_mode=True,)
-    from ansible_collections.kubernetes.core.plugins.module_utils.common import (
-        K8sAnsibleMixin,
-        get_api_client,
+    module = AnsibleK8SModule(
+        module_class=AnsibleModule,
+        check_pyyaml=False,
+        argument_spec=argspec(),
+        supports_check_mode=True,
     )
 
-    k8s_ansible_mixin = K8sAnsibleMixin(module)
-    k8s_ansible_mixin.client = get_api_client(module=module)
-    execute_module(module, k8s_ansible_mixin)
+    client = get_api_client(module)
+    execute_module(module, client)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1340

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Refactor k8s_exec to use new module_utils code

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Requires https://github.com/ansible-collections/kubernetes.core/pull/329

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
k8s_exec
