### PR TITLE
Update deprecation version for merge_type=json

### DIFF
--- a/plugins/modules/k8s.py
+++ b/plugins/modules/k8s.py
@@ -63,7 +63,7 @@ options:
       C(['strategic-merge', 'merge']), which is ideal for using the same parameters on resource kinds that
       combine Custom Resources and built-in resources.
     - mutually exclusive with C(apply)
-    - I(merge_type=json) is deprecated and will be removed in version 3.0.0. Please use M(kubernetes.core.k8s_json_patch) instead.
+    - I(merge_type=json) is deprecated and will be removed in version 4.0.0. Please use M(kubernetes.core.k8s_json_patch) instead.
     choices:
     - json
     - merge


### PR DESCRIPTION
##### SUMMARY
When looking at the parts of `plugins/module_utils/common.py` and `plugins/module_utils/k8s/service.py` during the post `3.0.0` release (see https://github.com/ansible-collections/kubernetes.core/pull/663/files#diff-9ee2d0860a5643da4e1f35136e9e7c3a41c5f2fd2952c197e7e32b941e5a301c) that affect `merge_type` when set to `json`, I don't believe `merge_type=json` was deprecated for (and removed from) the `k8s` module, and instead the deprecation version has moved to `4.0.0`. Hence, the documentation update.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`k8s` module
