### PR TITLE
Change line in doc fragment yaml

### DIFF
--- a/plugins/doc_fragments/k8s_auth_options.py
+++ b/plugins/doc_fragments/k8s_auth_options.py
@@ -128,7 +128,7 @@ options:
   impersonate_groups:
     description:
     - Group(s) to impersonate for the operation.
-    - "Can also be specified via K8S_AUTH_IMPERSONATE_GROUPS environment. Example: 'Group1,Group2'"
+    - "Can also be specified via K8S_AUTH_IMPERSONATE_GROUPS environment. Example: Group1,Group2"
     type: list
     elements: str
     version_added: 2.3.0


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
For whatever reason, the one line in this doc fragment leads to sanity
failures in the redhat.openshift collection, which uses this fragment.
The downstream build process for that collection creates yaml that
appears to be valid, but that fails to lint. I'm not sure exactly which
tool the problem is in, but the easiest solution is to just remove the
single quotes here.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
