### PR TITLE
Remove serial deletion of pods in template tests

### DIFF
--- a/molecule/default/tasks/template.yml
+++ b/molecule/default/tasks/template.yml
@@ -239,17 +239,6 @@
           - resource.result.results | selectattr('changed') | list | length == 1
           - resource.result.results | selectattr('error', 'defined') | list | length == 1
 
-    - name: Remove Pod (Cleanup)
-      kubernetes.core.k8s:
-        api_version: v1
-        kind: Pod
-        name: "pod-{{ item }}"
-        namespace: "{{ template_namespace }}"
-        state: absent
-        wait: yes
-      ignore_errors: yes
-      loop: "{{ range(1, 12) | list }}"
-
   always:
     - name: Remove namespace (Cleanup)
       kubernetes.core.k8s:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The template test suite deletes twelve pods in serial during cleanup
which is very slow and leads to frequent timeouts. There's no need to do
this since we delete the namespace the pods are in right after.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
