### PR TITLE
[backport/2.2] Remove distutils from connection plugin (#456)

### DIFF
--- a/changelogs/fragments/456-replace-distutils.yml
+++ b/changelogs/fragments/456-replace-distutils.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - kubectl.py - replace distutils.spawn.find_executable with shutil.which in the kubectl connection plugin (https://github.com/ansible-collections/kubernetes.core/pull/456).

--- a/plugins/connection/kubectl.py
+++ b/plugins/connection/kubectl.py
@@ -170,9 +170,9 @@ DOCUMENTATION = r"""
         aliases: [ kubectl_verify_ssl ]
 """
 
-import distutils.spawn
 import os
 import os.path
+import shutil
 import subprocess
 
 from ansible.parsing.yaml.loader import AnsibleLoader
@@ -217,13 +217,10 @@ class Connection(ConnectionBase):
 
         # Note: kubectl runs commands as the user that started the container.
         # It is impossible to set the remote user for a kubectl connection.
-        cmd_arg = '{0}_command'.format(self.transport)
-        if cmd_arg in kwargs:
-            self.transport_cmd = kwargs[cmd_arg]
-        else:
-            self.transport_cmd = distutils.spawn.find_executable(self.transport)
-            if not self.transport_cmd:
-                raise AnsibleError("{0} command not found in PATH".format(self.transport))
+        cmd_arg = "{0}_command".format(self.transport)
+        self.transport_cmd = kwargs.get(cmd_arg, shutil.which(self.transport))
+        if not self.transport_cmd:
+            raise AnsibleError("{0} command not found in PATH".format(self.transport))
 
     def _build_exec_cmd(self, cmd):
         """ Build the local kubectl exec command to run cmd on remote_host


### PR DESCRIPTION
Remove distutils from connection plugin

SUMMARY

distutils.spawn.find_executable is deprecated and shutils.which is a
suitable replacement.

ISSUE TYPE

Bugfix Pull Request

COMPONENT NAME

ADDITIONAL INFORMATION

Reviewed-by: Gonéri Le Bouder <goneri@lebouder.net>
Reviewed-by: Joseph Torcasso <None>
(cherry picked from commit 531a9fe3ac1a7f0be43fdccad4fdc4551f03ca33)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
