### PR TITLE
k8s: Display warnings to users

### DIFF
--- a/changelogs/fragments/20240423-k8s-display-warnings-to-users.yml
+++ b/changelogs/fragments/20240423-k8s-display-warnings-to-users.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - k8s - The module and K8sService were changed so warnings returned by the K8S API are now displayed to the user.

--- a/plugins/module_utils/apply.py
+++ b/plugins/module_utils/apply.py
@@ -149,6 +149,7 @@ def k8s_apply(resource, definition, **kwargs):
             force_conflicts=kwargs.get("force_conflicts"),
             field_manager=kwargs.get("field_manager"),
             dry_run=kwargs.get("dry_run"),
+            serialize=kwargs.get("serialize"),
         )
     if not existing:
         return resource.create(
@@ -158,6 +159,7 @@ def k8s_apply(resource, definition, **kwargs):
         return resource.get(
             name=definition["metadata"]["name"],
             namespace=definition["metadata"].get("namespace"),
+            **kwargs
         )
     return resource.patch(
         body=desired,

--- a/plugins/module_utils/k8s/runner.py
+++ b/plugins/module_utils/k8s/runner.py
@@ -191,7 +191,7 @@ def perform_action(svc, definition: Dict, params: Dict) -> Dict:
             instance, warnings = svc.replace(resource, definition, existing)
             result["method"] = "replace"
         else:
-            instance = svc.update(resource, definition, existing)
+            instance, warnings = svc.update(resource, definition, existing)
             result["method"] = "update"
 
     if warnings:

--- a/plugins/module_utils/k8s/runner.py
+++ b/plugins/module_utils/k8s/runner.py
@@ -173,7 +173,7 @@ def perform_action(svc, definition: Dict, params: Dict) -> Dict:
                 return result
 
         if params.get("apply"):
-            instance = svc.apply(resource, definition, existing)
+            instance, warnings = svc.apply(resource, definition, existing)
             result["method"] = "apply"
         elif not existing:
             if state == "patched":

--- a/plugins/module_utils/k8s/runner.py
+++ b/plugins/module_utils/k8s/runner.py
@@ -188,7 +188,7 @@ def perform_action(svc, definition: Dict, params: Dict) -> Dict:
             result["method"] = "create"
             result["changed"] = True
         elif params.get("force", False):
-            instance = svc.replace(resource, definition, existing)
+            instance, warnings = svc.replace(resource, definition, existing)
             result["method"] = "replace"
         else:
             instance = svc.update(resource, definition, existing)

--- a/plugins/module_utils/k8s/runner.py
+++ b/plugins/module_utils/k8s/runner.py
@@ -139,6 +139,7 @@ def perform_action(svc, definition: Dict, params: Dict) -> Dict:
 
     result = {"changed": False, "result": {}}
     instance = {}
+    warnings = []
 
     resource = svc.find_resource(kind, api_version, fail=True)
     definition["kind"] = resource.kind
@@ -183,7 +184,7 @@ def perform_action(svc, definition: Dict, params: Dict) -> Dict:
                     )
                 )
                 return result
-            instance = svc.create(resource, definition)
+            instance, warnings = svc.create(resource, definition)
             result["method"] = "create"
             result["changed"] = True
         elif params.get("force", False):
@@ -192,6 +193,9 @@ def perform_action(svc, definition: Dict, params: Dict) -> Dict:
         else:
             instance = svc.update(resource, definition, existing)
             result["method"] = "update"
+
+    if warnings:
+        result["warnings"] = warnings
 
     # If needed, wait and/or create diff
     success = True


### PR DESCRIPTION
##### SUMMARY

This changes K8sService and the k8s module so warnings returned by the K8S API are displayed to the user.

Fixes https://github.com/kubevirt/kubevirt.core/issues/30
Fixes https://github.com/kubevirt/kubevirt.core/issues/31

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

- k8s module
- K8sService

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
TASK [Create VM] **********************************************************************************************************************************************
ok: [localhost]
```

After:
```
TASK [Create VM] **********************************************************************************************************************************************
[WARNING]: unknown field "spec.template.spec.disk"
[WARNING]: unknown field "spec.template.spec.domain.bogus"
ok: [localhost]
```
