### PR TITLE
helm_template: add optional show_only and release_namespace arguments

### DIFF
--- a/changelogs/fragments/313-helm-template-add-support-for-show-only-and-release-namespace.yml
+++ b/changelogs/fragments/313-helm-template-add-support-for-show-only-and-release-namespace.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- helm_template - add show_only and release_namespace as module arguments (https://github.com/ansible-collections/kubernetes.core/issues/313).

--- a/plugins/modules/helm_template.py
+++ b/plugins/modules/helm_template.py
@@ -72,7 +72,7 @@ options:
     type: dict
   show_only:
     description:
-        - Only show manifests rendered from the given templates
+        - Only show manifests rendered from the given templates.
     required: false
     type: list
     elements: str

--- a/tests/unit/modules/test_helm_template.py
+++ b/tests/unit/modules/test_helm_template.py
@@ -40,3 +40,88 @@ def test_template_with_release_values_and_values_files():
     assert args.f[0] == "values1.yml"
     assert args.f[1] == "values2.yml"
     assert len(args.f) == 3
+
+
+def test_template_with_one_show_only_template():
+    my_chart_ref = "testref"
+    helm_cmd = "helm"
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("cmd")
+    parser.add_argument("template")
+    # to "simulate" helm template options, include two optional parameters NAME and CHART.
+    # if parsed string contains only one parameter, the value will be passed
+    # to CHART and NAME will be set to default value "release-name" as in helm template
+    parser.add_argument("NAME", nargs="?", default="release-name")
+    parser.add_argument("CHART", nargs="+")
+    parser.add_argument("-f", action="append")
+    parser.add_argument("-s", action="append")
+
+    rv = {"revision": "1-13-0", "revisionTags": ["canary"]}
+    so_string = "templates/revision-tags.yaml"
+    so = [so_string]
+    mytemplate = template(
+        cmd=helm_cmd, chart_ref=my_chart_ref, show_only=so, release_values=rv
+    )
+
+    args, unknown = parser.parse_known_args(mytemplate.split())
+    print(mytemplate)
+    print(args)
+
+    assert len(args.f) == 1
+    assert len(args.s) == 1
+    assert args.s[0] == so_string
+
+
+def test_template_with_two_show_only_templates():
+    my_chart_ref = "testref"
+    helm_cmd = "helm"
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("cmd")
+    parser.add_argument("template")
+    # to "simulate" helm template options, include two optional parameters NAME and CHART.
+    # if parsed string contains only one parameter, the value will be passed
+    # to CHART and NAME will be set to default value "release-name" as in helm template
+    parser.add_argument("NAME", nargs="?", default="release-name")
+    parser.add_argument("CHART", nargs="+")
+    parser.add_argument("-f", action="append")
+    parser.add_argument("-s", action="append")
+
+    rv = {"revision": "1-13-0", "revisionTags": ["canary"]}
+    so_string_1 = "templates/revision-tags.yaml"
+    so_string_2 = "templates/some-dummy-template.yaml"
+    so = [so_string_1, so_string_2]
+    mytemplate = template(
+        cmd=helm_cmd, chart_ref=my_chart_ref, show_only=so, release_values=rv
+    )
+
+    args, unknown = parser.parse_known_args(mytemplate.split())
+
+    assert len(args.f) == 1
+    assert len(args.s) == 2
+    assert args.s[0] == so_string_1
+    assert args.s[1] == so_string_2
+
+
+def test_template_with_release_namespace():
+    my_chart_ref = "testref"
+    helm_cmd = "helm"
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("cmd")
+    parser.add_argument("template")
+    # to "simulate" helm template options, include two optional parameters NAME and CHART.
+    # if parsed string contains only one parameter, the value will be passed
+    # to CHART and NAME will be set to default value "release-name" as in helm template
+    parser.add_argument("NAME", nargs="?", default="release-name")
+    parser.add_argument("CHART", nargs="+")
+    parser.add_argument("-n", action="append")
+
+    ns = "istio-ingress-canary"
+    mytemplate = template(cmd=helm_cmd, chart_ref=my_chart_ref, release_namespace=ns)
+
+    args, unknown = parser.parse_known_args(mytemplate.split())
+
+    assert len(args.n) == 1
+    assert args.n[0] == ns


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds the "show_only" and "release_namespace" as optional arguments to the helm_template module.
It does some work towards #313.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
changelogs/fragments/313-helm-template-add-support-for-show-only-and-release-namespace.yml
plugins/modules/helm_template.py
tests/unit/modules/test_helm_template.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The PR does include unit tests instead of integration test.

Reasoning: 

The existing integration tests already include a task based on helm_template. So we know that the module does a proper job of using the command line generated inside the module to call helm.
As I trust helm itself to "do its job" correctly, all that should be necessary is to test the correct generation of the command line itself. The included unit tests hopefully do a proper job.

With regards of the pretty long testing times for the module, I really prefer unit tests, if at all possible.

Please let me know if this fits.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
