### PR TITLE
[backport/2.3] Change line in doc fragment yaml (#439)

### DIFF
--- a/plugins/doc_fragments/k8s_auth_options.py
+++ b/plugins/doc_fragments/k8s_auth_options.py
@@ -128,7 +128,7 @@ options:
   impersonate_groups:
     description:
     - Group(s) to impersonate for the operation.
-    - "Can also be specified via K8S_AUTH_IMPERSONATE_GROUPS environment. Example: 'Group1,Group2'"
+    - "Can also be specified via K8S_AUTH_IMPERSONATE_GROUPS environment. Example: Group1,Group2"
     type: list
     elements: str
     version_added: 2.3.0


### PR DESCRIPTION
Depends-On: #446 

Change line in doc fragment yaml

SUMMARY

For whatever reason, the one line in this doc fragment leads to sanity
failures in the redhat.openshift collection, which uses this fragment.
The downstream build process for that collection creates yaml that
appears to be valid, but that fails to lint. I'm not sure exactly which
tool the problem is in, but the easiest solution is to just remove the
single quotes here.

ISSUE TYPE

Docs Pull Request

COMPONENT NAME

ADDITIONAL INFORMATION

Reviewed-by: Abhijeet Kasurde <None>
(cherry picked from commit b5cfc854cb95ee7c373cb5dbbcff97d7a4680354)
