### PR TITLE
k8copy: relax an error msg check

### DIFF
--- a/molecule/default/roles/k8scopy/tasks/test_copy_errors.yml
+++ b/molecule/default/roles/k8scopy/tasks/test_copy_errors.yml
@@ -14,7 +14,7 @@
   assert:
     that:
       - copy_non_existent is failed
-      - copy_non_existent.msg == "this_file_does_not_exist does not exist in local filesystem"
+      - "'this_file_does_not_exist does not exist in local filesystem' in copy_non_existent.msg"
 
 # copy non-existent pod file should fail
 - name: copy of non-existent file from remote pod should fail
@@ -31,7 +31,7 @@
   assert:
     that:
       - copy_non_existent is failed
-      - copy_non_existent.msg == "/this_file_does_not_exist does not exist in remote pod filesystem"
+      - "'/this_file_does_not_exist does not exist in remote pod filesystem' in copy_non_existent.msg"
 
 # copy file into multiple container pod without specifying the container should fail
 - name: copy file into multiple container pod


### PR DESCRIPTION
The msg string should actually be prefix with `Failed to copy object due to: `.

See: https://ansible.softwarefactory-project.io/zuul/build/50a9b85891c545149ab2ae35eaf73d22
