### PR TITLE
helm_repository: Silence false no_log warning

### DIFF
--- a/changelogs/fragments/412_pass_creds.yml
+++ b/changelogs/fragments/412_pass_creds.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- helm_repository - mark `pass_credentials` as no_log=True to silence false warning (https://github.com/ansible-collections/kubernetes.core/issues/412).

--- a/plugins/modules/helm_repository.py
+++ b/plugins/modules/helm_repository.py
@@ -228,7 +228,7 @@ def main():
             repo_state=dict(
                 default="present", choices=["present", "absent"], aliases=["state"]
             ),
-            pass_credentials=dict(type="bool", default=False),
+            pass_credentials=dict(type="bool", default=False, no_log=True),
             # Generic auth key
             host=dict(type="str", fallback=(env_fallback, ["K8S_AUTH_HOST"])),
             ca_cert=dict(


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/kubernetes.core/pull/424

##### SUMMARY

Apply no_log=True to pass_credentials to silence
false positive warning.

Fixes: #412

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/412_pass_creds.yml
plugins/modules/helm_repository.py
