### PR TITLE
fix integration test 2.9

### DIFF
--- a/changelogs/fragments/minor-fix-ci.yaml
+++ b/changelogs/fragments/minor-fix-ci.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+- "tests - Fix the integration test failing with ansible release 2.9 (https://github.com/ansible-collections/kubernetes.core/pull/550)."


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fix the following error with integration testing on `ansible 2.9`

```
"Traceback (most recent call last):\n  File \"/home/zuul-worker/.ansible/tmp/ansible-tmp-1670848053.522889-37466-177335097386880/AnsiballZ_test_inventory_read_credentials.py\", line 116, in <module>\n    _ansiballz_main()\n  File \"/home/zuul-worker/.ansible/tmp/ansible-tmp-1670848053.522889-37466-177335097386880/AnsiballZ_test_inventory_read_credentials.py\", line 108, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/zuul-worker/.ansible/tmp/ansible-tmp-1670848053.522889-37466-177335097386880/AnsiballZ_test_inventory_read_credentials.py\", line 54, in invoke_module\n    runpy.run_module(mod_name='ansible.modules.test_inventory_read_credentials', init_globals=None, run_name='__main__', alter_sys=True)\n  File \"/usr/lib64/python3.8/runpy.py\", line 207, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib64/python3.8/runpy.py\", line 97, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/usr/lib64/python3.8/runpy.py\", line 87, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_test_inventory_read_credentials_payload_set5jnfm/ansible_test_inventory_read_credentials_payload.zip/ansible/modules/test_inventory_read_credentials.py\", line 140, in <module>\n  File \"/tmp/ansible_test_inventory_read_credentials_payload_set5jnfm/ansible_test_inventory_read_credentials_payload.zip/ansible/modules/test_inventory_read_credentials.py\", line 136, in main\n  File \"/tmp/ansible_test_inventory_read_credentials_payload_set5jnfm/ansible_test_inventory_read_credentials_payload.zip/ansible/modules/test_inventory_read_credentials.py\", line 98, in __init__\n  File \"/tmp/ansible_test_inventory_read_credentials_payload_set5jnfm/ansible_test_inventory_read_credentials_payload.zip/ansible/modules/test_inventory_read_credentials.py\", line 121, in execute_module\n  File \"/home/zuul-worker/venv/lib/python3.8/site-packages/kubernetes/dynamic/client.py\", line 84, in __init__\n    self.__discoverer = discoverer(self, cache_file)\n  File \"/home/zuul-worker/venv/lib/python3.8/site-packages/kubernetes/dynamic/discovery.py\", line 224, in __init__\n    Discoverer.__init__(self, client, cache_file)\n  File \"/home/zuul-worker/venv/lib/python3.8/site-packages/kubernetes/dynamic/discovery.py\", line 48, in __init__\n    default_cachefile_name = 'osrcp-{0}.json'.format(hashlib.md5(default_cache_id, usedforsecurity=False).hexdigest())\nTypeError: openssl_md5() takes at most 1 argument (2 given)\n",
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
