### PR TITLE
fix: Allow Discoverer to handle APIs of the format a/b/c

### DIFF
--- a/plugins/module_utils/client/discovery.py
+++ b/plugins/module_utils/client/discovery.py
@@ -113,7 +113,7 @@ class Discoverer(kubernetes.dynamic.discovery.Discoverer):
             filter(lambda resource: "/" in resource["name"], resources_response)
         )
         for subresource in subresources_raw:
-            resource, name = subresource["name"].split("/")
+            resource, name = subresource["name"].split("/", 1)
             subresources[resource][name] = subresource
 
         for resource in resources_raw:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Allow the Discoverer to handle APIs of the format a/b/c by updating the call to split.

See
https://github.com/ansible-collections/kubernetes.core/issues/685
https://github.com/kubernetes-client/python/issues/2091
https://github.com/kubernetes-client/python/pull/2095

Fixes #685 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

`module_utils.client.discovery.Discoverer`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Allows discovery of KubeVirt APIs of format a/b/c, see issue description.
