### PR TITLE
feat: add new tail_lines parameter to k8s_log module (#488)

### DIFF
--- a/changelogs/fragments/488-add-support-for-tail-logs.yaml
+++ b/changelogs/fragments/488-add-support-for-tail-logs.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- k8s_log - added the `tail_lines` parameter to limit the number of lines to be retrieved from the end of the logs (https://github.com/ansible-collections/kubernetes.core/issues/488).

--- a/plugins/modules/k8s_log.py
+++ b/plugins/modules/k8s_log.py
@@ -67,6 +67,12 @@ options:
     type: bool
     default: False
     version_added: '2.4.0'
+  tail_lines:
+    description:
+    - A number of lines from the end of the logs to retrieve.
+    required: no
+    type: int
+    version_added: '2.4.0'
 
 requirements:
   - "python >= 3.6"
@@ -106,6 +112,7 @@ EXAMPLES = r"""
     kind: DeploymentConfig
     namespace: testing
     name: example
+    tail_lines: 100
   register: log
 """
 
@@ -156,6 +163,7 @@ def argspec():
             since_seconds=dict(),
             label_selectors=dict(type="list", elements="str", default=[]),
             previous=dict(type="bool", default=False),
+            tail_lines=dict(type="int"),
         )
     )
     return args
@@ -203,6 +211,11 @@ def execute_module(svc, params):
 
     if params.get("previous"):
         kwargs.setdefault("query_params", {}).update({"previous": params["previous"]})
+
+    if params.get("tail_lines"):
+        kwargs.setdefault("query_params", {}).update(
+            {"tailLines": params["tail_lines"]}
+        )
 
     response = resource.log.get(
         name=name, namespace=namespace, serialize=False, **kwargs

--- a/tests/integration/targets/k8s_log/tasks/main.yml
+++ b/tests/integration/targets/k8s_log/tasks/main.yml
@@ -112,6 +112,46 @@
       assert:
         that: job_logs.log_lines[0] == "7"
 
+    - name: create a job that has 10 log lines
+      k8s:
+        state: present
+        wait: yes
+        wait_timeout: "{{ k8s_wait_timeout | default(omit) }}"
+        wait_condition:
+          type: Complete
+          status: 'True'
+        definition:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: multiline-log
+            namespace: "{{ test_namespace }}"
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: busybox
+                    image: busybox
+                    command: ['sh']
+                    args: ['-c', 'for i in $(seq 0 9); do echo $i; done']
+                restartPolicy: Never
+            backoffLimit: 4
+
+    - name: retrieve last 5 log lines from the job
+      k8s_log:
+        api_version: batch/v1
+        kind: Job
+        namespace: "{{ test_namespace }}"
+        name: multiline-log
+        tail_lines: 5
+      register: tailed_log
+
+    # The log_lines by k8s_log always contain a trailing empty element,
+    # so if "tail"ing 5 lines, the length will be 6.
+    - name: verify that specific number of logs have been retrieved
+      assert:
+        that: tailed_log.log_lines | length == 5 + 1
+
   always:
     - name: ensure that namespace is removed
       k8s:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Add new `tail_lines` parameter to `k8s_log` module to limit the number of lines to be retrieved from the end of the logs.

Closes #488.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

`kubernetes.core.k8s_log`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Thanks for useful collection 😃 
This is the first time to send PR to this collection, so please let me know if I'm on the wrong way.

- The `version_added` is set to `2.4.0`, but I'm not aware of the roadmap for this collection, so I'd like to know this is the right version to specify.
- Changelog and simple integration test is also added.
- It seems that the end of `log_lines` always contains an empty element, so if `tail_lines` is set to `5`, the length of `log_lines` will be 6, as noted in the comment in the test. I've considered that truncating the trailing empty element, but decided not to for the following reasons.
  - It is inconsistent and unnatural to remove trailing empty elements only when tail_lines is specified.
  - Removing trailing empty elements always with or without tail_lines is a destructive change and should not be done because it would break backward compatibility.

<!--- Paste verbatim command output below, e.g. before and after your change -->

Example tasks in playbook:

```yaml
  tasks: 
    - name: create a job that has 10 lines of log
      kubernetes.core.k8s:
        state: present
        wait: yes
        wait_timeout: "{{ k8s_wait_timeout | default(omit) }}"
        wait_condition:
          type: Complete
          status: 'True'
        definition:
          apiVersion: batch/v1
          kind: Job
          metadata:
            name: multiline-log
            namespace: test
          spec:
            template:
              spec:
                containers:
                  - name: busybox
                    image: busybox
                    command: ['sh']
                    args: ['-c', 'for i in $(seq 0 9); do echo $i; done']
                restartPolicy: Never
            backoffLimit: 4

    - name: retrieve all logs from the job
      kubernetes.core.k8s_log:
        api_version: batch/v1
        kind: Job
        namespace: test
        name: multiline-log
      register: full_log

    - name: retrieve last 5 lines of log from the job
      kubernetes.core.k8s_log:
        api_version: batch/v1
        kind: Job
        namespace: test
        name: multiline-log
        tail_lines: 5
      register: tailed_log

    - ansible.builtin.debug:
        var: full_log.log_lines

    - ansible.builtin.debug:
        var: tailed_log.log_lines
```

Example output:

```bash
TASK [create a job that has 10 lines of log] *****************************************************************************************
ok: [localhost]

TASK [retrieve all logs from the job] ************************************************************************************************
ok: [localhost]

TASK [retrieve last 5 lines of log from the job] *************************************************************************************
ok: [localhost]

TASK [ansible.builtin.debug] *********************************************************************************************************
ok: [localhost] => 
  full_log.log_lines:
  - '0'
  - '1'
  - '2'
  - '3'
  - '4'
  - '5'
  - '6'
  - '7'
  - '8'
  - '9'
  - ''

TASK [ansible.builtin.debug] *********************************************************************************************************
ok: [localhost] => 
  tailed_log.log_lines:
  - '5'
  - '6'
  - '7'
  - '8'
  - '9'
  - ''

PLAY RECAP ***************************************************************************************************************************
localhost                  : ok=5    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0 
```