### PR TITLE
Fix broken idempotence when using Helm '--post-renderer' module arg

### DIFF
--- a/changelogs/fragments/608-fix-broken-idempotence-when-using-post-renderer
+++ b/changelogs/fragments/608-fix-broken-idempotence-when-using-post-renderer
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - helm - Fix broken idempotence when using Helm '--post-renderer' module arg (https://github.com/ansible-collections/kubernetes.core/pull/608)

--- a/plugins/modules/helm.py
+++ b/plugins/modules/helm.py
@@ -637,6 +637,7 @@ def helmdiff_check(
     chart_version=None,
     replace=False,
     chart_repo_url=None,
+    post_renderer=None,
 ):
     """
     Use helm diff to determine if a release would change by upgrading a chart.
@@ -651,6 +652,8 @@ def helmdiff_check(
         cmd += " " + "--version=" + chart_version
     if not replace:
         cmd += " " + "--reset-values"
+    if post_renderer:
+        cmd += " " + "--post-renderer=" + post_renderer
 
     if release_values != {}:
         fd, path = tempfile.mkstemp(suffix=".yml")
@@ -892,6 +895,7 @@ def main():
                     chart_version,
                     replace,
                     chart_repo_url,
+                    post_renderer,
                 )
                 if would_change and module._diff:
                     opt_result["diff"] = {"prepared": prepared}


### PR DESCRIPTION
SUMMARY
The post_renderer module arg is not being used for helmdiff, only for helm_deploy. This change fixes that.

ISSUE TYPE
Bugfix Pull Request

COMPONENT NAME
kubernetes.core.helm

ADDITIONAL INFORMATION
The "bug" here is that, when using the '--post-renderer' module arg, idempotence is broken because the post_renderer arg isn't being used in the diff.
