### PR TITLE
Update kubernetes.core.k8s_drain_module.rst for issue #615

### DIFF
--- a/docs/kubernetes.core.k8s_drain_module.rst
+++ b/docs/kubernetes.core.k8s_drain_module.rst
@@ -554,14 +554,15 @@ Examples
       kubernetes.core.k8s_drain:
         state: drain
         name: foo
-        force: yes
+        delete_options:
+          force: yes
 
     - name: Drain node "foo", but abort if there are pods not managed by a ReplicationController, Job, or DaemonSet, and use a grace period of 15 minutes.
       kubernetes.core.k8s_drain:
         state: drain
         name: foo
         delete_options:
-            terminate_grace_period: 900
+          terminate_grace_period: 900
 
     - name: Mark node "foo" as schedulable.
       kubernetes.core.k8s_drain:


### PR DESCRIPTION
##### SUMMARY
Quick documentation fix to the example section of the k8s_drain_module documentation to make the "force" option work. I also updated the formatting of the "grace_period" example to follow the two space formatting in the rest of the examples.

Fixes #615

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
k8s_drain_module.rst

##### ADDITIONAL INFORMATION
I have tested that the example works based on running ansible as shown:

```
# ansible --version
ansible [core 2.14.4]
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.11/site-packages/ansible
  ansible collection location = /root/.ansible/collections:/usr/share/ansible/collections
  executable location = /usr/local/bin/ansible
  python version = 3.11.3 (main, Apr  5 2023, 00:00:00) [GCC 12.2.1 20221121 (Red Hat 12.2.1-4)] (/usr/bin/python3)
  jinja version = 3.1.2
  libyaml = True
```

