### PR TITLE
k8s_cp - fix issue when using local_path

### DIFF
--- a/changelogs/fragments/422-k8s_cp-fix-issue-when-issue-local_path.yaml
+++ b/changelogs/fragments/422-k8s_cp-fix-issue-when-issue-local_path.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - k8s_cp - fix issue when using parameter local_path with file on managed node. (https://github.com/ansible-collections/kubernetes.core/issues/421).

--- a/plugins/action/k8s_info.py
+++ b/plugins/action/k8s_info.py
@@ -352,7 +352,7 @@ class ActionModule(ActionBase):
 
         local_path = self._task.args.get("local_path")
         state = self._task.args.get("state", None)
-        if local_path and state == "to_pod":
+        if local_path and state == "to_pod" and not remote_transport:
             new_module_args["local_path"] = self.get_file_realpath(local_path)
 
         # Execute the k8s_* module.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When copying from local path to pod, the file is found on the controller node instead of the managed node.
This PR aims to resolve this issue. 
Fixes #421
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
k8s_cp