### PR TITLE
Helm template add name and disable hook

### DIFF
--- a/changelogs/fragments/313-helm-template-add-support-for-name-and-disablehook.yml
+++ b/changelogs/fragments/313-helm-template-add-support-for-name-and-disablehook.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- helm_template - add name (NAME of release) and disable_hook as optional module arguments (https://github.com/ansible-collections/kubernetes.core/issues/313).

--- a/plugins/modules/helm_template.py
+++ b/plugins/modules/helm_template.py
@@ -54,12 +54,24 @@ options:
     type: bool
     aliases: [ dep_up ]
     version_added: "2.4.0"
+  disable_hook:
+    description:
+      - Prevent hooks from running during install.
+    default: False
+    type: bool
+    version_added: 2.4.0
   include_crds:
     description:
       - Include custom resource descriptions in rendered templates.
     required: false
     type: bool
     default: false
+  name:
+    description:
+      - Release name to use in rendered templates.
+    required: false
+    type: str
+    version_added: 2.4.0
   output_dir:
     description:
       - Output directory where templates will be written.
@@ -177,6 +189,8 @@ def template(
     chart_repo_url=None,
     chart_version=None,
     dependency_update=None,
+    disable_hook=None,
+    name=None,
     output_dir=None,
     show_only=None,
     release_values=None,
@@ -184,7 +198,12 @@ def template(
     values_files=None,
     include_crds=False,
 ):
-    cmd += " template " + chart_ref
+    cmd += " template "
+
+    if name:
+        cmd += name + " "
+
+    cmd += chart_ref
 
     if dependency_update:
         cmd += " --dependency-update"
@@ -194,6 +213,9 @@ def template(
 
     if chart_version:
         cmd += " --version=" + chart_version
+
+    if disable_hook:
+        cmd += " --no-hooks"
 
     if output_dir:
         cmd += " --output-dir=" + output_dir
@@ -229,7 +251,9 @@ def main():
             chart_repo_url=dict(type="str"),
             chart_version=dict(type="str"),
             dependency_update=dict(type="bool", default=False, aliases=["dep_up"]),
+            disable_hook=dict(type="bool", default=False),
             include_crds=dict(type="bool", default=False),
+            name=dict(type="str"),
             output_dir=dict(type="path"),
             release_namespace=dict(type="str"),
             release_values=dict(type="dict", default={}, aliases=["values"]),
@@ -246,7 +270,9 @@ def main():
     chart_repo_url = module.params.get("chart_repo_url")
     chart_version = module.params.get("chart_version")
     dependency_update = module.params.get("dependency_update")
+    disable_hook = module.params.get("disable_hook")
     include_crds = module.params.get("include_crds")
+    name = module.params.get("name")
     output_dir = module.params.get("output_dir")
     show_only = module.params.get("show_only")
     release_namespace = module.params.get("release_namespace")
@@ -269,6 +295,8 @@ def main():
         dependency_update=dependency_update,
         chart_repo_url=chart_repo_url,
         chart_version=chart_version,
+        disable_hook=disable_hook,
+        name=name,
         output_dir=output_dir,
         release_namespace=release_namespace,
         release_values=release_values,

--- a/plugins/modules/helm_template.py
+++ b/plugins/modules/helm_template.py
@@ -254,7 +254,7 @@ def main():
             dependency_update=dict(type="bool", default=False, aliases=["dep_up"]),
             disable_hook=dict(type="bool", default=False),
             include_crds=dict(type="bool", default=False),
-            release_name=dict(type="str", default={}, aliases=["name"]),
+            release_name=dict(type="str", aliases=["name"]),
             output_dir=dict(type="path"),
             release_namespace=dict(type="str"),
             release_values=dict(type="dict", default={}, aliases=["values"]),

--- a/plugins/modules/helm_template.py
+++ b/plugins/modules/helm_template.py
@@ -66,18 +66,19 @@ options:
     required: false
     type: bool
     default: false
-  name:
-    description:
-      - Release name to use in rendered templates.
-    required: false
-    type: str
-    version_added: 2.4.0
   output_dir:
     description:
       - Output directory where templates will be written.
       - If the directory already exists, it will be overwritten.
     required: false
     type: path
+  release_name:
+    description:
+      - Release name to use in rendered templates.
+    required: false
+    aliases: [ name ]
+    type: str
+    version_added: 2.4.0
   release_namespace:
     description:
       - namespace scope for this request.
@@ -190,18 +191,18 @@ def template(
     chart_version=None,
     dependency_update=None,
     disable_hook=None,
-    name=None,
     output_dir=None,
     show_only=None,
-    release_values=None,
+    release_name=None,
     release_namespace=None,
+    release_values=None,
     values_files=None,
     include_crds=False,
 ):
     cmd += " template "
 
-    if name:
-        cmd += name + " "
+    if release_name:
+        cmd += release_name + " "
 
     cmd += chart_ref
 
@@ -253,7 +254,7 @@ def main():
             dependency_update=dict(type="bool", default=False, aliases=["dep_up"]),
             disable_hook=dict(type="bool", default=False),
             include_crds=dict(type="bool", default=False),
-            name=dict(type="str"),
+            release_name=dict(type="str", default={}, aliases=["name"]),
             output_dir=dict(type="path"),
             release_namespace=dict(type="str"),
             release_values=dict(type="dict", default={}, aliases=["values"]),
@@ -272,7 +273,7 @@ def main():
     dependency_update = module.params.get("dependency_update")
     disable_hook = module.params.get("disable_hook")
     include_crds = module.params.get("include_crds")
-    name = module.params.get("name")
+    release_name = module.params.get("release_name")
     output_dir = module.params.get("output_dir")
     show_only = module.params.get("show_only")
     release_namespace = module.params.get("release_namespace")
@@ -296,7 +297,7 @@ def main():
         chart_repo_url=chart_repo_url,
         chart_version=chart_version,
         disable_hook=disable_hook,
-        name=name,
+        release_name=release_name,
         output_dir=output_dir,
         release_namespace=release_namespace,
         release_values=release_values,

--- a/tests/integration/targets/helm/tasks/tests_chart.yml
+++ b/tests/integration/targets/helm/tasks/tests_chart.yml
@@ -375,7 +375,6 @@
           "myValue": "ThisValue"
       register: result
       when: chart_source is search("test-chart")
-      # limit test of "show-only" to controlled (local) chart_source
 
     - assert:
         that:

--- a/tests/integration/targets/helm/tasks/tests_chart.yml
+++ b/tests/integration/targets/helm/tasks/tests_chart.yml
@@ -367,7 +367,7 @@
         chart_ref: "{{ chart_source }}"
         chart_version: "{{ chart_source_version | default(omit) }}"
         disable_hook: True
-        name: "MyRelease"
+        release_name: "MyRelease"
         release_namespace: "MyReleaseNamespace"
         show_only:
           - "templates/configmap.yaml"

--- a/tests/integration/targets/helm/tasks/tests_chart.yml
+++ b/tests/integration/targets/helm/tasks/tests_chart.yml
@@ -361,6 +361,32 @@
         that:
           result.stat.exists
 
+    - name: Render single template from chart to result
+      helm_template:
+        binary_path: "{{ helm_binary }}"
+        chart_ref: "{{ chart_source }}"
+        chart_version: "{{ chart_source_version | default(omit) }}"
+        disable_hook: True
+        name: "MyRelease"
+        release_namespace: "MyReleaseNamespace"
+        show_only:
+          - "templates/configmap.yaml"
+        release_values:
+          "myValue": "ThisValue"
+      register: result
+      when: chart_source is search("test-chart")
+      # limit test of "show-only" to controlled (local) chart_source
+
+    - assert:
+        that:
+          - result is changed
+          - result is not failed
+          - result.rc == 0
+          - result.command is match("{{ helm_binary }} template MyRelease {{ chart_source }}")
+          - result.stdout is search("ThisValue")
+      when: chart_source is search("test-chart")
+      # limit assertion of test result to controlled (local) chart_source
+
     - name: Release using non-existent context
       helm:
         binary_path: "{{ helm_binary }}"

--- a/tests/unit/modules/test_helm_template.py
+++ b/tests/unit/modules/test_helm_template.py
@@ -125,3 +125,46 @@ def test_template_with_release_namespace():
 
     assert len(args.n) == 1
     assert args.n[0] == ns
+
+
+def test_template_with_name():
+    my_chart_ref = "testref"
+    helm_cmd = "helm"
+    name = "mytestrelease"
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("cmd")
+    parser.add_argument("template")
+    # to "simulate" helm template options, include two optional parameters NAME and CHART.
+    # if parsed string contains only one parameter, the value will be passed
+    # to CHART and NAME will be set to default value "release-name" as in helm template
+    parser.add_argument("NAME", nargs="?", default="release-name")
+    parser.add_argument("CHART", nargs="+")
+
+    mytemplate = template(cmd=helm_cmd, chart_ref=my_chart_ref, name=name)
+
+    args, unknown = parser.parse_known_args(mytemplate.split())
+
+    assert args.NAME == name
+
+
+def test_template_with_disablehook():
+    my_chart_ref = "testref"
+    helm_cmd = "helm"
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("cmd")
+    parser.add_argument("template")
+    # to "simulate" helm template options, include two optional parameters NAME and CHART.
+    # if parsed string contains only one parameter, the value will be passed
+    # to CHART and NAME will be set to default value "release-name" as in helm template
+    parser.add_argument("NAME", nargs="?", default="release-name")
+    parser.add_argument("CHART", nargs="+")
+    parser.add_argument("--no-hooks", dest="no_hooks", action="store_true")
+    parser.set_defaults(no_hooks=False)
+
+    mytemplate = template(cmd=helm_cmd, chart_ref=my_chart_ref, disable_hook=True)
+
+    args, unknown = parser.parse_known_args(mytemplate.split())
+
+    assert args.no_hooks is True

--- a/tests/unit/modules/test_helm_template.py
+++ b/tests/unit/modules/test_helm_template.py
@@ -130,7 +130,7 @@ def test_template_with_release_namespace():
 def test_template_with_name():
     my_chart_ref = "testref"
     helm_cmd = "helm"
-    name = "mytestrelease"
+    release_name = "mytestrelease"
     parser = argparse.ArgumentParser()
 
     parser.add_argument("cmd")
@@ -141,11 +141,11 @@ def test_template_with_name():
     parser.add_argument("NAME", nargs="?", default="release-name")
     parser.add_argument("CHART", nargs="+")
 
-    mytemplate = template(cmd=helm_cmd, chart_ref=my_chart_ref, name=name)
+    mytemplate = template(cmd=helm_cmd, chart_ref=my_chart_ref, release_name=release_name)
 
     args, unknown = parser.parse_known_args(mytemplate.split())
 
-    assert args.NAME == name
+    assert args.NAME == release_name
 
 
 def test_template_with_disablehook():

--- a/tests/unit/modules/test_helm_template.py
+++ b/tests/unit/modules/test_helm_template.py
@@ -141,7 +141,9 @@ def test_template_with_name():
     parser.add_argument("NAME", nargs="?", default="release-name")
     parser.add_argument("CHART", nargs="+")
 
-    mytemplate = template(cmd=helm_cmd, chart_ref=my_chart_ref, release_name=release_name)
+    mytemplate = template(
+        cmd=helm_cmd, chart_ref=my_chart_ref, release_name=release_name
+    )
 
     args, unknown = parser.parse_known_args(mytemplate.split())
 


### PR DESCRIPTION
##### SUMMARY
This PR adds "disable_hook" and "name" (NAME of the release)  as optional arguments to the helm_template module.
It contains the rest of my planned work towards https://github.com/ansible-collections/kubernetes.core/issues/313.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/modules/helm_template.py
changelogs/fragments/313-helm-template-add-support-for-name-and-disablehook.yml
tests/unit/modules/test_helm_template.py
integration/targets/helm/tasks/tests_chart.yml

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The PR contains unit tests and an integration test for the new parameters added in this and the previous PR. 
I limited the execution of the integration test to the local test chart, because the testing of the "show_only" parameter requires a known chart structure. As I think I do not have to test the workings of "helm template ..." itself, I hope this is sufficient.

Please adjust / comment as necessary.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
