### PR TITLE
k8scopy: rely on existing kubectl binary

### DIFF
--- a/molecule/default/roles/k8scopy/defaults/main.yml
+++ b/molecule/default/roles/k8scopy/defaults/main.yml
@@ -11,5 +11,3 @@ pod_with_two_container:
   container:
   - container-10
   - container-11
-
-kubectl_path: /tmp/kubectl

--- a/molecule/default/roles/k8scopy/tasks/main.yml
+++ b/molecule/default/roles/k8scopy/tasks/main.yml
@@ -1,15 +1,5 @@
 ---
 - block:
-    - name: Download kubeclt executable used to compare results
-      get_url:
-        url: https://dl.k8s.io/release/v1.21.3/bin/linux/amd64/kubectl
-        dest: "{{ kubectl_path }}"
-
-    - name: make kubectl executable
-      ansible.builtin.file:
-        path: "{{ kubectl_path }}"
-        mode: "+x"
-
     # Ensure namespace and create pod to perform tests on
     - name: Ensure namespace exists
       k8s:
@@ -32,11 +22,6 @@
     - include_tasks: test_copy_large_file.yml
 
   always:
-    - name: Remove kubectl executable
-      ansible.builtin.file:
-        path: "{{ kubectl_path }}"
-        state: absent
-      ignore_errors: true
 
     - name: Remove namespace
       k8s:

--- a/molecule/default/roles/k8scopy/tasks/test_copy_directory.yml
+++ b/molecule/default/roles/k8scopy/tasks/test_copy_directory.yml
@@ -14,7 +14,6 @@
       pod: '{{ pod_with_one_container.name }}'
       remote_path: /dest_data
       local_path: '{{ role_path }}/files/data'
-      kubectl_path: "{{ kubectl_path }}"
 
   - name: copy directory into remote Pod (existing directory)
     k8s_cp:
@@ -30,7 +29,6 @@
       pod: '{{ pod_with_one_container.name }}'
       remote_path: /tmp/data
       local_path: '{{ role_path }}/files/data'
-      kubectl_path: "{{ kubectl_path }}"
 
   - name: copy directory from Pod into local filesystem (new directory to create)
     k8s_cp:
@@ -46,7 +44,6 @@
       pod: '{{ pod_with_one_container.name }}'
       remote_path: /tmp/data
       local_path: /tmp/test
-      kubectl_path: "{{ kubectl_path }}"
 
   - name: copy directory from Pod into local filesystem (existing directory)
     k8s_cp:
@@ -62,7 +59,6 @@
       pod: '{{ pod_with_one_container.name }}'
       remote_path: /tmp/data
       local_path: /tmp/data
-      kubectl_path: "{{ kubectl_path }}"
 
   always:
   - name: Remove directories created into remote Pod

--- a/molecule/default/roles/k8scopy/tasks/test_copy_file.yml
+++ b/molecule/default/roles/k8scopy/tasks/test_copy_file.yml
@@ -15,7 +15,6 @@
       pod: '{{ pod_with_one_container.name }}'
       remote_path: /tmp/simple_file.txt
       content: "{{ lookup('file', 'simple_file.txt')}}"
-      kubectl_path: "{{ kubectl_path }}"
 
   - name: Copy simple text file from Pod
     k8s_cp:
@@ -31,7 +30,6 @@
       pod: '{{ pod_with_one_container.name }}'
       remote_path: /tmp/simple_file.txt
       local_path: /tmp/copy_from_pod.txt
-      kubectl_path: "{{ kubectl_path }}"
 
   # Binary file
 
@@ -109,7 +107,6 @@
       pod: '{{ pod_with_one_container.name }}'
       remote_path: /tmp/simple_zip_file.txt.gz
       local_path: '{{ role_path }}/files/simple_zip_file.txt.gz'
-      kubectl_path: "{{ kubectl_path }}"
 
   - name: copy zip file from pod into local filesystem
     k8s_cp:
@@ -125,7 +122,6 @@
       pod: '{{ pod_with_one_container.name }}'
       remote_path: /tmp/simple_zip_file.txt.gz
       local_path: /tmp/copied_from_pod.txt.gz
-      kubectl_path: "{{ kubectl_path }}"
 
   # tar files
   - name: copy archive into remote pod
@@ -142,7 +138,6 @@
       pod: '{{ pod_with_one_container.name }}'
       remote_path: /tmp/archive.tar
       local_path: '{{ role_path }}/files/archive.tar'
-      kubectl_path: "{{ kubectl_path }}"
 
   - name: copy archive from remote pod into local filesystem
     k8s_cp:
@@ -158,7 +153,6 @@
       pod: '{{ pod_with_one_container.name }}'
       remote_path: /tmp/archive.tar
       local_path: /tmp/local_archive.tar
-      kubectl_path: "{{ kubectl_path }}"
 
   # Copy into Pod using content option
   - name: set content to be copied into Pod
@@ -179,7 +173,6 @@
       pod: '{{ pod_with_one_container.name }}'
       remote_path: /this_content.txt
       content: '{{ pod_content }}'
-      kubectl_path: "{{ kubectl_path }}"
 
   always:
   - name: Delete file created on Pod

--- a/molecule/default/roles/k8scopy/tasks/test_copy_large_file.yml
+++ b/molecule/default/roles/k8scopy/tasks/test_copy_large_file.yml
@@ -36,7 +36,6 @@
       pod: '{{ pod_with_one_container.name }}'
       remote_path: /large_text_file.txt
       local_path: "{{ test_directory }}/large_text_file.txt"
-      kubectl_path: "{{ kubectl_path }}"
 
   - name: copy large file from Pod into local filesystem
     k8s_cp:
@@ -52,7 +51,6 @@
       pod: '{{ pod_with_one_container.name }}'
       remote_path: /large_text_file.txt
       local_path: "{{ test_directory }}/large_text_file_from_pod.txt"
-      kubectl_path: "{{ kubectl_path }}"
 
   # Copy large binary file from/to local filesystem to Pod
   - name: copy large file into remote Pod

--- a/molecule/default/roles/k8scopy/tasks/test_multi_container_pod.yml
+++ b/molecule/default/roles/k8scopy/tasks/test_multi_container_pod.yml
@@ -18,7 +18,6 @@
     remote_path: /file_from_localhost.txt
     container: '{{ pod_with_two_container.container[0] }}'
     content: '{{ random_content }}'
-    kubectl_path: "{{ kubectl_path }}"
 
 - name: Assert that content has not been copied into second container
   kubectl_file_compare:
@@ -27,7 +26,6 @@
     remote_path: /file_from_localhost.txt
     container: '{{ pod_with_two_container.container[1] }}'
     content: '{{ random_content }}'
-    kubectl_path: "{{ kubectl_path }}"
   register: diff
   ignore_errors: true
 
@@ -52,7 +50,6 @@
     remote_path: /file_from_localhost_01.txt
     container: '{{ pod_with_two_container.container[0] }}'
     content: '{{ random_content }}-secondpod'
-    kubectl_path: "{{ kubectl_path }}"
   ignore_errors: true
   register: diff_1
 
@@ -68,4 +65,3 @@
     remote_path: /file_from_localhost_01.txt
     container: '{{ pod_with_two_container.container[1] }}'
     content: '{{ random_content }}-secondpod'
-    kubectl_path: "{{ kubectl_path }}"

--- a/molecule/default/tasks/lookup_kustomize.yml
+++ b/molecule/default/tasks/lookup_kustomize.yml
@@ -59,17 +59,26 @@
 
     - set_fact:
         kustomize_binary: "{{ _install.stdout | regex_search('kustomize installed to (.*)', '\\1') | list | join('') }}"
+        kubectl_release: "v1.22.0"
         kubectl_binary: "{{ tmp_dir_path }}/kubectl"
 
-    - name: Download kubeclt executable used to compare results
-      get_url:
-        url: https://dl.k8s.io/release/v1.21.3/bin/linux/amd64/kubectl
+    - name: Install Kubectl
+      ansible.builtin.get_url:
+        url: "https://dl.k8s.io/release/{{ kubectl_release }}/bin/linux/amd64/kubectl"
         dest: "{{ kubectl_binary }}"
+      register: result
+      until: result is not failed
+      retries: 3
+      delay: 60
+      become: true
 
-    - name: make kubectl executable
+    - name: Make kubectl as executable
       ansible.builtin.file:
-        path: "{{ kubectl_binary }}"
-        mode: "+x"
+        path: '{{ item }}'
+        mode: '0755'
+      become: true
+      with_items:
+      - "{{ kubectl_binary }}"
 
     - name: Run lookup using kustomize binary
       set_fact:


### PR DESCRIPTION
##### SUMMARY

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
molecule/default/roles/k8scopy/defaults/main.yml
molecule/default/roles/k8scopy/tasks/main.yml
molecule/default/roles/k8scopy/tasks/test_copy_directory.yml
molecule/default/roles/k8scopy/tasks/test_copy_file.yml
molecule/default/roles/k8scopy/tasks/test_copy_large_file.yml
molecule/default/roles/k8scopy/tasks/test_multi_container_pod.yml
molecule/default/tasks/lookup_kustomize.yml
