### PR TITLE
[backport/2.2] Fix k8s_drain failing when pod has local storage

### DIFF
--- a/changelogs/fragments/295-fix-k8s-drain-variable-declaration.yaml
+++ b/changelogs/fragments/295-fix-k8s-drain-variable-declaration.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - k8s_drain - fix error caused by accessing an undefined variable when pods have local storage (https://github.com/ansible-collections/kubernetes.core/issues/292).

--- a/plugins/modules/k8s_drain.py
+++ b/plugins/modules/k8s_drain.py
@@ -183,6 +183,7 @@ def filter_pods(pods, force, ignore_daemonset):
 
     # local storage
     if localStorage:
+        pod_names = ",".join([pod[0] + "/" + pod[1] for pod in localStorage])
         errors.append("cannot delete Pods with local storage: {0}.".format(pod_names))
 
     # DaemonSet managed Pods


### PR DESCRIPTION
Fix k8s_drain failing when pod has local storage

SUMMARY

The module fails to define the pod_names variable before using it for
pods with local storage.

Fixes #292
ISSUE TYPE

Bugfix Pull Request

COMPONENT NAME

k8s_drain
ADDITIONAL INFORMATION

Reviewed-by: Abhijeet Kasurde <None>
Reviewed-by: None <None>
Reviewed-by: None <None>
(cherry picked from commit ef46c352d0261d8d2c51f77ca6df3f2f6dc0b294)
