### PR TITLE
fix: OpenShift Project/ProjectRequest

### DIFF
--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -1474,28 +1474,6 @@ class K8sAnsibleMixin(object):
             )
             return None, error
 
-    def create_project_request(self, definition):
-        definition["kind"] = "ProjectRequest"
-        result = {"changed": False, "result": {}}
-        resource = self.find_resource(
-            "ProjectRequest", definition["apiVersion"], fail=True
-        )
-        if not self.check_mode:
-            try:
-                k8s_obj = resource.create(definition)
-                result["result"] = k8s_obj.to_dict()
-            except DynamicApiError as exc:
-                self.fail_json(
-                    msg="Failed to create object: {0}".format(exc.body),
-                    error=exc.status,
-                    status=exc.status,
-                    reason=exc.reason,
-                )
-        result["changed"] = True
-        result["method"] = "create"
-        return result
-
-
 def _encode_stringdata(definition):
     if definition["kind"] == "Secret" and "stringData" in definition:
         for k, v in definition["stringData"].items():

--- a/plugins/module_utils/k8s/runner.py
+++ b/plugins/module_utils/k8s/runner.py
@@ -146,7 +146,7 @@ def perform_action(svc, definition: Dict, params: Dict) -> Dict:
     resource = svc.find_resource(kind, api_version, fail=True)
     definition["kind"] = resource.kind
     definition["apiVersion"] = resource.group_version
-    existing = svc.retrieve(resource, definition)
+    existing, resource, definition = svc.retrieve_with_rewrite(resource, definition)
 
     if state == "absent":
         if exists(existing) and existing.kind.endswith("List"):

--- a/plugins/module_utils/k8s/service.py
+++ b/plugins/module_utils/k8s/service.py
@@ -165,6 +165,42 @@ class K8sService:
             msg = "Failed to patch object: {0}".format(reason)
             raise CoreException(msg) from e
 
+    def retrieve_with_rewrite(self, resource: Dict, definition: Dict) -> Tuple[ResourceInstance, Dict, Dict]:
+        if resource.group_version == "project.openshift.io/v1":
+            if resource.kind == "Project":
+                existing = self.retrieve(resource, definition)
+                if exists(existing):
+                    return existing, resource, definition
+                # Project does not exist, ProjectRequest is the relevant object
+                project_request_resource = self.find_resource("ProjectRequest", resource.group_version, fail=True)
+                # Placement of **definitions ensures existing fields (except for "kind") are not overwritten
+                project_request_definition = {
+                    "description": definition["metadata"].get("annotations", {}).get("openshift.io/description"),
+                    "displayName": definition["metadata"].get("annotations", {}).get("openshift.io/display-name"),
+                    **definition,
+                    "kind": "ProjectRequest",
+                }
+                return existing, project_request_resource, project_request_definition
+            if resource.kind == "ProjectRequest":
+                project_resource = self.find_resource("Project", resource.group_version, fail=True)
+                project_definition = {**definition,
+                    "kind": project_resource.kind,
+                    "metadata": {**definition["metadata"],
+                        "annotations": {
+                            "openshift.io/description": definition.get("description"),
+                            "openshift.io/display-name": definition.get("displayName"),
+                            **definition["metadata"].get("annotations", {}),
+                        }
+                    }
+                }
+                existing = self.retrieve(project_resource, project_definition)
+                if exists(existing):
+                    return existing, project_resource, project_definition
+                # Project exists, ProjectRequest is not relevant anymore
+                return existing, resource, definition
+
+        return self.retrieve(resource, definition), resource, definition
+
     def retrieve(self, resource: Resource, definition: Dict) -> ResourceInstance:
         state = self.module.params.get("state", None)
         append_hash = self.module.params.get("append_hash", False)
@@ -197,14 +233,13 @@ class K8sService:
         except (NotFoundError, MethodNotAllowedError):
             pass
         except ForbiddenError as e:
-            if (
-                definition["kind"] in ["Project", "ProjectRequest"]
-                and state != "absent"
+            if not (
+                definition["apiVersion"] == "project.openshift.io/v1"
+                and definition["kind"] in ("Project", "ProjectRequest")
             ):
-                return self.create_project_request(definition)
-            reason = e.body if hasattr(e, "body") else e
-            msg = "Failed to retrieve requested object: {0}".format(reason)
-            raise CoreException(msg) from e
+                reason = e.body if hasattr(e, "body") else e
+                msg = "Failed to retrieve requested object: {0}".format(reason)
+                raise CoreException(msg) from e
         except Exception as e:
             reason = e.body if hasattr(e, "body") else e
             msg = "Failed to retrieve requested object: {0}".format(reason)


### PR DESCRIPTION
##### SUMMARY

Fixes https://github.com/ansible-collections/kubernetes.core/issues/623

Introduces Project/ProjectRequest translation logic that enables working with both

```yaml
k8s:
  api_version: project.openshift.io/v1
  kind: Project
  resource_definition:
    annotations:
      openshift.io/display-name: Foo
      openshift.io/description: Bar
```
and
```yaml
k8s:
  api_version: project.openshift.io/v1
  kind: ProjectRequest
  resource_definition:
    displayName: Foo
    description: Bar
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
k8s

##### ADDITIONAL INFORMATION

Should all this custom OpenShift logic really be in a kubernetes core?  
