### PR TITLE
[backport/2.2] Fix for common non-ASCII characters in CRDs

### DIFF
--- a/changelogs/fragments/308-fix-for-common-non-ascii-characters-in-resources.yaml
+++ b/changelogs/fragments/308-fix-for-common-non-ascii-characters-in-resources.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - module_utils.common - change default opening mode to read-bytes to avoid bad interpretation of non ascii characters and strings, often present in 3rd party manifests.

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -331,7 +331,7 @@ class K8sAnsibleMixin(object):
         if not os.path.exists(path):
             self.fail(msg="Error accessing {0}. Does the file exist?".format(path))
         try:
-            with open(path, 'r') as f:
+            with open(path, "rb") as f:
                 result = list(yaml.safe_load_all(f))
         except (IOError, yaml.YAMLError) as exc:
             self.fail(msg="Error loading resource_definition: {0}".format(exc))


### PR DESCRIPTION
Fix for common non-ASCII characters in CRDs

This should keep the module safe from digesting non-ASCII chars like here (https://github.com/projectcalico/api/pull/46/files)
SUMMARY
Add support for non-ASCII chars in manifests.

ISSUE TYPE

Bugfix Pull Request

COMPONENT NAME
core.k8s module failing if resources contain non ascii chars

Reviewed-by: Abhijeet Kasurde <None>
Reviewed-by: Mike Graves <mgraves@redhat.com>
Reviewed-by: Alessandro Rossi <None>
Reviewed-by: None <None>
(cherry picked from commit 526f0454aba3fcdfe2b673915b9a427b693d0a7f)
