### PR TITLE
tests: adjust the target durations

### DIFF
--- a/changelogs/fragments/minor-tests-duration.yaml
+++ b/changelogs/fragments/minor-tests-duration.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+- "tests - Adjust the duration of some test targets (https://github.com/ansible-collections/kubernetes.core/pull/513)."

--- a/tests/integration/targets/k8s_apply/aliases
+++ b/tests/integration/targets/k8s_apply/aliases
@@ -1,5 +1,4 @@
-# duration 9min
 slow
 k8s_service
 k8s
-time=192
+time=9m

--- a/tests/integration/targets/k8s_drain/aliases
+++ b/tests/integration/targets/k8s_drain/aliases
@@ -1,4 +1,4 @@
 k8s_drain
 k8s
 k8s_info
-time=121
+time=4m

--- a/tests/integration/targets/k8s_info/aliases
+++ b/tests/integration/targets/k8s_info/aliases
@@ -1,3 +1,3 @@
-time=13
+time=20m
 k8s
 k8s_info

--- a/tests/integration/targets/k8s_rollback/aliases
+++ b/tests/integration/targets/k8s_rollback/aliases
@@ -1,4 +1,4 @@
 k8s_rollback
 k8s
 k8s_info
-time=187
+time=16m

--- a/tests/integration/targets/k8s_scale/aliases
+++ b/tests/integration/targets/k8s_scale/aliases
@@ -1,4 +1,4 @@
 k8s_scale
 k8s
 k8s_info
-time=210
+time=6m


### PR DESCRIPTION
By default, the duration defined by the `time=XX` entry is in second.
The value set for `k8s_info` was way to low.
This commit also increase some other durations to be sure we don't hit
timeout.
