### PR TITLE
k8s_rollback/tests: speed up test

### DIFF
--- a/changelogs/fragments/k8s_rollback_reduce_tmeouts.yaml
+++ b/changelogs/fragments/k8s_rollback_reduce_tmeouts.yaml
@@ -1,3 +1,3 @@
 ---
-minor_changes:
+trivial:
 - "Speed up the tests of k8s_rollback with lower timeout value (https://github.com/ansible-collections/kubernetes.core/pull/518)."

--- a/changelogs/fragments/k8s_rollback_reduce_tmeouts.yaml
+++ b/changelogs/fragments/k8s_rollback_reduce_tmeouts.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- "Speed up the tests of k8s_rollback with lower timeout value (https://github.com/ansible-collections/kubernetes.core/pull/518)."

--- a/tests/integration/targets/k8s_rollback/tasks/main.yml
+++ b/tests/integration/targets/k8s_rollback/tasks/main.yml
@@ -3,12 +3,12 @@
     - name: Set variables
       set_fact:
         namespace: "{{ test_namespace }}"
-
+        k8s_wait_timeout: 180
     - name: Create a deployment
       k8s:
         state: present
         wait: yes
-        wait_timeout: "{{ k8s_wait_timeout | default(omit) }}"
+        wait_timeout: "{{ k8s_wait_timeout }}"
         inline: &deploy
           apiVersion: apps/v1
           kind: Deployment
@@ -38,7 +38,7 @@
       k8s:
         state: present
         wait: yes
-        wait_timeout: "{{ k8s_wait_timeout | default(omit) }}"
+        wait_timeout: 30
         definition:
           apiVersion: apps/v1
           kind: Deployment
@@ -134,7 +134,7 @@
       k8s:
         state: present
         wait: yes
-        wait_timeout: "{{ k8s_wait_timeout | default(omit) }}"
+        wait_timeout: 30
         definition:
           apiVersion: apps/v1
           kind: DaemonSet


### PR DESCRIPTION
Set a low timeout for the tasks that are expected to fail fast to speed up the whole tests.