### PR TITLE
[helm] Add the force_update arg

### DIFF
--- a/changelogs/fragments/509-helm-repo-add-force_update-argument.yaml
+++ b/changelogs/fragments/509-helm-repo-add-force_update-argument.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - helm_repository - Ability to replace (overwrite) the repo if it already exists by forcing (https://github.com/ansible-collections/kubernetes.core/issues/491).

--- a/plugins/modules/helm_repository.py
+++ b/plugins/modules/helm_repository.py
@@ -261,6 +261,7 @@ def argument_spec():
                 default="present", choices=["present", "absent"], aliases=["state"]
             ),
             pass_credentials=dict(type="bool", default=False, no_log=True),
+            force_update=dict(type="bool", default=False, aliases=["force"]),
         )
     )
     return arg_spec
@@ -271,28 +272,6 @@ def main():
 
     module = AnsibleModule(
         argument_spec=argument_spec(),
-            # Generic auth key
-            host=dict(type="str", fallback=(env_fallback, ["K8S_AUTH_HOST"])),
-            ca_cert=dict(
-                type="path",
-                aliases=["ssl_ca_cert"],
-                fallback=(env_fallback, ["K8S_AUTH_SSL_CA_CERT"]),
-            ),
-            validate_certs=dict(
-                type="bool",
-                default=True,
-                aliases=["verify_ssl"],
-                fallback=(env_fallback, ["K8S_AUTH_VERIFY_SSL"]),
-            ),
-            force_update=dict(
-                type="bool",
-                default=False,
-                aliases=["force"],
-            ),
-            api_key=dict(
-                type="str", no_log=True, fallback=(env_fallback, ["K8S_AUTH_API_KEY"])
-            ),
-        ),
         required_together=[["repo_username", "repo_password"]],
         required_if=[("repo_state", "present", ["repo_url"])],
         mutually_exclusive=HELM_AUTH_MUTUALLY_EXCLUSIVE,

--- a/plugins/modules/helm_repository.py
+++ b/plugins/modules/helm_repository.py
@@ -237,7 +237,7 @@ def install_repository(
         install_command += " --pass-credentials"
 
     if force_update:
-      install_command += " --force-update"
+        install_command += " --force-update"
 
     return install_command
 

--- a/plugins/modules/helm_repository.py
+++ b/plugins/modules/helm_repository.py
@@ -118,7 +118,7 @@ options:
     type: bool
     aliases: [ force ]
     default: False
-    version_added: "2.3.3"
+    version_added: "2.4.0"
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/helm_repository.py
+++ b/plugins/modules/helm_repository.py
@@ -225,7 +225,7 @@ def install_repository(
     repository_username,
     repository_password,
     pass_credentials,
-    force_update
+    force_update,
 ):
     install_command = command + " repo add " + repository_name + " " + repository_url
 
@@ -307,7 +307,7 @@ def main():
                 repo_username,
                 repo_password,
                 pass_credentials,
-                force_update
+                force_update,
             )
             changed = True
         elif repository_status["url"] != repo_url:

--- a/tests/integration/targets/helm/tasks/main.yml
+++ b/tests/integration/targets/helm/tasks/main.yml
@@ -4,4 +4,4 @@
   loop_control:
     loop_var: helm_version
   with_items:
-    - "v3.2.4"
+    - "v3.7.0"

--- a/tests/integration/targets/helm/tasks/tests_repository.yml
+++ b/tests/integration/targets/helm/tasks/tests_repository.yml
@@ -42,6 +42,19 @@
     that:
       - repository_errors is failed
 
+- name: Succesfully add repository with the same name when forcing
+  helm_repository:
+    binary_path: "{{ helm_binary }}"
+    name: test_helm_repo
+    repo_url: "{{ chart_test_repo }}"
+    force: true
+  register: repository
+
+- name: Assert that test_helm_repo repository is changed
+  assert:
+    that:
+      - repository is changed
+
 - name: Remove test_helm_repo chart repository
   helm_repository:
     binary_path: "{{ helm_binary }}"


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1648
Depends-On: https://github.com/ansible-collections/kubernetes.core/pull/522

##### SUMMARY
Sometimes a Helm repo needs to be updated with a new URL. The `helm repo add` command allows for this with the `--force-update` flag:
```
      --force-update               replace (overwrite) the repo if it already exists
```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request - Closes https://github.com/ansible-collections/kubernetes.core/issues/491

##### COMPONENT NAME
`kubernetes.core.helm_repository`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
