### PR TITLE
k8s_exec: Update deprecation warning

### DIFF
--- a/changelogs/fragments/417_deprecation.yml
+++ b/changelogs/fragments/417_deprecation.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- k8s_exec - update deprecation warning for `return_code` (https://github.com/ansible-collections/kubernetes.core/issues/417).

--- a/plugins/modules/k8s_exec.py
+++ b/plugins/modules/k8s_exec.py
@@ -212,7 +212,7 @@ def execute_module(module, k8s_ansible_mixin):
         rc = int(err["details"]["causes"][0]["message"])
 
     module.deprecate(
-        "The 'return_code' return key is deprecated. Please use 'rc' instead. "
+        "The 'return_code' return key is being renamed to 'rc'. "
         "Both keys are being returned for now to allow users to migrate their automation.",
         version="4.0.0",
         collection_name="kubernetes.core",

--- a/plugins/modules/k8s_exec.py
+++ b/plugins/modules/k8s_exec.py
@@ -212,7 +212,8 @@ def execute_module(module, k8s_ansible_mixin):
         rc = int(err["details"]["causes"][0]["message"])
 
     module.deprecate(
-        "The 'return_code' return key is deprecated. Please use 'rc' instead.",
+        "The 'return_code' return key is deprecated. Please use 'rc' instead. "
+        "Both keys are being returned for now to allow users to migrate their automation.",
         version="4.0.0",
         collection_name="kubernetes.core",
     )


### PR DESCRIPTION
##### SUMMARY

return_code is deprecated in favor of rc, update the
deprecation warning to tell user about the reason behind
this.

Fixes: #417

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/417_deprecation.yml
plugins/modules/k8s_exec.py
