### PR TITLE
Pass right amount of args to ResourceTimeout

### DIFF
--- a/changelogs/fragments/583-k8s_scale-clean-handling-of-ResourceTimeout-exception.yaml
+++ b/changelogs/fragments/583-k8s_scale-clean-handling-of-ResourceTimeout-exception.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - k8s_scale - clean handling of ResourceTimeout exception (https://github.com/ansible-collections/kubernetes.core/issues/583).

--- a/plugins/modules/k8s_scale.py
+++ b/plugins/modules/k8s_scale.py
@@ -390,7 +390,7 @@ def scale(
                 namespace=namespace,
             )
             if not success:
-                raise ResourceTimeout("Resource scaling timed out", **result)
+                raise ResourceTimeout("Resource scaling timed out", result)
 
     match, diffs = diff_objects(existing.to_dict(), result["result"])
     result["changed"] = not match


### PR DESCRIPTION
##### SUMMARY
Pass right amount of args to ResourceTimeout
Fixes #583 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
k8s_scale

##### ADDITIONAL INFORMATION
ResourceTimeout constuructor does not accept variable argument length.
The passed result dict seems not to be used currently. One could also pass `result["result"]` or not pass `result` at all.

