### PR TITLE
[backport/2.3] continue waiting when an exception is raised (#408)

### DIFF
--- a/changelogs/fragments/408-fix-wait-on-exception.yml
+++ b/changelogs/fragments/408-fix-wait-on-exception.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Catch expectation raised when the process is waiting for resources (https://github.com/ansible-collections/kubernetes.core/issues/407).

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -473,9 +473,11 @@ class K8sAnsibleMixin(object):
         if result_empty(result):
             res = dict(resources=[], api_found=True)
             if last_exception is not None:
-                res["msg"] = (
-                    "Exception '%s' raised while trying to get resource using %s"
-                    % (last_exception, params)
+                res[
+                    "msg"
+                ] = "Exception '%s' raised while trying to get resource using %s" % (
+                    last_exception,
+                    params,
                 )
             return res
 

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -421,18 +421,25 @@ class K8sAnsibleMixin(object):
             field_selectors = []
 
         result = None
+        params = dict(
+            name=name,
+            namespace=namespace,
+            label_selector=",".join(label_selectors),
+            field_selector=",".join(field_selectors),
+        )
         try:
-            result = resource.get(
-                name=name,
-                namespace=namespace,
-                label_selector=",".join(label_selectors),
-                field_selector=",".join(field_selectors),
-            )
+            result = resource.get(**params)
         except BadRequestError:
             return dict(resources=[], api_found=True)
         except NotFoundError:
             if not wait or name is None:
                 return dict(resources=[], api_found=True)
+        except Exception as e:
+            if not wait or name is None:
+                err = "Exception '{0}' raised while trying to get resource using {1}".format(
+                    e, params
+                )
+                return dict(resources=[], msg=err, api_found=True)
 
         if not wait:
             result = result.to_dict()
@@ -452,21 +459,25 @@ class K8sAnsibleMixin(object):
                 and not result.get("items")
             )
 
+        last_exception = None
         while result_empty(result) and _elapsed() < wait_timeout:
             try:
-                result = resource.get(
-                    name=name,
-                    namespace=namespace,
-                    label_selector=",".join(label_selectors),
-                    field_selector=",".join(field_selectors),
-                )
+                result = resource.get(**params)
             except NotFoundError:
                 pass
+            except Exception as e:
+                last_exception = e
             if not result_empty(result):
                 break
             time.sleep(wait_sleep)
         if result_empty(result):
-            return dict(resources=[], api_found=True)
+            res = dict(resources=[], api_found=True)
+            if last_exception is not None:
+                res["msg"] = (
+                    "Exception '%s' raised while trying to get resource using %s"
+                    % (last_exception, params)
+                )
+            return res
 
         if isinstance(result, ResourceInstance):
             satisfied_by = []
@@ -583,6 +594,8 @@ class K8sAnsibleMixin(object):
             except NotFoundError:
                 if state == "absent":
                     return True, {}, _wait_for_elapsed()
+            except Exception:
+                pass
         if response:
             response = response.to_dict()
         return False, response, _wait_for_elapsed()


### PR DESCRIPTION
Depends-On: #446 

Continue waiting when an exception is raised

SUMMARY
When an exception is raised and the wait_timeout is not reached, we should continue waiting as this may occurs due to temporary issue on cluster

Fixes #407

ISSUE TYPE

Bugfix Pull Request

COMPONENT NAME

ADDITIONAL INFORMATION

Reviewed-by: Mike Graves <mgraves@redhat.com>
Reviewed-by: Abhijeet Kasurde <None>
(cherry picked from commit f418353e44b4ca2a5bff7c5a14a5bcf7deb0335b)
