### PR TITLE
Move module dependency functions outside of module

### DIFF
--- a/molecule/default/tasks/validate.yml
+++ b/molecule/default/tasks/validate.yml
@@ -209,7 +209,7 @@
         - name: assert that task failed with proper message
           assert:
             that:
-              - '"kubernetes >= 17.17.0 is required" in _result.module_stderr'
+              - '"This is required to use in-memory config." in _result.msg'
       when:
         - _stat.stat.exists
         - _stat.stat.readable

--- a/plugins/module_utils/k8s/client.py
+++ b/plugins/module_utils/k8s/client.py
@@ -3,7 +3,6 @@
 
 import os
 import hashlib
-from distutils.version import LooseVersion
 from typing import Any, Dict, List, Optional
 
 from ansible.module_utils.six import iteritems, string_types
@@ -13,6 +12,7 @@ from ansible_collections.kubernetes.core.plugins.module_utils.args_common import
     AUTH_ARG_SPEC,
     AUTH_PROXY_HEADERS_SPEC,
 )
+from ansible_collections.kubernetes.core.plugins.module_utils.k8s.core import requires
 
 try:
     from ansible_collections.kubernetes.core.plugins.module_utils import (
@@ -40,18 +40,7 @@ except ImportError:
     pass
 
 
-module = None
 _pool = {}
-
-
-def _requires_kubernetes_at_least(version: str):
-    if module:
-        module.requires("kubernetes", version)
-    else:
-        if LooseVersion(kubernetes.__version__) < LooseVersion(version):
-            raise Exception(
-                f"kubernetes >= {version} is required to use in-memory kubeconfig."
-            )
 
 
 def _create_auth_spec(module=None, **kwargs) -> Dict:
@@ -97,7 +86,6 @@ def _load_config(auth: Dict) -> None:
         if isinstance(kubeconfig, string_types):
             kubernetes.config.load_kube_config(config_file=kubeconfig, **optional_arg)
         elif isinstance(kubeconfig, dict):
-            _requires_kubernetes_at_least("17.17.0")
             kubernetes.config.load_kube_config_from_dict(
                 config_dict=kubeconfig, **optional_arg
             )
@@ -241,6 +229,11 @@ class K8SClient:
 
 def get_api_client(module=None, **kwargs: Optional[Any]) -> K8SClient:
     auth_spec = _create_auth_spec(module, **kwargs)
+    if isinstance(auth_spec.get("kubeconfig"), dict):
+        if module:
+            module.requires("kubernetes", "17.17.0", "to use in-memory config")
+        else:
+            requires("kubernetes", "17.17.0", "to use in-memory config")
     configuration = _create_configuration(auth_spec)
     client = create_api_client(configuration)
 

--- a/plugins/module_utils/k8s/core.py
+++ b/plugins/module_utils/k8s/core.py
@@ -84,7 +84,7 @@ class AnsibleK8SModule:
         reason: Optional[str] = None,
     ) -> None:
         try:
-            requires(dependency, minimum)
+            requires(dependency, minimum, reason=reason)
         except Exception as e:
             self.fail_json(msg=to_text(e))
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This moves the has_at_least and requires functions that had been on the
module to top level functions. The functions on the module now call
these with a few added bits of functionality.

Moving these functions to the top level and removing their requirement
on having a module makes them usable in situations where we may not yet
have a module, such as during client creation.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
