### PR TITLE
Fix helm test suite

### DIFF
--- a/changelogs/fragments/522-fix-helm-tests.yml
+++ b/changelogs/fragments/522-fix-helm-tests.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - fix helm test suite (https://github.com/ansible-collections/kubernetes.core/pull/522).

--- a/tests/integration/targets/helm/defaults/main.yml
+++ b/tests/integration/targets/helm/defaults/main.yml
@@ -4,9 +4,9 @@ helm_binary: "/tmp/helm/{{ ansible_system | lower }}-amd64/helm"
 
 chart_test: "ingress-nginx"
 chart_test_local_path: "nginx-ingress"
-chart_test_version: 3.8.0
+chart_test_version: 4.2.4
 chart_test_version_local_path: 1.32.0
-chart_test_version_upgrade: 3.9.0
+chart_test_version_upgrade: 4.2.5
 chart_test_version_upgrade_local_path: 1.33.0
 chart_test_repo: "https://kubernetes.github.io/ingress-nginx"
 chart_test_git_repo: "http://github.com/helm/charts.git"

--- a/tests/integration/targets/helm/tasks/main.yml
+++ b/tests/integration/targets/helm/tasks/main.yml
@@ -4,4 +4,4 @@
   loop_control:
     loop_var: helm_version
   with_items:
-    - "v3.2.4"
+    - "v3.7.0"

--- a/tests/integration/targets/helm/tasks/tests_chart.yml
+++ b/tests/integration/targets/helm/tasks/tests_chart.yml
@@ -335,6 +335,13 @@
         that:
           - not (install is changed)
 
+    - name: "Remove {{ chart_release_name }} release"
+      helm:
+        binary_path: "{{ helm_binary }}"
+        name: "{{ chart_release_name }}"
+        namespace: "{{ helm_namespace }}"
+        state: absent
+
     - name: Render templates
       helm_template:
         binary_path: "{{ helm_binary }}"

--- a/tests/integration/targets/helm/tasks/tests_chart/from_repository.yml
+++ b/tests/integration/targets/helm/tasks/tests_chart/from_repository.yml
@@ -14,7 +14,7 @@
     chart_source_version_upgrade: "{{ chart_test_version_upgrade }}"
     helm_namespace: "{{ test_namespace[6] }}"
 
-- name: Add chart repo
+- name: Remove chart repo
   helm_repository:
     binary_path: "{{ helm_binary }}"
     name: test_helm

--- a/tests/integration/targets/helm/tasks/tests_chart/from_url.yml
+++ b/tests/integration/targets/helm/tasks/tests_chart/from_url.yml
@@ -3,6 +3,6 @@
   include_tasks: "../tests_chart.yml"
   vars:
     source: url
-    chart_source: "https://github.com/kubernetes/ingress-nginx/releases/download/{{ chart_test }}-{{ chart_test_version }}/{{ chart_test }}-{{ chart_test_version }}.tgz"
-    chart_source_upgrade: "https://github.com/kubernetes/ingress-nginx/releases/download/{{ chart_test }}-{{ chart_test_version_upgrade }}/{{ chart_test }}-{{ chart_test_version_upgrade }}.tgz"
+    chart_source: "https://github.com/kubernetes/ingress-nginx/releases/download/helm-chart-{{ chart_test_version }}/{{ chart_test }}-{{ chart_test_version }}.tgz"
+    chart_source_upgrade: "https://github.com/kubernetes/ingress-nginx/releases/download/helm-chart-{{ chart_test_version_upgrade }}/{{ chart_test }}-{{ chart_test_version_upgrade }}.tgz"
     helm_namespace: "{{ test_namespace[5] }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The old version of the nginx ingress controller that was being used for helm testing is incompatible with the recent upgrade to k8s 1.25 in CI. This upgrades the version used for testing and fixes a few other related issues.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
