### PR TITLE
Extend hidden_fields to allow more complicated field definitions

### DIFF
--- a/plugins/module_utils/k8s/service.py
+++ b/plugins/module_utils/k8s/service.py
@@ -501,23 +501,21 @@ def diff_objects(
     result["before"] = diff[0]
     result["after"] = diff[1]
 
-    if list(result["after"].keys()) != ["metadata"] or list(
+    if list(result["after"].keys()) == ["metadata"] and list(
         result["before"].keys()
-    ) != ["metadata"]:
-        return False, result
+    ) == ["metadata"]:
+        # If only metadata.generation and metadata.resourceVersion changed, ignore it
+        ignored_keys = set(["generation", "resourceVersion"])
 
-    # If only metadata.generation and metadata.resourceVersion changed, ignore it
-    ignored_keys = set(["generation", "resourceVersion"])
-
-    if not set(result["after"]["metadata"].keys()).issubset(ignored_keys):
-        return False, result
-    if not set(result["before"]["metadata"].keys()).issubset(ignored_keys):
-        return False, result
+        if set(result["after"]["metadata"].keys()).issubset(ignored_keys) and set(
+            result["before"]["metadata"].keys()
+        ).issubset(ignored_keys):
+            return True, result
 
     result["before"] = hide_fields(result["before"], hidden_fields)
     result["after"] = hide_fields(result["after"], hidden_fields)
 
-    return True, result
+    return False, result
 
 
 def hide_fields(definition: dict, hidden_fields: Optional[list]) -> dict:
@@ -657,10 +655,10 @@ def hide_field_split2(hidden_field: str) -> (str, str):
 
     if lbracket == 0:
         # skip past right bracket and any following dot
-        rest = hidden_field[rbracket + 1:]
+        rest = hidden_field[rbracket + 1 :]
         if rest and rest[0] == ".":
             rest = rest[1:]
-        return (hidden_field[lbracket + 1:rbracket], rest)
+        return (hidden_field[lbracket + 1 : rbracket], rest)
 
     if lbracket != -1 and (dot == -1 or lbracket < dot):
         return (hidden_field[:lbracket], hidden_field[lbracket:])

--- a/plugins/modules/k8s.py
+++ b/plugins/modules/k8s.py
@@ -188,7 +188,8 @@ options:
     description:
       - Hide fields matching this option in the result
       - An example might be C(hidden_fields=[metadata.managedFields])
-      - Only field definitions that don't reference list items are supported (so V(spec.containers[0]) would not work)
+        or C(hidden_fields=[spec.containers[0].env[3].value])
+        or C(hidden_fields=[metadata.annotations[kubectl.kubernetes.io/last-applied-configuration]])
     type: list
     elements: str
     version_added: 3.0.0

--- a/plugins/modules/k8s_info.py
+++ b/plugins/modules/k8s_info.py
@@ -48,7 +48,8 @@ options:
     description:
       - Hide fields matching any of the field definitions in the result
       - An example might be C(hidden_fields=[metadata.managedFields])
-      - Only field definitions that don't reference list items are supported (so V(spec.containers[0]) would not work)
+        or C(hidden_fields=[spec.containers[0].env[3].value])
+        or C(hidden_fields=[metadata.annotations[kubectl.kubernetes.io/last-applied-configuration]])
     type: list
     elements: str
     version_added: 3.0.0

--- a/tests/integration/targets/k8s_hide_fields/tasks/main.yml
+++ b/tests/integration/targets/k8s_hide_fields/tasks/main.yml
@@ -77,6 +77,7 @@
         definition: "{{ hide_fields_base_configmap | combine({'data':{'anew':'value'}}) }}"
         hidden_fields:
           - data
+          - metadata.annotations[kubectl.kubernetes.io/last-applied-configuration]
         apply: true
       register: hf6
       diff: true
@@ -85,6 +86,14 @@
       assert:
         that:
           - hf6.changed
+
+    - name: Ensure hidden fields are not present
+      assert:
+        that:
+          - >-
+            'annotations' not in hf6.resources[0].metadata or
+            q'kubectl.kubernetes.io/last-applied-configuration'
+            not in hf6.resources[0].metadata.annotations
 
     - name: Hidden field should not show up in deletion
       k8s:

--- a/tests/integration/targets/k8s_hide_fields/tasks/main.yml
+++ b/tests/integration/targets/k8s_hide_fields/tasks/main.yml
@@ -91,9 +91,17 @@
       assert:
         that:
           - >-
-            'annotations' not in hf6.resources[0].metadata or
-            q'kubectl.kubernetes.io/last-applied-configuration'
-            not in hf6.resources[0].metadata.annotations
+            'annotations' not in hf6.result.metadata or
+            'kubectl.kubernetes.io/last-applied-configuration'
+            not in hf6.result.metadata.annotations
+          - >-
+            'annotations' not in hf6.diff.before.metadata or
+            'kubectl.kubernetes.io/last-applied-configuration'
+            not in hf6.diff.before.metadata.annotations
+          - >-
+            'annotations' not in hf6.diff.after.metadata or
+            'kubectl.kubernetes.io/last-applied-configuration'
+            not in hf6.diff.after.metadata.annotations
 
     - name: Hidden field should not show up in deletion
       k8s:

--- a/tests/unit/module_utils/test_hide_fields.py
+++ b/tests/unit/module_utils/test_hide_fields.py
@@ -1,0 +1,76 @@
+from ansible_collections.kubernetes.core.plugins.module_utils.k8s.service import (
+    hide_fields,
+)
+
+tests = [
+    dict(
+        output=dict(
+            kind="ConfigMap", metadata=dict(name="foo"), data=dict(one="1", two="2")
+        ),
+        hide_fields=["metadata"],
+        expected=dict(kind="ConfigMap", data=dict(one="1", two="2")),
+    ),
+    dict(
+        output=dict(
+            kind="ConfigMap",
+            metadata=dict(
+                name="foo",
+                annotations={
+                    "kubectl.kubernetes.io/last-applied-configuration": '{"testvalue"}'
+                },
+            ),
+            data=dict(one="1", two="2"),
+        ),
+        hide_fields=[
+            "metadata.annotations[kubectl.kubernetes.io/last-applied-configuration]",
+            "data.one",
+        ],
+        expected=dict(kind="ConfigMap", metadata=dict(name="foo"), data=dict(two="2")),
+    ),
+    dict(
+        output=dict(
+            kind="Pod",
+            metadata=dict(name="foo"),
+            spec=dict(
+                containers=[
+                    dict(
+                        name="containers",
+                        image="busybox",
+                        env=[
+                            dict(name="ENV1", value="env1"),
+                            dict(name="ENV2", value="env2"),
+                            dict(name="ENV3", value="env3"),
+                        ],
+                    )
+                ]
+            ),
+        ),
+        hide_fields=["spec.containers[0].env[1].value"],
+        expected=dict(
+            kind="Pod",
+            metadata=dict(name="foo"),
+            spec=dict(
+                containers=[
+                    dict(
+                        name="containers",
+                        image="busybox",
+                        env=[
+                            dict(name="ENV1", value="env1"),
+                            dict(name="ENV2"),
+                            dict(name="ENV3", value="env3"),
+                        ],
+                    )
+                ]
+            ),
+        ),
+    ),
+]
+
+
+def test_hide_fields():
+    for test in tests:
+        if hide_fields(test["output"], test["hide_fields"]) != test["expected"]:
+            print(test["output"])
+            print(hide_fields(test["output"], test["hide_fields"]))
+            print(test["expected"])
+        assert hide_fields(test["output"], test["hide_fields"]) == test["expected"]

--- a/tests/unit/module_utils/test_hide_fields.py
+++ b/tests/unit/module_utils/test_hide_fields.py
@@ -2,75 +2,168 @@ from ansible_collections.kubernetes.core.plugins.module_utils.k8s.service import
     hide_fields,
 )
 
-tests = [
-    dict(
-        output=dict(
-            kind="ConfigMap", metadata=dict(name="foo"), data=dict(one="1", two="2")
-        ),
-        hide_fields=["metadata"],
-        expected=dict(kind="ConfigMap", data=dict(one="1", two="2")),
-    ),
-    dict(
-        output=dict(
-            kind="ConfigMap",
-            metadata=dict(
-                name="foo",
-                annotations={
-                    "kubectl.kubernetes.io/last-applied-configuration": '{"testvalue"}'
-                },
-            ),
-            data=dict(one="1", two="2"),
-        ),
-        hide_fields=[
-            "metadata.annotations[kubectl.kubernetes.io/last-applied-configuration]",
-            "data.one",
-        ],
-        expected=dict(kind="ConfigMap", metadata=dict(name="foo"), data=dict(two="2")),
-    ),
-    dict(
-        output=dict(
-            kind="Pod",
-            metadata=dict(name="foo"),
-            spec=dict(
-                containers=[
-                    dict(
-                        name="containers",
-                        image="busybox",
-                        env=[
-                            dict(name="ENV1", value="env1"),
-                            dict(name="ENV2", value="env2"),
-                            dict(name="ENV3", value="env3"),
-                        ],
-                    )
-                ]
-            ),
-        ),
-        hide_fields=["spec.containers[0].env[1].value"],
-        expected=dict(
-            kind="Pod",
-            metadata=dict(name="foo"),
-            spec=dict(
-                containers=[
-                    dict(
-                        name="containers",
-                        image="busybox",
-                        env=[
-                            dict(name="ENV1", value="env1"),
-                            dict(name="ENV2"),
-                            dict(name="ENV3", value="env3"),
-                        ],
-                    )
-                ]
-            ),
-        ),
-    ),
-]
+
+def test_hiding_missing_field_does_nothing():
+    output = dict(
+        kind="ConfigMap", metadata=dict(name="foo"), data=dict(one="1", two="2")
+    )
+    hidden_fields = ["doesnotexist"]
+    assert hide_fields(output, hidden_fields) == output
 
 
-def test_hide_fields():
-    for test in tests:
-        if hide_fields(test["output"], test["hide_fields"]) != test["expected"]:
-            print(test["output"])
-            print(hide_fields(test["output"], test["hide_fields"]))
-            print(test["expected"])
-        assert hide_fields(test["output"], test["hide_fields"]) == test["expected"]
+def test_hiding_simple_field():
+    output = dict(
+        kind="ConfigMap", metadata=dict(name="foo"), data=dict(one="1", two="2")
+    )
+    hidden_fields = ["metadata"]
+    expected = dict(kind="ConfigMap", data=dict(one="1", two="2"))
+    assert hide_fields(output, hidden_fields) == expected
+
+
+def test_hiding_only_key_in_dict_removes_dict():
+    output = dict(kind="ConfigMap", metadata=dict(name="foo"), data=dict(one="1"))
+    hidden_fields = ["data.one"]
+    expected = dict(kind="ConfigMap", metadata=dict(name="foo"))
+    assert hide_fields(output, hidden_fields) == expected
+
+
+def test_hiding_all_keys_in_dict_removes_dict():
+    output = dict(
+        kind="ConfigMap", metadata=dict(name="foo"), data=dict(one="1", two="2")
+    )
+    hidden_fields = ["data.one", "data.two"]
+    expected = dict(kind="ConfigMap", metadata=dict(name="foo"))
+    assert hide_fields(output, hidden_fields) == expected
+
+
+def test_hiding_multiple_fields():
+    output = dict(
+        kind="ConfigMap", metadata=dict(name="foo"), data=dict(one="1", two="2")
+    )
+    hidden_fields = ["metadata", "data.one"]
+    expected = dict(kind="ConfigMap", data=dict(two="2"))
+    assert hide_fields(output, hidden_fields) == expected
+
+
+def test_hiding_dict_key():
+    output = dict(
+        kind="ConfigMap",
+        metadata=dict(
+            name="foo",
+            annotations={
+                "kubectl.kubernetes.io/last-applied-configuration": '{"testvalue"}'
+            },
+        ),
+        data=dict(one="1", two="2"),
+    )
+    hidden_fields = [
+        "metadata.annotations[kubectl.kubernetes.io/last-applied-configuration]",
+    ]
+    expected = dict(
+        kind="ConfigMap", metadata=dict(name="foo"), data=dict(one="1", two="2")
+    )
+    assert hide_fields(output, hidden_fields) == expected
+
+
+def test_hiding_list_value_key():
+    output = dict(
+        kind="Pod",
+        metadata=dict(name="foo"),
+        spec=dict(
+            containers=[
+                dict(
+                    name="containers",
+                    image="busybox",
+                    env=[
+                        dict(name="ENV1", value="env1"),
+                        dict(name="ENV2", value="env2"),
+                        dict(name="ENV3", value="env3"),
+                    ],
+                )
+            ]
+        ),
+    )
+    hidden_fields = ["spec.containers[0].env[1].value"]
+    expected = dict(
+        kind="Pod",
+        metadata=dict(name="foo"),
+        spec=dict(
+            containers=[
+                dict(
+                    name="containers",
+                    image="busybox",
+                    env=[
+                        dict(name="ENV1", value="env1"),
+                        dict(name="ENV2"),
+                        dict(name="ENV3", value="env3"),
+                    ],
+                )
+            ]
+        ),
+    )
+    assert hide_fields(output, hidden_fields) == expected
+
+
+def test_hiding_last_list_item():
+    output = dict(
+        kind="Pod",
+        metadata=dict(name="foo"),
+        spec=dict(
+            containers=[
+                dict(
+                    name="containers",
+                    image="busybox",
+                    env=[
+                        dict(name="ENV1", value="env1"),
+                    ],
+                )
+            ]
+        ),
+    )
+    hidden_fields = ["spec.containers[0].env[0]"]
+    expected = dict(
+        kind="Pod",
+        metadata=dict(name="foo"),
+        spec=dict(
+            containers=[
+                dict(
+                    name="containers",
+                    image="busybox",
+                )
+            ]
+        ),
+    )
+    assert hide_fields(output, hidden_fields) == expected
+
+
+def test_hiding_nested_dicts_using_brackets():
+    output = dict(
+        kind="Pod",
+        metadata=dict(name="foo"),
+        spec=dict(
+            containers=[
+                dict(
+                    name="containers",
+                    image="busybox",
+                    securityContext=dict(runAsUser=101),
+                )
+            ]
+        ),
+    )
+    hidden_fields = ["spec.containers[0][securityContext][runAsUser]"]
+    expected = dict(
+        kind="Pod",
+        metadata=dict(name="foo"),
+        spec=dict(
+            containers=[
+                dict(
+                    name="containers",
+                    image="busybox",
+                )
+            ]
+        ),
+    )
+    if hide_fields(output, hidden_fields) != expected:
+        print(output)
+        print(expected)
+    assert hide_fields(output, hidden_fields) == expected


### PR DESCRIPTION
##### SUMMARY
This allows us to ignore e.g. the last-applied-configuration annotation by specifying
`metadata.annotations[kubectl.kubernetes.io/last-applied-configuration]`

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
hidden_fields
