### PR TITLE
test-requirements: use selinux-please-lie-to-me

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,4 @@ kubernetes-validate
 coverage==4.5.4
 pytest
 pytest-xdist
+selinux_please_lie_to_me


### PR DESCRIPTION
Depends-upon: https://github.com/ansible/ansible-zuul-jobs/pull/1334

Use selinux-please-lie-to-me to avoid any selinux related
check. The tests don't interact with selinux.
