### PR TITLE
Adding previous container log support

### DIFF
--- a/plugins/modules/k8s_log.py
+++ b/plugins/modules/k8s_log.py
@@ -60,6 +60,11 @@ options:
     required: no
     type: str
     version_added: '2.2.0'
+  previous:
+    description:
+    - If true, print the logs for the previous instance of the container in a pod if it exists. 
+    required: no
+    type: bool
 
 requirements:
   - "python >= 3.6"
@@ -138,6 +143,7 @@ def argspec():
             container=dict(),
             since_seconds=dict(),
             label_selectors=dict(type="list", elements="str", default=[]),
+            previous=dict(type="bool", default=False),
         )
     )
     return args
@@ -183,6 +189,11 @@ def execute_module(module, k8s_ansible_mixin):
     if module.params.get("since_seconds"):
         kwargs.setdefault("query_params", {}).update(
             {"sinceSeconds": module.params["since_seconds"]}
+        )
+
+    if module.params.get("previous"):
+        kwargs.setdefault("query_params", {}).update(
+            {"previous": module.params["previous"]}
         )
 
     log = serialize_log(


### PR DESCRIPTION
Signed-off-by: Joshua Eason <josh.eason@anchore.com>

##### SUMMARY
Adds support for the `previous` parameter in `kubectl logs`. This allows for the retrieval of the previously terminated containers logs which is useful for troubleshooting.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
k8s_log

##### ADDITIONAL INFORMATION
Adds the `previous` parameter (bool) to `k8s_log` module. This matches the documentation for `kubectl logs --previous` parameter. This parameter allows for retrieving the previously terminated containers logs.

Output of the module is identical with the exception being the logs returned are from the previously terminated container.
