### PR TITLE
Use resource prefix when apiVersion is v1

### DIFF
--- a/changelogs/fragments/364-use-resource-prefix.yaml
+++ b/changelogs/fragments/364-use-resource-prefix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - use resource prefix when finding resource and apiVersion is v1 (https://github.com/ansible-collections/kubernetes.core/issues/351).

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -366,9 +366,8 @@ class K8sAnsibleMixin(object):
             prefix=prefix, api_version=api_version, short_names=[kind]
         )
 
-
     def find_resource(self, kind, api_version, fail=False):
-        msg="Failed to find exact match for {0}.{1} by [kind, name, singularName, shortNames]".format(
+        msg = "Failed to find exact match for {0}.{1} by [kind, name, singularName, shortNames]".format(
             api_version, kind
         )
         try:
@@ -377,7 +376,7 @@ class K8sAnsibleMixin(object):
         except ResourceNotUniqueError:
             # No point trying again as we'll just get the same error
             if fail:
-                self.fail(msg)
+                self.fail(msg=msg)
             else:
                 return None
         except ResourceNotFoundError:
@@ -389,8 +388,7 @@ class K8sAnsibleMixin(object):
             return self._find_resource_with_prefix(None, kind, api_version)
         except (ResourceNotFoundError, ResourceNotUniqueError):
             if fail:
-                self.fail(msg)
-
+                self.fail(msg=msg)
 
     def kubernetes_facts(
         self,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When getting a resource from the core api group, the prefix was not
passed, leading the lookup to happen in all api groups. This broad
search is not really necessary and leads to problems in some corner
cases, for example, when an api is deleted after the api group list is
cached.

This fix uses the 'api' prefix when the apiVersion is 'v1', as this is
almost certainly what the user wants. As a fallback, to retain backwards
compatibility, the old behavior is used if the first lookup failed to
find a resource. Given that the module defaults to 'v1' for the
apiVersion, there are likely many cases where a resource, such as
StatefulSet, is used while failing to provide an apiVersion. While
technically incorrect, this has worked in most cases, so we probably
shouldn't break this behavior.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #351 
Depends-On: https://github.com/ansible-collections/kubernetes.core/pull/366

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
