### PR TITLE
Move diff and wait to perform_action

### DIFF
--- a/plugins/module_utils/k8s/exceptions.py
+++ b/plugins/module_utils/k8s/exceptions.py
@@ -7,4 +7,6 @@ class CoreException(Exception):
 
 
 class ResourceTimeout(CoreException):
-    pass
+    def __init__(self, message="", result=None):
+        self.result = result or {}
+        super().__init__(message)

--- a/plugins/module_utils/k8s/waiter.py
+++ b/plugins/module_utils/k8s/waiter.py
@@ -107,7 +107,7 @@ RESOURCE_PREDICATES = {
 
 
 def empty_list(resource: ResourceInstance) -> bool:
-    return resource.kind.endswith("List") and not resource.get("items")
+    return resource["kind"].endswith("List") and not resource.get("items")
 
 
 def clock(total: int, interval: int) -> Iterator[int]:
@@ -134,7 +134,7 @@ class Waiter:
         namespace: Optional[str] = None,
         label_selectors: Optional[List[str]] = None,
         field_selectors: Optional[List[str]] = None,
-    ) -> Tuple[bool, Optional[Dict], int]:
+    ) -> Tuple[bool, Dict, int]:
         params = {}
 
         if name:
@@ -149,7 +149,7 @@ class Waiter:
         if field_selectors:
             params["field_selector"] = ",".join(field_selectors)
 
-        instance: Optional[Dict] = None
+        instance = {}
         response = None
         elapsed = 0
         for i in clock(timeout, sleep):

--- a/tests/unit/module_utils/test_client.py
+++ b/tests/unit/module_utils/test_client.py
@@ -43,7 +43,10 @@ _temp_files = []
 
 def _remove_temp_file():
     for f in _temp_files:
-        os.remove(f)
+        try:
+            os.remove(f)
+        except FileNotFoundError:
+            pass
 
 
 def _create_temp_file(content=""):

--- a/tests/unit/module_utils/test_runner.py
+++ b/tests/unit/module_utils/test_runner.py
@@ -1,5 +1,8 @@
 import pytest
-from unittest.mock import MagicMock, call
+from copy import deepcopy
+from unittest.mock import Mock
+
+from kubernetes.dynamic.resource import ResourceInstance
 
 from ansible_collections.kubernetes.core.plugins.module_utils.k8s.runner import (
     perform_action,
@@ -24,30 +27,109 @@ definition = {
     },
 }
 
+modified_def = deepcopy(definition)
+modified_def["metadata"]["labels"]["environment"] = "testing"
+
 
 @pytest.mark.parametrize(
-    "params, expected",
+    "action, params, existing, instance, expected",
     [
-        ({"state": "absent"}, call.__setitem__("method", "delete")),
-        ({"apply": True}, call.__setitem__("method", "apply")),
-        ({"force": True}, call.__setitem__("method", "replace")),
-        ({"apply": False}, call.__setitem__("method", "update")),
-        ({}, call.__setitem__("method", "update")),
+        (
+            "delete",
+            {"state": "absent"},
+            {},
+            {},
+            {"changed": False, "method": "delete", "result": {}},
+        ),
+        (
+            "delete",
+            {"state": "absent"},
+            definition,
+            {"kind": "Status"},
+            {"changed": True, "method": "delete", "result": {"kind": "Status"}},
+        ),
+        (
+            "apply",
+            {"apply": "yes"},
+            {},
+            definition,
+            {"changed": True, "method": "apply", "result": definition},
+        ),
+        (
+            "create",
+            {"state": "patched"},
+            {},
+            {},
+            {
+                "changed": False,
+                "result": {},
+                "warnings": [
+                    "resource 'kind=Pod,name=foo' was not found but will not be created as 'state' parameter has been set to 'patched'"
+                ],
+            },
+        ),
+        (
+            "create",
+            {},
+            {},
+            definition,
+            {"changed": True, "method": "create", "result": definition},
+        ),
+        (
+            "replace",
+            {"force": "yes"},
+            definition,
+            definition,
+            {"changed": False, "method": "replace", "result": definition},
+        ),
+        (
+            "replace",
+            {"force": "yes"},
+            definition,
+            modified_def,
+            {"changed": True, "method": "replace", "result": modified_def},
+        ),
+        (
+            "update",
+            {},
+            definition,
+            definition,
+            {"changed": False, "method": "update", "result": definition},
+        ),
+        (
+            "update",
+            {},
+            definition,
+            modified_def,
+            {"changed": True, "method": "update", "result": modified_def},
+        ),
+        (
+            "create",
+            {"label_selectors": ["app=foo"]},
+            {},
+            definition,
+            {
+                "changed": False,
+                "msg": "resource 'kind=Pod,name=foo,namespace=foo' filtered by label_selectors.",
+            },
+        ),
+        (
+            "create",
+            {"label_selectors": ["app=nginx"]},
+            {},
+            definition,
+            {"changed": True, "method": "create", "result": definition},
+        ),
     ],
 )
-def test_perform_action(params, expected):
-    module = MagicMock()
-    module.params = params
+def test_perform_action(action, params, existing, instance, expected):
+    svc = Mock()
+    svc.find_resource.return_value = Mock(
+        kind=definition["kind"], group_version=definition["apiVersion"]
+    )
+    svc.retrieve.return_value = ResourceInstance(None, existing) if existing else None
+    spec = {action + ".return_value": instance}
+    svc.configure_mock(**spec)
 
-    result = perform_action(MagicMock(), definition, module.params)
-    result.assert_has_calls([expected], any_order=True)
-
-
-def test_perform_action_create():
-    spec = {"retrieve.side_effect": [{}]}
-    svc = MagicMock(**spec)
-    module = MagicMock()
-    module.params = {}
-
-    result = perform_action(svc, definition, module.params)
-    result.assert_has_calls([call.__setitem__("method", "create")], any_order=True)
+    result = perform_action(svc, definition, params)
+    assert expected.items() <= result.items()

--- a/tests/unit/module_utils/test_waiter.py
+++ b/tests/unit/module_utils/test_waiter.py
@@ -89,7 +89,7 @@ def test_waiter_waits_for_missing_resource():
         namespace=RESOURCES[0]["metadata"].get("namespace"),
     )
     assert result is False
-    assert instance is None
+    assert instance == {}
     assert abs(elapsed - 3) <= 1
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This primarily moves the diff and wait logic from the various service
methods to perform_action to eliminate code duplication. I also moved
the diff_objects function out of the service object and moved most of
the find_resource logic to a new resource client method. We ended up
with several modules creating a service object just to use one of these
methods, so it seemed to make sense to make these more accessible.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
