### PR TITLE
helm_template: change order of values_release and values_files

### DIFF
--- a/changelogs/fragments/348-helm_template-fix-precedence-of-release-values-over-values-files.yaml
+++ b/changelogs/fragments/348-helm_template-fix-precedence-of-release-values-over-values-files.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - helm_template - evaluate release_values after values_files, insuring highest precedence (now same behavior as in helm module). (https://github.com/ansible-collections/kubernetes.core/pull/348)

--- a/plugins/modules/helm_template.py
+++ b/plugins/modules/helm_template.py
@@ -152,15 +152,15 @@ def template(
     if output_dir:
         cmd += " --output-dir=" + output_dir
 
+    if values_files:
+        for values_file in values_files:
+            cmd += " -f=" + values_file
+
     if release_values:
         fd, path = tempfile.mkstemp(suffix=".yml")
         with open(path, "w") as yaml_file:
             yaml.dump(release_values, yaml_file, default_flow_style=False)
         cmd += " -f=" + path
-
-    if values_files:
-        for values_file in values_files:
-            cmd += " -f=" + values_file
 
     if include_crds:
         cmd += " --include-crds"

--- a/tests/unit/modules/test_helm_template.py
+++ b/tests/unit/modules/test_helm_template.py
@@ -28,9 +28,9 @@ def test_template_with_release_values_and_values_files():
     parser.add_argument('NAME', nargs='?', default="release-name")
     parser.add_argument('CHART', nargs='+')
     parser.add_argument('-f', action='append')
-    
+
     rv = {
-        "v1" : {
+        "v1": {
             "enabled": True
         }
     }
@@ -38,14 +38,13 @@ def test_template_with_release_values_and_values_files():
         "values1.yml",
         "values2.yml"
     ]
-
     mytemplate = template(cmd=helm_cmd, chart_ref=my_chart_ref, release_values=rv, values_files=vf)
-   
+
     args, unknown = parser.parse_known_args(mytemplate.split())
-    
+
     # helm_template writes release_values to temporary file with changing name
-    # these tests should insure 
-    # - correct order values_files 
+    # these tests should insure
+    # - correct order values_files
     # - unknown being included as last
     assert args.f[0] == "values1.yml"
     assert args.f[1] == "values2.yml"

--- a/tests/unit/modules/test_helm_template.py
+++ b/tests/unit/modules/test_helm_template.py
@@ -6,13 +6,9 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import os.path
-
 import argparse
 
-from ansible_collections.kubernetes.core.plugins.modules.helm_template import (
-    template,
-)
+from ansible_collections.kubernetes.core.plugins.modules.helm_template import template
 
 
 def test_template_with_release_values_and_values_files():
@@ -20,25 +16,20 @@ def test_template_with_release_values_and_values_files():
     helm_cmd = "helm"
     parser = argparse.ArgumentParser()
 
-    parser.add_argument('cmd')
-    parser.add_argument('template')
-# to "simulate" helm template options, include two optional parameters NAME and CHART.
-# if parsed string contains only one parameter, the value will be passed
-# to CHART and NAME will be set to default value "release-name" as in helm template
-    parser.add_argument('NAME', nargs='?', default="release-name")
-    parser.add_argument('CHART', nargs='+')
-    parser.add_argument('-f', action='append')
+    parser.add_argument("cmd")
+    parser.add_argument("template")
+    # to "simulate" helm template options, include two optional parameters NAME and CHART.
+    # if parsed string contains only one parameter, the value will be passed
+    # to CHART and NAME will be set to default value "release-name" as in helm template
+    parser.add_argument("NAME", nargs="?", default="release-name")
+    parser.add_argument("CHART", nargs="+")
+    parser.add_argument("-f", action="append")
 
-    rv = {
-        "v1": {
-            "enabled": True
-        }
-    }
-    vf = [
-        "values1.yml",
-        "values2.yml"
-    ]
-    mytemplate = template(cmd=helm_cmd, chart_ref=my_chart_ref, release_values=rv, values_files=vf)
+    rv = {"v1": {"enabled": True}}
+    vf = ["values1.yml", "values2.yml"]
+    mytemplate = template(
+        cmd=helm_cmd, chart_ref=my_chart_ref, release_values=rv, values_files=vf
+    )
 
     args, unknown = parser.parse_known_args(mytemplate.split())
 

--- a/tests/unit/modules/test_helm_template.py
+++ b/tests/unit/modules/test_helm_template.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2020, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import os.path
+
+import argparse
+
+from ansible_collections.kubernetes.core.plugins.modules.helm_template import (
+    template,
+)
+
+
+def test_template_with_release_values_and_values_files():
+    my_chart_ref = "testref"
+    helm_cmd = "helm"
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('cmd')
+    parser.add_argument('template')
+# to "simulate" helm template options, include two optional parameters NAME and CHART.
+# if parsed string contains only one parameter, the value will be passed
+# to CHART and NAME will be set to default value "release-name" as in helm template
+    parser.add_argument('NAME', nargs='?', default="release-name")
+    parser.add_argument('CHART', nargs='+')
+    parser.add_argument('-f', action='append')
+    
+    rv = {
+        "v1" : {
+            "enabled": True
+        }
+    }
+    vf = [
+        "values1.yml",
+        "values2.yml"
+    ]
+
+    mytemplate = template(cmd=helm_cmd, chart_ref=my_chart_ref, release_values=rv, values_files=vf)
+   
+    args, unknown = parser.parse_known_args(mytemplate.split())
+    
+    # helm_template writes release_values to temporary file with changing name
+    # these tests should insure 
+    # - correct order values_files 
+    # - unknown being included as last
+    assert args.f[0] == "values1.yml"
+    assert args.f[1] == "values2.yml"
+    assert len(args.f) == 3


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This fix aligns precedence of release_values and values_files in kubernetes.core.helm_template with the one in kubernetes.core.helm. 
The values in release_values are now processed last, thus with highest precedence.
This allows overwriting of values in values_files with the values presented in release_values.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
