### PR TITLE
fix multiple issues with dry_run logic

### DIFF
--- a/changelogs/fragments/561-fix-dry-run.yml
+++ b/changelogs/fragments/561-fix-dry-run.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix dry_run logic - Pass the value dry_run=All instead of dry_run=True to the client, add conditional check on kubernetes client version as this feature is supported only for kubernetes >= 18.20.0 (https://github.com/ansible-collections/kubernetes.core/issues/561).

--- a/changelogs/fragments/561-fix-dry-run.yml
+++ b/changelogs/fragments/561-fix-dry-run.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - Fix dry_run logic - Pass the value dry_run=All instead of dry_run=True to the client, add conditional check on kubernetes client version as this feature is supported only for kubernetes >= 18.20.0 (https://github.com/ansible-collections/kubernetes.core/issues/561).
+  - Fix dry_run logic - Pass the value dry_run=All instead of dry_run=True to the client, add conditional check on kubernetes client version as this feature is supported only for kubernetes >= 18.20.0 (https://github.com/ansible-collections/kubernetes.core/pull/561).

--- a/plugins/module_utils/k8s/client.py
+++ b/plugins/module_utils/k8s/client.py
@@ -267,6 +267,8 @@ class K8SClient:
     If there is a need for other methods or attributes to be proxied, they can be added here.
     """
 
+    K8S_SERVER_DRY_RUN = "All"
+
     def __init__(self, configuration, client, dry_run: bool = False) -> None:
         self.configuration = configuration
         self.client = client
@@ -305,7 +307,7 @@ class K8SClient:
 
     def _ensure_dry_run(self, params: Dict) -> Dict:
         if self.dry_run:
-            params["dry_run"] = True
+            params["dry_run"] = self.K8S_SERVER_DRY_RUN
         return params
 
     def validate(
@@ -354,8 +356,8 @@ def get_api_client(module=None, **kwargs: Optional[Any]) -> K8SClient:
         raise CoreException(msg) from e
 
     dry_run = False
-    if module:
-        dry_run = module.params.get("dry_run", False)
+    if module and module.server_side_dry_run:
+        dry_run = True
 
     k8s_client = K8SClient(
         configuration=configuration,

--- a/plugins/module_utils/k8s/core.py
+++ b/plugins/module_utils/k8s/core.py
@@ -48,6 +48,10 @@ class AnsibleK8SModule:
         return self._module.check_mode
 
     @property
+    def server_side_dry_run(self):
+        return self.check_mode and self.has_at_least("kubernetes", "18.20.0")
+
+    @property
     def _diff(self):
         return self._module._diff
 

--- a/tests/integration/targets/k8s_check_mode/aliases
+++ b/tests/integration/targets/k8s_check_mode/aliases
@@ -1,0 +1,3 @@
+time=30
+k8s
+k8s_info

--- a/tests/integration/targets/k8s_check_mode/defaults/main.yml
+++ b/tests/integration/targets/k8s_check_mode/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+test_namespace: "check-mode-ns"
+
+test_config:
+  - k8s_release: "kubernetes < 18.20.0"
+    dry_run: false
+    virtualenv: 'env1'
+  - k8s_release: "kubernetes >= 18.20.0"
+    dry_run: true
+    virtualenv: 'env2'

--- a/tests/integration/targets/k8s_check_mode/meta/main.yml
+++ b/tests/integration/targets/k8s_check_mode/meta/main.yml
@@ -1,0 +1,3 @@
+---
+# dependencies:
+#   - remove_namespace

--- a/tests/integration/targets/k8s_check_mode/meta/main.yml
+++ b/tests/integration/targets/k8s_check_mode/meta/main.yml
@@ -1,3 +1,3 @@
 ---
-# dependencies:
-#   - remove_namespace
+dependencies:
+  - remove_namespace

--- a/tests/integration/targets/k8s_check_mode/tasks/check_mode.yml
+++ b/tests/integration/targets/k8s_check_mode/tasks/check_mode.yml
@@ -1,0 +1,32 @@
+- name: Create virtualenv with kubernetes release
+  pip:
+    name:
+      - '{{ item.k8s_release }}'
+    virtualenv_command: "virtualenv --python {{ ansible_python_interpreter }}"
+    virtualenv: "{{ tmpdir }}/{{ item.virtualenv }}"
+
+- name: Create resource using check mode
+  k8s:
+    kind: Namespace
+    name: '{{ test_namespace }}'
+  check_mode: true
+  register: _create
+
+- name: Ensure namespace was not created
+  k8s_info:
+    kind: Namespace
+    name: '{{ test_namespace }}'
+  register: info
+  failed_when: info.resources | length > 0
+
+- name: Ensure server side dry_run has being used
+  assert:
+    that:
+      - '"creationTimestamp" in _create.result.metadata'
+  when: item.dry_run
+
+- name: Ensure server side dry_run was not used
+  assert:
+    that:
+      - '"creationTimestamp" in _create.result.metadata'
+  when: not item.dry_run

--- a/tests/integration/targets/k8s_check_mode/tasks/main.yml
+++ b/tests/integration/targets/k8s_check_mode/tasks/main.yml
@@ -1,0 +1,19 @@
+- name: create temporary directory for tests
+  tempfile:
+    suffix: .k8s
+    state: directory
+  register: _path
+
+- block:
+    - include_tasks: tasks/check_mode.yml
+      with_items: '{{ test_config }}'
+
+  vars:
+    tmpdir: '{{ _path.path }}'
+
+  always:
+    - name: Delete temporaray directory
+      file:
+        state: absent
+        path: '{{ tmpdir }}'
+      ignore_errors: true


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix multiple issues with dry_run logic
 - The parameter value passed to the client set to `dry_run=All` instead of `dry_run=True`.
 - Add conditional check for Kubernetes release for the dry_run to be set
 - Add integration test that checks to ensure server side dry run is being used during check mode.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
