### PR TITLE
Add example usage of from_yaml_all

### DIFF
--- a/changelogs/fragments/505-add-from-yaml-all-example.yml
+++ b/changelogs/fragments/505-add-from-yaml-all-example.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - add example usage for from_yaml_all (https://github.com/ansible-collections/kubernetes.core/pull/505).

--- a/plugins/modules/k8s.py
+++ b/plugins/modules/k8s.py
@@ -232,6 +232,15 @@ EXAMPLES = r"""
     state: present
     definition: "{{ lookup('file', '/testing/deployment.yml') | from_yaml }}"
 
+- name: >-
+    (Alternative) Read definition file from the Ansible controller file system.
+    In this case, the definition file contains multiple YAML documents, separated by ---.
+    If the definition file has been encrypted with Ansible Vault it will automatically be decrypted.
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ item }}"
+  loop: "{{ lookup('file', '/testing/deployment.yml') | from_yaml_all | list }}"
+
 - name: Read definition template file from the Ansible controller file system
   kubernetes.core.k8s:
     state: present

--- a/plugins/modules/k8s.py
+++ b/plugins/modules/k8s.py
@@ -238,8 +238,7 @@ EXAMPLES = r"""
     If the definition file has been encrypted with Ansible Vault it will automatically be decrypted.
   kubernetes.core.k8s:
     state: present
-    definition: "{{ item }}"
-  loop: "{{ lookup('file', '/testing/deployment.yml') | from_yaml_all | list }}"
+    definition: "{{ lookup('file', '/testing/deployment.yml') | from_yaml_all }}"
 
 - name: Read definition template file from the Ansible controller file system
   kubernetes.core.k8s:


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/kubernetes.core/pull/513

##### SUMMARY
Sometimes one might want to use a single YAML file that contains multiple Kubernetes definitions. This PR updates the documentation to provide a simple example of how to accomplish that.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
k8s

##### ADDITIONAL INFORMATION
I have not tested this solution against other modules, simply because I did not have use-case for those.
