### PR TITLE
use post_renderer when checking 'changed' status for a helm release

### DIFF
--- a/changelogs/fragments/588-helm-use-post-renderer-for-helmdiff.yml
+++ b/changelogs/fragments/588-helm-use-post-renderer-for-helmdiff.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - helm - use post_renderer when checking 'changed' status for a helm release (https://github.com/ansible-collections/kubernetes.core/pull/588).

--- a/plugins/modules/helm.py
+++ b/plugins/modules/helm.py
@@ -631,6 +631,7 @@ def helmdiff_check(
     chart_version=None,
     replace=False,
     chart_repo_url=None,
+    post_renderer=False,
 ):
     """
     Use helm diff to determine if a release would change by upgrading a chart.
@@ -645,6 +646,8 @@ def helmdiff_check(
         cmd += " " + "--version=" + chart_version
     if not replace:
         cmd += " " + "--reset-values"
+    if post_renderer:
+        cmd += " --post-renderer=" + post_renderer
 
     if release_values != {}:
         fd, path = tempfile.mkstemp(suffix=".yml")
@@ -884,6 +887,7 @@ def main():
                     chart_version,
                     replace,
                     chart_repo_url,
+                    post_renderer,
                 )
                 if would_change and module._diff:
                     opt_result["diff"] = {"prepared": prepared}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

`helmdiff_check` needs to use --post-renderer if configured in order to detect changes correctly

idempotency still seems to work

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request (50%)
- Feature Pull Request (50%)

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
kubernetes.core.helm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```diff
- /snap/bin/helm diff upgrade myrelease some/chart --version=1.2.3 --reset-values -f=/tmp/tmpnn0rr50h.yml
+ /snap/bin/helm diff upgrade myrelease some/chart --version=1.2.3 --reset-values --post-renderer=/tmp/somescript.sh -f=/tmp/tmpnn0rr50h.yml

```
