### PR TITLE
[backport/2.3] Upgrade black version (#424)

### DIFF
--- a/plugins/action/k8s_info.py
+++ b/plugins/action/k8s_info.py
@@ -295,7 +295,7 @@ class ActionModule(ActionBase):
             )
 
     def run(self, tmp=None, task_vars=None):
-        """ handler for k8s options """
+        """handler for k8s options"""
         if task_vars is None:
             task_vars = dict()
 

--- a/plugins/connection/kubectl.py
+++ b/plugins/connection/kubectl.py
@@ -205,7 +205,7 @@ CONNECTION_OPTIONS = {
 
 
 class Connection(ConnectionBase):
-    """ Local kubectl based connections """
+    """Local kubectl based connections"""
 
     transport = CONNECTION_TRANSPORT
     connection_options = CONNECTION_OPTIONS
@@ -240,12 +240,12 @@ class Connection(ConnectionBase):
                 # Translate verify_ssl to skip_verify_ssl, and output as string
                 skip_verify_ssl = not self.get_option(key)
                 local_cmd.append(
-                    u"{0}={1}".format(
+                    "{0}={1}".format(
                         self.connection_options[key], str(skip_verify_ssl).lower()
                     )
                 )
                 censored_local_cmd.append(
-                    u"{0}={1}".format(
+                    "{0}={1}".format(
                         self.connection_options[key], str(skip_verify_ssl).lower()
                     )
                 )
@@ -262,12 +262,12 @@ class Connection(ConnectionBase):
                 else:
                     censored_local_cmd += [cmd_arg, self.get_option(key)]
 
-        extra_args_name = u"{0}_extra_args".format(self.transport)
+        extra_args_name = "{0}_extra_args".format(self.transport)
         if self.get_option(extra_args_name):
             local_cmd += self.get_option(extra_args_name).split(" ")
             censored_local_cmd += self.get_option(extra_args_name).split(" ")
 
-        pod = self.get_option(u"{0}_pod".format(self.transport))
+        pod = self.get_option("{0}_pod".format(self.transport))
         if not pod:
             pod = self._play_context.remote_addr
         # -i is needed to keep stdin open which allows pipelining to work
@@ -275,7 +275,7 @@ class Connection(ConnectionBase):
         censored_local_cmd += ["exec", "-i", pod]
 
         # if the pod has more than one container, then container is required
-        container_arg_name = u"{0}_container".format(self.transport)
+        container_arg_name = "{0}_container".format(self.transport)
         if self.get_option(container_arg_name):
             local_cmd += ["-c", self.get_option(container_arg_name)]
             censored_local_cmd += ["-c", self.get_option(container_arg_name)]
@@ -286,17 +286,17 @@ class Connection(ConnectionBase):
         return local_cmd, censored_local_cmd
 
     def _connect(self, port=None):
-        """ Connect to the container. Nothing to do """
+        """Connect to the container. Nothing to do"""
         super(Connection, self)._connect()
         if not self._connected:
             display.vvv(
-                u"ESTABLISH {0} CONNECTION".format(self.transport),
+                "ESTABLISH {0} CONNECTION".format(self.transport),
                 host=self._play_context.remote_addr,
             )
             self._connected = True
 
     def exec_command(self, cmd, in_data=None, sudoable=False):
-        """ Run a command in the container """
+        """Run a command in the container"""
         super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
 
         local_cmd, censored_local_cmd = self._build_exec_cmd(
@@ -333,7 +333,7 @@ class Connection(ConnectionBase):
         return os.path.normpath(remote_path)
 
     def put_file(self, in_path, out_path):
-        """ Transfer a file from local to the container """
+        """Transfer a file from local to the container"""
         super(Connection, self).put_file(in_path, out_path)
         display.vvv(
             "PUT %s TO %s" % (in_path, out_path), host=self._play_context.remote_addr
@@ -376,7 +376,7 @@ class Connection(ConnectionBase):
                 )
 
     def fetch_file(self, in_path, out_path):
-        """ Fetch a file from container to local. """
+        """Fetch a file from container to local."""
         super(Connection, self).fetch_file(in_path, out_path)
         display.vvv(
             "FETCH %s TO %s" % (in_path, out_path), host=self._play_context.remote_addr
@@ -420,6 +420,6 @@ class Connection(ConnectionBase):
             )
 
     def close(self):
-        """ Terminate the connection. Nothing to do for kubectl"""
+        """Terminate the connection. Nothing to do for kubectl"""
         super(Connection, self).close()
         self._connected = False

--- a/plugins/module_utils/client/discovery.py
+++ b/plugins/module_utils/client/discovery.py
@@ -96,7 +96,7 @@ class Discoverer(kubernetes.dynamic.discovery.Discoverer):
             self._write_cache()
 
     def get_resources_for_api_version(self, prefix, group, version, preferred):
-        """ returns a dictionary of resources associated with provided (prefix, group, version)"""
+        """returns a dictionary of resources associated with provided (prefix, group, version)"""
 
         resources = defaultdict(list)
         subresources = defaultdict(dict)

--- a/plugins/module_utils/copy.py
+++ b/plugins/module_utils/copy.py
@@ -385,8 +385,10 @@ def check_pod(k8s_ansible_mixin, module):
     def _fail(exc):
         arg = {}
         if hasattr(exc, "body"):
-            msg = "Namespace={0} Kind=Pod Name={1}: Failed requested object: {2}".format(
-                namespace, name, exc.body
+            msg = (
+                "Namespace={0} Kind=Pod Name={1}: Failed requested object: {2}".format(
+                    namespace, name, exc.body
+                )
             )
         else:
             msg = to_native(exc)

--- a/plugins/module_utils/exceptions.py
+++ b/plugins/module_utils/exceptions.py
@@ -19,4 +19,4 @@ __metaclass__ = type
 
 
 class ApplyException(Exception):
-    """ Could not apply patch """
+    """Could not apply patch"""

--- a/plugins/modules/helm_plugin.py
+++ b/plugins/modules/helm_plugin.py
@@ -123,9 +123,15 @@ def main():
             state=dict(
                 type="str", default="present", choices=["present", "absent", "latest"]
             ),
-            plugin_path=dict(type="str",),
-            plugin_name=dict(type="str",),
-            plugin_version=dict(type="str",),
+            plugin_path=dict(
+                type="str",
+            ),
+            plugin_name=dict(
+                type="str",
+            ),
+            plugin_version=dict(
+                type="str",
+            ),
             # Helm options
             context=dict(
                 type="str",

--- a/plugins/modules/helm_plugin_info.py
+++ b/plugins/modules/helm_plugin_info.py
@@ -81,7 +81,9 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             binary_path=dict(type="path"),
-            plugin_name=dict(type="str",),
+            plugin_name=dict(
+                type="str",
+            ),
             # Helm options
             context=dict(
                 type="str",

--- a/plugins/modules/k8s_exec.py
+++ b/plugins/modules/k8s_exec.py
@@ -227,7 +227,10 @@ def execute_module(module, k8s_ansible_mixin):
 
 
 def main():
-    module = AnsibleModule(argument_spec=argspec(), supports_check_mode=True,)
+    module = AnsibleModule(
+        argument_spec=argspec(),
+        supports_check_mode=True,
+    )
     from ansible_collections.kubernetes.core.plugins.module_utils.common import (
         K8sAnsibleMixin,
         get_api_client,

--- a/plugins/modules/k8s_scale.py
+++ b/plugins/modules/k8s_scale.py
@@ -164,7 +164,8 @@ SCALE_ARG_SPEC = {
 
 
 def execute_module(
-    module, k8s_ansible_mixin,
+    module,
+    k8s_ansible_mixin,
 ):
     k8s_ansible_mixin.set_resource_definitions(module)
 

--- a/plugins/modules/k8s_service.py
+++ b/plugins/modules/k8s_service.py
@@ -187,7 +187,7 @@ def merge_dicts(x, y):
 
 
 def argspec():
-    """ argspec property builder """
+    """argspec property builder"""
     argument_spec = copy.deepcopy(AUTH_ARG_SPEC)
     argument_spec.update(COMMON_ARG_SPEC)
     argument_spec.update(RESOURCE_ARG_SPEC)
@@ -196,7 +196,7 @@ def argspec():
 
 
 def execute_module(module, k8s_ansible_mixin):
-    """ Module execution """
+    """Module execution"""
     k8s_ansible_mixin.set_resource_definitions(module)
 
     api_version = "v1"

--- a/plugins/modules/k8s_taint.py
+++ b/plugins/modules/k8s_taint.py
@@ -301,7 +301,10 @@ class K8sTaintAnsible:
 
 
 def main():
-    module = AnsibleModule(argument_spec=argspec(), supports_check_mode=True,)
+    module = AnsibleModule(
+        argument_spec=argspec(),
+        supports_check_mode=True,
+    )
     k8s_taint = K8sTaintAnsible(module)
     k8s_taint.execute_module()
 

--- a/tests/integration/targets/helm/library/helm_test_version.py
+++ b/tests/integration/targets/helm/library/helm_test_version.py
@@ -62,7 +62,8 @@ from ansible.module_utils.basic import AnsibleModule
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            binary_path=dict(type="path"), version=dict(type="str", default="3.7.0"),
+            binary_path=dict(type="path"),
+            version=dict(type="str", default="3.7.0"),
         ),
     )
 

--- a/tests/unit/module_utils/test_apply.py
+++ b/tests/unit/module_utils/test_apply.py
@@ -324,27 +324,27 @@ tests = [
     # str type and everything else was mostly unicode type (don't ask me how)
     dict(
         last_applied={
-            u"kind": u"ConfigMap",
-            u"data": {u"one": "1", "three": "3", "two": "2"},
-            u"apiVersion": u"v1",
-            u"metadata": {u"namespace": u"apply", u"name": u"apply-configmap"},
+            "kind": "ConfigMap",
+            "data": {"one": "1", "three": "3", "two": "2"},
+            "apiVersion": "v1",
+            "metadata": {"namespace": "apply", "name": "apply-configmap"},
         },
         actual={
-            u"kind": u"ConfigMap",
-            u"data": {u"one": "1", "three": "3", "two": "2"},
-            u"apiVersion": u"v1",
-            u"metadata": {
-                u"namespace": u"apply",
-                u"name": u"apply-configmap",
-                u"resourceVersion": "1714994",
-                u"creationTimestamp": u"2019-08-17T05:08:05Z",
-                u"annotations": {},
-                u"selfLink": u"/api/v1/namespaces/apply/configmaps/apply-configmap",
-                u"uid": u"fed45fb0-c0ac-11e9-9d95-025000000001",
+            "kind": "ConfigMap",
+            "data": {"one": "1", "three": "3", "two": "2"},
+            "apiVersion": "v1",
+            "metadata": {
+                "namespace": "apply",
+                "name": "apply-configmap",
+                "resourceVersion": "1714994",
+                "creationTimestamp": "2019-08-17T05:08:05Z",
+                "annotations": {},
+                "selfLink": "/api/v1/namespaces/apply/configmaps/apply-configmap",
+                "uid": "fed45fb0-c0ac-11e9-9d95-025000000001",
             },
         },
         desired={
-            "kind": u"ConfigMap",
+            "kind": "ConfigMap",
             "data": {"one": "1", "three": "3", "two": "2"},
             "apiVersion": "v1",
             "metadata": {"namespace": "apply", "name": "apply-configmap"},
@@ -355,7 +355,7 @@ tests = [
     # then apply the Deployment again. Should un-scale the Deployment
     dict(
         last_applied={
-            "kind": u"Deployment",
+            "kind": "Deployment",
             "spec": {
                 "replicas": 1,
                 "template": {
@@ -372,10 +372,10 @@ tests = [
                     }
                 },
             },
-            "metadata": {"namespace": "apply", "name": u"apply-deployment"},
+            "metadata": {"namespace": "apply", "name": "apply-deployment"},
         },
         actual={
-            "kind": u"Deployment",
+            "kind": "Deployment",
             "spec": {
                 "replicas": 0,
                 "template": {
@@ -392,10 +392,10 @@ tests = [
                     }
                 },
             },
-            "metadata": {"namespace": "apply", "name": u"apply-deployment"},
+            "metadata": {"namespace": "apply", "name": "apply-deployment"},
         },
         desired={
-            "kind": u"Deployment",
+            "kind": "Deployment",
             "spec": {
                 "replicas": 1,
                 "template": {
@@ -409,7 +409,7 @@ tests = [
                     }
                 },
             },
-            "metadata": {"namespace": "apply", "name": u"apply-deployment"},
+            "metadata": {"namespace": "apply", "name": "apply-deployment"},
         },
         expected={
             "spec": {

--- a/tests/unit/module_utils/test_marshal.py
+++ b/tests/unit/module_utils/test_marshal.py
@@ -26,25 +26,49 @@ from ansible_collections.kubernetes.core.plugins.module_utils.hashes import (
 
 tests = [
     dict(
-        resource=dict(kind="ConfigMap", name="", data=dict(),),
+        resource=dict(
+            kind="ConfigMap",
+            name="",
+            data=dict(),
+        ),
         expected=b'{"data":{},"kind":"ConfigMap","name":""}',
     ),
     dict(
-        resource=dict(kind="ConfigMap", name="", data=dict(one=""),),
+        resource=dict(
+            kind="ConfigMap",
+            name="",
+            data=dict(one=""),
+        ),
         expected=b'{"data":{"one":""},"kind":"ConfigMap","name":""}',
     ),
     dict(
         resource=dict(
-            kind="ConfigMap", name="", data=dict(two="2", one="", three="3",),
+            kind="ConfigMap",
+            name="",
+            data=dict(
+                two="2",
+                one="",
+                three="3",
+            ),
         ),
         expected=b'{"data":{"one":"","three":"3","two":"2"},"kind":"ConfigMap","name":""}',
     ),
     dict(
-        resource=dict(kind="Secret", type="my-type", name="", data=dict(),),
+        resource=dict(
+            kind="Secret",
+            type="my-type",
+            name="",
+            data=dict(),
+        ),
         expected=b'{"data":{},"kind":"Secret","name":"","type":"my-type"}',
     ),
     dict(
-        resource=dict(kind="Secret", type="my-type", name="", data=dict(one=""),),
+        resource=dict(
+            kind="Secret",
+            type="my-type",
+            name="",
+            data=dict(one=""),
+        ),
         expected=b'{"data":{"one":""},"kind":"Secret","name":"","type":"my-type"}',
     ),
     dict(
@@ -52,7 +76,11 @@ tests = [
             kind="Secret",
             type="my-type",
             name="",
-            data=dict(two="Mg==", one="", three="Mw==",),
+            data=dict(
+                two="Mg==",
+                one="",
+                three="Mw==",
+            ),
         ),
         expected=b'{"data":{"one":"","three":"Mw==","two":"Mg=="},"kind":"Secret","name":"","type":"my-type"}',
     ),

--- a/tox.ini
+++ b/tox.ini
@@ -21,16 +21,16 @@ commands = collection_prep_add_docs -p .
 
 [testenv:black]
 deps =
-    black==19.10b0
+  black >= 22.0, < 23.0
 
 commands =
   black -v --check --diff {toxinidir}/plugins {toxinidir}/tests
 
 [testenv:linters]
 deps =
-    yamllint
-    flake8
-    black==19.10b0
+  yamllint
+  flake8
+  {[testenv:black]deps}
 
 commands =
   black -v --check --diff {toxinidir}/plugins {toxinidir}/tests


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1515

Upgrade black version

SUMMARY

Move off of beta version of black and pin to current calendar year
version.
The only manual changes here are to tox.ini. Everything else is from running the new version of black.

ISSUE TYPE

COMPONENT NAME

ADDITIONAL INFORMATION

Reviewed-by: Abhijeet Kasurde <None>
(cherry picked from commit 7c71436f3b3e3fb51e1ce78177a885b7293007c4)
