### PR TITLE
Fix module_defaults by removing routing hack

### DIFF
--- a/changelogs/fragments/347-routing.yml
+++ b/changelogs/fragments/347-routing.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- fixed module_defaults by removing routing hacks from runtime.yml (https://github.com/ansible-collections/kubernetes.core/pull/347).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -17,37 +17,6 @@ action_groups:
     - k8s_drain
 
 plugin_routing:
-  action:
-    helm:
-      redirect: kubernetes.core.k8s_info
-    helm_info:
-      redirect: kubernetes.core.k8s_info
-    helm_plugin:
-      redirect: kubernetes.core.k8s_info
-    helm_plugin_info:
-      redirect: kubernetes.core.k8s_info
-    helm_repository:
-      redirect: kubernetes.core.k8s_info
-    k8s:
-      redirect: kubernetes.core.k8s_info
-    k8s_cluster_info:
-      redirect: kubernetes.core.k8s_info
-    k8s_cp:
-      redirect: kubernetes.core.k8s_info
-    k8s_drain:
-      redirect: kubernetes.core.k8s_info
-    k8s_event_info:
-      redirect: kubernetes.core.k8s_info
-    k8s_exec:
-      redirect: kubernetes.core.k8s_info
-    k8s_log:
-      redirect: kubernetes.core.k8s_info
-    k8s_rollback:
-      redirect: kubernetes.core.k8s_info
-    k8s_scale:
-      redirect: kubernetes.core.k8s_info
-    k8s_service:
-      redirect: kubernetes.core.k8s_info
   inventory:
     openshift:
       redirect: community.okd.openshift


### PR DESCRIPTION
##### SUMMARY
Fixes #202
Fixes https://github.com/ansible/ansible/issues/76687

As mentioned [here](https://github.com/ansible-collections/kubernetes.core/issues/202#issuecomment-1011189516), I'm not sure what the redirection was originally solving, but this would be the ideal solution for module_defaults.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
