### PR TITLE
k8s - fix issue when try to delete resources using label_selectors

### DIFF
--- a/changelogs/fragments/434-fix-k8s-delete-using-label_selector.yaml
+++ b/changelogs/fragments/434-fix-k8s-delete-using-label_selector.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - k8s - fix the issue when trying to delete resources using label_selectors options (https://github.com/ansible-collections/kubernetes.core/issues/433).

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -993,6 +993,7 @@ class K8sAnsibleMixin(object):
                 if self.check_mode and not self.supports_dry_run:
                     return result
                 else:
+                    params = {"namespace": namespace}
                     if delete_options:
                         body = {
                             "apiVersion": "v1",
@@ -1003,8 +1004,18 @@ class K8sAnsibleMixin(object):
                     if self.check_mode:
                         params["dry_run"] = "All"
                     try:
-                        k8s_obj = resource.delete(**params)
-                        result["result"] = k8s_obj.to_dict()
+                        if existing.kind.endswith("List"):
+                            result["result"] = []
+                            for item in existing.items:
+                                origin_name = item.metadata.name
+                                params["name"] = origin_name
+                                k8s_obj = resource.delete(**params)
+                                result["result"].append(k8s_obj.to_dict())
+                        else:
+                            origin_name = existing.metadata.name
+                            params["name"] = origin_name
+                            k8s_obj = resource.delete(**params)
+                            result["result"] = k8s_obj.to_dict()
                     except DynamicApiError as exc:
                         msg = "Failed to delete object: {0}".format(exc.body)
                         if continue_on_error:

--- a/tests/integration/targets/k8s_delete/tasks/main.yml
+++ b/tests/integration/targets/k8s_delete/tasks/main.yml
@@ -76,6 +76,51 @@
         that:
           - not pods_delete.resources
 
+    # test deletion using label selector
+    - name: Deploy load balancer
+      k8s:
+        namespace: "{{ test_namespace }}"
+        definition:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            labels:
+              test: deletion
+            name: "deletion-svc-{{ item }}"
+          spec:
+            ports:
+              - port: 5000
+                targetPort: 5000
+            selector:
+              test: deletion
+            type: LoadBalancer
+      with_items:
+        - "01"
+        - "02"
+        - "03"
+
+    - name: Delete services using label selector
+      kubernetes.core.k8s:
+        api_version: v1
+        namespace: "{{ test_namespace }}"
+        kind: Service
+        state: absent
+        label_selectors:
+          - test=deletion
+
+    - name: list services using label selector
+      k8s_info:
+        kind: Service
+        namespace: "{{ test_namespace }}"
+        label_selectors:
+          - test=deletion
+      register: _result
+
+    - name: Validate that all services were deleted
+      assert:
+        that:
+          - _result.resources | length == 0
+
   always:
     - name: Remove namespace
       k8s:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The kubernetes dynamic client has ``label_selector`` parameter for the ``delete`` method, however based on the documentation of REST API we cannot delete resources using labelSelector option, this fix update the way the resources are deleted. The list of resources are deleted one after another like in the kubectl go client.
Fixes #428 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
