### PR TITLE
fix(Collection's util resource discovery fails when complex subresources present #659)

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -132,6 +132,8 @@ jobs:
 
       - name: create kubernetes cluster
         uses: helm/kind-action@v1.8.0
+        with:
+          node_image: "kindest/node:v1.29.2"
 
       - name: Run integration tests
         uses: ansible-network/github_actions/.github/actions/ansible_test_integration@main

--- a/changelogs/fragments/20240222-Collections-util-resource-discovery-fails-when-complex-subresources-present.yml
+++ b/changelogs/fragments/20240222-Collections-util-resource-discovery-fails-when-complex-subresources-present.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Resolve Collections util resource discovery fails when complex subresources present (https://github.com/ansible-collections/kubernetes.core/pull/676).

--- a/plugins/module_utils/client/discovery.py
+++ b/plugins/module_utils/client/discovery.py
@@ -113,7 +113,7 @@ class Discoverer(kubernetes.dynamic.discovery.Discoverer):
             filter(lambda resource: "/" in resource["name"], resources_response)
         )
         for subresource in subresources_raw:
-            resource, name = subresource["name"].split("/")
+            resource, name = subresource["name"].split("/", 1)
             subresources[resource][name] = subresource
 
         for resource in resources_raw:

--- a/tests/integration/targets/k8s_info/tasks/discovery.yml
+++ b/tests/integration/targets/k8s_info/tasks/discovery.yml
@@ -1,0 +1,32 @@
+---
+# Testing fix for issue https://github.com/ansible-collections/kubernetes.core/pull/676
+- vars:
+    kubevirt_release: "v1.1.1"
+  block:
+    - name: Delete existing namespace
+      kubernetes.core.k8s:
+        kind: namespace
+        namespace: kubevirt
+        state: absent
+
+    - name: Create kubevirt resources
+      kubernetes.core.k8s:
+        state: present
+        apply: true
+        src: "{{ item }}"
+      with_items:
+        - "https://github.com/kubevirt/kubevirt/releases/download/{{ kubevirt_release }}/kubevirt-operator.yaml"
+        - "https://github.com/kubevirt/kubevirt/releases/download/{{ kubevirt_release }}/kubevirt-cr.yaml"
+
+    - name: Read kubevirt Deployment
+      k8s_info:
+        kind: Deployment
+        namespace: kubevirt
+  always:
+    - name: Delete existing namespace
+      kubernetes.core.k8s:
+        kind: namespace
+        namespace: kubevirt
+        state: absent
+        wait: true
+      ignore_errors: true

--- a/tests/integration/targets/k8s_info/tasks/main.yml
+++ b/tests/integration/targets/k8s_info/tasks/main.yml
@@ -3,3 +3,4 @@
   with_items:
     - wait
     - api-server-caching
+    - discovery


### PR DESCRIPTION
##### SUMMARY
Hi,
We have the same problem and on our side we have fixed the code, specifying to the split to do it only on the first /.
```
resource, name = subresource["name"].split("/", 1)
```
It seems more logical to add this control, since the current code doesn't support more than two elements

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request #659 

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
discovery.py

