### PR TITLE
Adding sleep 0 as workaround when copying files with kubectl exec

### DIFF
--- a/changelogs/fragments/321-kubectl_sleep.yml
+++ b/changelogs/fragments/321-kubectl_sleep.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- kubectl - wait for dd command to complete before proceeding (https://github.com/ansible-collections/kubernetes.core/pull/321).

--- a/plugins/connection/kubectl.py
+++ b/plugins/connection/kubectl.py
@@ -355,7 +355,7 @@ class Connection(ConnectionBase):
                 [
                     self._play_context.executable,
                     "-c",
-                    "dd of=%s bs=%s%s" % (out_path, BUFSIZE, count),
+                    "dd of=%s bs=%s%s && sleep 0" % (out_path, BUFSIZE, count),
                 ]
             )
             args = [to_bytes(i, errors="surrogate_or_strict") for i in args]


### PR DESCRIPTION
##### SUMMARY

For all the commands executed remotely, ** && sleep 0** will be
appended as a workaround for all the commands to terminate properly:

https://github.com/ansible/ansible/blob/16def8050a38510fe3e477a943a90a47a1bf3c8a/lib/ansible/plugins/action/__init__.py#L1243

Workaround will be applied in case of **kubectl exec** too:

https://github.com/ansible-collections/kubernetes.core/blob/b19ff9d70a6ad2efc17a995edf3f348deb67d603/plugins/connection/kubectl.py#L300

That is not the case in the case of the file copy executed by using **kubectl exec**, therefore it is possible for the **kubectl exec** to

terminate before **dd** finishes properly causing the file to be truncated.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/321-kubectl_sleep.yml
plugins/connection/kubectl.py
