### PR TITLE
Remove ``omit`` value from template args

### DIFF
--- a/changelogs/fragments/432-fix-issue-when-using-template-parameter.yaml
+++ b/changelogs/fragments/432-fix-issue-when-using-template-parameter.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Remove `omit` placeholder when defining resource using template parameter (https://github.com/ansible-collections/kubernetes.core/issues/431).

--- a/tests/integration/targets/k8s_template/tasks/main.yml
+++ b/tests/integration/targets/k8s_template/tasks/main.yml
@@ -239,6 +239,63 @@
           - resource.result.results | selectattr('changed') | list | length == 1
           - resource.result.results | selectattr('error', 'defined') | list | length == 1
 
+    # Test resource definition using template with 'omit'
+    - name: Deploy configmap using template
+      k8s:
+        namespace: "{{ template_namespace }}"
+        name: test-data
+        template: configmap.yml.j2
+
+    - name: Read configmap created
+      k8s_info:
+        kind: configmap
+        namespace: "{{ template_namespace }}"
+        name: test-data
+      register: _configmap
+
+    - name: Validate that the configmap does not contains annotations
+      assert:
+        that:
+          - '"annotations" not in _configmap.resources.0.metadata'
+
+    - name: Create resource once again
+      k8s:
+        namespace: "{{ template_namespace }}"
+        name: test-data
+        template: configmap.yml.j2
+      register: _configmap
+
+    - name: assert that nothing changed
+      assert:
+        that:
+          - _configmap is not changed
+
+    - name: Create resource once again (using description)
+      k8s:
+        namespace: "{{ template_namespace }}"
+        name: test-data
+        template: configmap.yml.j2
+      register: _configmap
+      vars:
+        k8s_configmap_desc: "This is a simple configmap used to test ansible k8s collection"
+
+    - name: assert that configmap was changed
+      assert:
+        that:
+          - _configmap is changed
+
+    - name: Read configmap created
+      k8s_info:
+        kind: configmap
+        namespace: "{{ template_namespace }}"
+        name: test-data
+      register: _configmap
+
+    - name: Validate that the configmap does not contains annotations
+      assert:
+        that:
+          - _configmap.resources.0.metadata.annotations.description == "This is a simple configmap used to test ansible k8s collection"
+
   always:
     - name: Remove namespace (Cleanup)
       kubernetes.core.k8s:

--- a/tests/integration/targets/k8s_template/templates/configmap.yml.j2
+++ b/tests/integration/targets/k8s_template/templates/configmap.yml.j2
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    annotations:
+        description: "{{ k8s_configmap_desc | default(omit) }}"
+data:
+    key: "testing-template"

--- a/tests/unit/action/test_remove_omit.py
+++ b/tests/unit/action/test_remove_omit.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2022, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from datetime import datetime
+from ansible_collections.kubernetes.core.plugins.action.k8s_info import RemoveOmit
+
+
+def get_omit_token():
+    return "__omit_place_holder__%s" % datetime.now().strftime("%Y%m%d%H%M%S")
+
+
+def test_remove_omit_from_str():
+    omit_token = get_omit_token()
+    src = """
+        project: ansible
+        collection: {omit}
+    """.format(
+        omit=omit_token
+    )
+    result = RemoveOmit(src, omit_value=omit_token).output()
+    assert len(result) == 1
+    assert result[0] == dict(project="ansible")
+
+
+def test_remove_omit_from_list():
+    omit_token = get_omit_token()
+    src = """
+        items:
+          - {omit}
+    """.format(
+        omit=omit_token
+    )
+    result = RemoveOmit(src, omit_value=omit_token).output()
+    assert len(result) == 1
+    assert result[0] == dict(items=[])
+
+
+def test_remove_omit_from_list_of_dict():
+    omit_token = get_omit_token()
+    src = """
+        items:
+          - owner: ansible
+            team: {omit}
+          - simple_list_item
+    """.format(
+        omit=omit_token
+    )
+    result = RemoveOmit(src, omit_value=omit_token).output()
+    assert len(result) == 1
+    assert result[0] == dict(items=[dict(owner="ansible"), "simple_list_item"])
+
+
+def test_remove_omit_combined():
+    omit_token = get_omit_token()
+    src = """
+        items:
+          - {omit}
+          - list_item_a
+          - list_item_b
+        parent:
+          child:
+            subchilda: {omit}
+            subchildb:
+                name: {omit}
+                age: 3
+    """.format(
+        omit=omit_token
+    )
+    result = RemoveOmit(src, omit_value=omit_token).output()
+    assert len(result) == 1
+    assert result[0] == dict(
+        items=["list_item_a", "list_item_b"],
+        parent=dict(child=dict(subchildb=dict(age=3))),
+    )
+
+
+def test_remove_omit_mutiple_documents():
+    omit_token = get_omit_token()
+    src = [
+        """
+    project: ansible
+    collection: {omit}
+    """.format(
+            omit=omit_token
+        ),
+        "---",
+        """
+    project: kubernetes
+    environment: production
+    collection: {omit}""".format(
+            omit=omit_token
+        ),
+    ]
+    src = "\n".join(src)
+    print(src)
+    result = RemoveOmit(src, omit_value=omit_token).output()
+    assert len(result) == 2
+    assert result[0] == dict(project="ansible")
+    assert result[1] == dict(project="kubernetes", environment="production")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
While defining resource using ``template`` parameter, the code does not remove the ``omit`` value if any.
This fix adds a post process to remove any omit value from the resource definition.
fixes #431 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
k8s*