### PR TITLE
[backport/2.2] Fix validation errors in plugin documentation (#399)

### DIFF
--- a/plugins/connection/kubectl.py
+++ b/plugins/connection/kubectl.py
@@ -22,9 +22,9 @@ __metaclass__ = type
 
 DOCUMENTATION = r"""
     author:
-        - xuxinkun
+        - xuxinkun (@xuxinkun)
 
-    connection: kubectl
+    name: kubectl
 
     short_description: Execute tasks in pods running on Kubernetes.
 

--- a/plugins/inventory/k8s.py
+++ b/plugins/inventory/k8s.py
@@ -6,10 +6,9 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
     name: k8s
-    plugin_type: inventory
     author:
-      - Chris Houseknecht <@chouseknecht>
-      - Fabian von Feilitzsch <@fabianvf>
+      - Chris Houseknecht (@chouseknecht)
+      - Fabian von Feilitzsch (@fabianvf)
 
     short_description: Kubernetes (K8s) inventory source
 

--- a/plugins/lookup/k8s.py
+++ b/plugins/lookup/k8s.py
@@ -7,14 +7,14 @@ from __future__ import (absolute_import, division, print_function)
 
 __metaclass__ = type
 
-DOCUMENTATION = '''
-    lookup: k8s
+DOCUMENTATION = """
+    name: k8s
 
     short_description: Query the K8s API
 
     author:
-      - Chris Houseknecht <@chouseknecht>
-      - Fabian von Feilitzsch <@fabianvf>
+      - Chris Houseknecht (@chouseknecht)
+      - Fabian von Feilitzsch (@fabianvf)
 
     description:
       - Uses the Kubernetes Python client to fetch a specific object by name, all matching objects within a
@@ -117,7 +117,7 @@ DOCUMENTATION = '''
       - "python >= 3.6"
       - "kubernetes >= 12.0.0"
       - "PyYAML >= 3.11"
-'''
+"""
 
 EXAMPLES = """
 - name: Fetch a list of namespaces
@@ -159,28 +159,19 @@ RETURN = """
   _list:
     description:
       - One ore more object definitions returned from the API.
-    type: complex
-    contains:
-      api_version:
-        description: The versioned schema of this representation of an object.
-        returned: success
-        type: str
-      kind:
-        description: Represents the REST resource this object represents.
-        returned: success
-        type: str
-      metadata:
-        description: Standard object metadata. Includes name, namespace, annotations, labels, etc.
-        returned: success
-        type: complex
-      spec:
-        description: Specific attributes of the object. Will vary based on the I(api_version) and I(kind).
-        returned: success
-        type: complex
-      status:
-        description: Current status details for the object.
-        returned: success
-        type: complex
+    type: list
+    elements: dict
+    sample:
+        - kind: ConfigMap
+          apiVersion: v1
+          metadata:
+            creationTimestamp: "2022-03-04T13:59:49Z"
+            name: my-config-map
+            namespace: default
+            resourceVersion: "418"
+            uid: 5714b011-d090-4eac-8272-a0ea82ec0abd
+          data:
+            key1: val1
 """
 
 from ansible.errors import AnsibleError

--- a/plugins/lookup/kustomize.py
+++ b/plugins/lookup/kustomize.py
@@ -3,15 +3,15 @@
 #
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-DOCUMENTATION = '''
-    lookup: kustomize
+DOCUMENTATION = """
+    name: kustomize
 
     short_description: Build a set of kubernetes resources using a 'kustomization.yaml' file.
 
     version_added: "2.2.0"
 
     author:
-      - Aubin Bikouo <@abikouo>
+      - Aubin Bikouo (@abikouo)
     notes:
       - If both kustomize and kubectl are part of the PATH, kustomize will be used by the plugin.
     description:
@@ -33,7 +33,7 @@ DOCUMENTATION = '''
 
     requirements:
       - "python >= 3.6"
-'''
+"""
 
 EXAMPLES = """
 - name: Run lookup using kustomize
@@ -52,29 +52,16 @@ EXAMPLES = """
 RETURN = """
   _list:
     description:
-      - One ore more object definitions returned from the tool execution.
-    type: complex
-    contains:
-      api_version:
-        description: The versioned schema of this representation of an object.
-        returned: success
-        type: str
-      kind:
-        description: Represents the REST resource this object represents.
-        returned: success
-        type: str
+      - YAML string for the object definitions returned from the tool execution.
+    type: str
+    sample:
+      kind: ConfigMap
+      apiVersion: v1
       metadata:
-        description: Standard object metadata. Includes name, namespace, annotations, labels, etc.
-        returned: success
-        type: complex
-      spec:
-        description: Specific attributes of the object. Will vary based on the I(api_version) and I(kind).
-        returned: success
-        type: complex
-      status:
-        description: Current status details for the object.
-        returned: success
-        type: complex
+        name: my-config-map
+        namespace: default
+      data:
+        key1: val1
 """
 
 from ansible.errors import AnsibleLookupError


### PR DESCRIPTION
Fix validation errors in plugin documentation

SUMMARY

This fixes validation errors in plugin documentation now that ansible
test for 2.13 is running validate-modules on all plugins. The kubectl
connection plugin validation is ignored because there seems to be a
requirement for the author field to have a github username, which we do
not have.

ISSUE TYPE

Docs Pull Request

COMPONENT NAME

plugins/connection/kubectl
plugins/inventory/k8s
plugins/lookup/k8s
plugins/lookup/kustomize
ADDITIONAL INFORMATION

Reviewed-by: None <None>
(cherry picked from commit 30e84faa243509ed5de76975dffd8c96fe7f5a29)
