### PR TITLE
[backport/2.3] helm_repository: Silence false no_log warning (#423)

### DIFF
--- a/changelogs/fragments/412_pass_creds.yml
+++ b/changelogs/fragments/412_pass_creds.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- helm_repository - mark `pass_credentials` as no_log=True to silence false warning (https://github.com/ansible-collections/kubernetes.core/issues/412).

--- a/plugins/modules/helm_repository.py
+++ b/plugins/modules/helm_repository.py
@@ -228,7 +228,7 @@ def main():
             repo_state=dict(
                 default="present", choices=["present", "absent"], aliases=["state"]
             ),
-            pass_credentials=dict(type="bool", default=False),
+            pass_credentials=dict(type="bool", default=False, no_log=True),
             # Generic auth key
             host=dict(type="str", fallback=(env_fallback, ["K8S_AUTH_HOST"])),
             ca_cert=dict(


### PR DESCRIPTION
Depends-on: https://github.com/ansible/ansible-zuul-jobs/pull/1563

helm_repository: Silence false no_log warning

Depends-On: #424
SUMMARY
Apply no_log=True to pass_credentials to silence
false positive warning.
Fixes: #412
Signed-off-by: Abhijeet Kasurde akasurde@redhat.com
ISSUE TYPE

Bugfix Pull Request

COMPONENT NAME
changelogs/fragments/412_pass_creds.yml
plugins/modules/helm_repository.py

Reviewed-by: Mike Graves <mgraves@redhat.com>
(cherry picked from commit d311ac718e55bb602b2c483f595477a5234c7a85)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
