### PR TITLE
[backport/2.3] k8s_cp - fix issue when using local_path (#422)

### DIFF
--- a/changelogs/fragments/422-k8s_cp-fix-issue-when-issue-local_path.yaml
+++ b/changelogs/fragments/422-k8s_cp-fix-issue-when-issue-local_path.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - k8s_cp - fix issue when using parameter local_path with file on managed node. (https://github.com/ansible-collections/kubernetes.core/issues/421).

--- a/plugins/action/k8s_info.py
+++ b/plugins/action/k8s_info.py
@@ -352,7 +352,7 @@ class ActionModule(ActionBase):
 
         local_path = self._task.args.get("local_path")
         state = self._task.args.get("state", None)
-        if local_path and state == "to_pod":
+        if local_path and state == "to_pod" and not remote_transport:
             new_module_args["local_path"] = self.get_file_realpath(local_path)
 
         # Execute the k8s_* module.


### PR DESCRIPTION
Depends-On: #446 

k8s_cp - fix issue when using local_path

SUMMARY

When copying from local path to pod, the file is found on the controller node instead of the managed node.
This PR aims to resolve this issue.
Fixes #421

ISSUE TYPE

Bugfix Pull Request

COMPONENT NAME

k8s_cp

Reviewed-by: Abhijeet Kasurde <None>
Reviewed-by: Mike Graves <mgraves@redhat.com>
(cherry picked from commit 1d05cf54f0b64bada811a4aa2c34e170b87588a1)
