### PR TITLE
[backport/2.2] Don't wait on *List resources for info module

### DIFF
--- a/changelogs/fragments/253-dont-wait-on-list-resources.yaml
+++ b/changelogs/fragments/253-dont-wait-on-list-resources.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - k8s_info - don't wait on empty List resources (https://github.com/ansible-collections/kubernetes.core/pull/253).

--- a/molecule/default/tasks/info.yml
+++ b/molecule/default/tasks/info.yml
@@ -199,6 +199,38 @@
         that:
           - "{{ lookup('pipe', 'date +%s') }} - {{ start }} > 30"
 
+    - name: Create simple pod
+      k8s:
+        definition:
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: wait-pod-1
+            namespace: "{{ wait_namespace }}"
+          spec:
+            containers:
+              - image: busybox
+                name: busybox
+                command:
+                  - /bin/sh
+                  - -c
+                  - while true; do sleep 5; done
+
+    - name: Wait for multiple non-existent pods to be created
+      k8s_info:
+        kind: Pod
+        namespace: "{{ wait_namespace }}"
+        label_selectors:
+          - thislabel=doesnotexist
+        wait: yes
+        wait_timeout: 10
+      register: result
+
+    - name: Assert no pods were found
+      assert:
+        that:
+          - not result.resources
+
   vars:
     k8s_pod_name: pod-info-1
 

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -279,18 +279,28 @@ class K8sAnsibleMixin(object):
         def _elapsed():
             return (datetime.now() - start).seconds
 
-        if result is None:
-            while _elapsed() < wait_timeout:
-                try:
-                    result = resource.get(name=name, namespace=namespace,
-                                          label_selector=','.join(label_selectors),
-                                          field_selector=','.join(field_selectors))
-                    break
-                except NotFoundError:
-                    pass
-                time.sleep(wait_sleep)
-            if result is None:
-                return dict(resources=[], api_found=True)
+        def result_empty(result):
+            return (
+                result is None
+                or result.kind.endswith("List")
+                and not result.get("items")
+            )
+
+        while result_empty(result) and _elapsed() < wait_timeout:
+            try:
+                result = resource.get(
+                    name=name,
+                    namespace=namespace,
+                    label_selector=",".join(label_selectors),
+                    field_selector=",".join(field_selectors),
+                )
+            except NotFoundError:
+                pass
+            if not result_empty(result):
+                break
+            time.sleep(wait_sleep)
+        if result_empty(result):
+            return dict(resources=[], api_found=True)
 
         if isinstance(result, ResourceInstance):
             satisfied_by = []

--- a/plugins/modules/k8s_info.py
+++ b/plugins/modules/k8s_info.py
@@ -191,6 +191,10 @@ def main():
 
     k8s_ansible_mixin = K8sAnsibleMixin(module)
     k8s_ansible_mixin.client = get_api_client(module=module)
+    k8s_ansible_mixin.fail_json = module.fail_json
+    k8s_ansible_mixin.fail = module.fail_json
+    k8s_ansible_mixin.exit_json = module.exit_json
+    k8s_ansible_mixin.warn = module.warn
     execute_module(module, k8s_ansible_mixin)
 
 


### PR DESCRIPTION
Don't wait on *List resources for info module

SUMMARY

We can't use the same wait logic on *List resources because they lack
the same metadata that other resources have. We should ensure that we
are waiting on the items in the list, but not the list itself. Waiting
on the list itself results in unexpected behavior.
This fixes the waiting logic when waiting on a list to wait until the
list being queried contains one or more items, or the wait timeout has
been reached. Each item in the list can then be waited on with the usual
wait logic.

ISSUE TYPE

Bugfix Pull Request

COMPONENT NAME

ADDITIONAL INFORMATION

Reviewed-by: None <None>
Reviewed-by: Alina Buzachis <None>
Reviewed-by: None <None>
(cherry picked from commit bf26f5a3be025822f8f26250c09f39d8ff73da11)
