### PR TITLE
minor(doc): use the same style of version_added across repo

### DIFF
--- a/plugins/doc_fragments/helm_common_options.py
+++ b/plugins/doc_fragments/helm_common_options.py
@@ -36,12 +36,12 @@ options:
     description:
     - Provide a URL for accessing the API. Can also be specified via C(K8S_AUTH_HOST) environment variable.
     type: str
-    version_added: "1.2.0"
+    version_added: 1.2.0
   api_key:
     description:
     - Token used to authenticate with the API. Can also be specified via C(K8S_AUTH_API_KEY) environment variable.
     type: str
-    version_added: "1.2.0"
+    version_added: 1.2.0
   validate_certs:
     description:
     - Whether or not to verify the API server's SSL certificates. Can also be specified via C(K8S_AUTH_VERIFY_SSL)
@@ -49,12 +49,12 @@ options:
     type: bool
     aliases: [ verify_ssl ]
     default: True
-    version_added: "1.2.0"
+    version_added: 1.2.0
   ca_cert:
     description:
     - Path to a CA certificate used to authenticate with the API. The full certificate chain must be provided to
       avoid certificate validation errors. Can also be specified via C(K8S_AUTH_SSL_CA_CERT) environment variable.
     type: path
     aliases: [ ssl_ca_cert ]
-    version_added: "1.2.0"
+    version_added: 1.2.0
 """

--- a/plugins/doc_fragments/k8s_delete_options.py
+++ b/plugins/doc_fragments/k8s_delete_options.py
@@ -15,7 +15,7 @@ class ModuleDocFragment(object):
 options:
   delete_options:
     type: dict
-    version_added: '1.2.0'
+    version_added: 1.2.0
     description:
     - Configure behavior when deleting an object.
     - Only used when I(state=absent).

--- a/plugins/lookup/kustomize.py
+++ b/plugins/lookup/kustomize.py
@@ -8,7 +8,7 @@ DOCUMENTATION = """
 
     short_description: Build a set of kubernetes resources using a 'kustomization.yaml' file.
 
-    version_added: "2.2.0"
+    version_added: 2.2.0
 
     author:
       - Aubin Bikouo (@abikouo)

--- a/plugins/modules/helm.py
+++ b/plugins/modules/helm.py
@@ -14,7 +14,7 @@ module: helm
 
 short_description: Manages Kubernetes packages with the Helm package manager
 
-version_added: "0.11.0"
+version_added: 0.11.0
 
 author:
   - Lucas Boisserie (@LucasBoisserie)
@@ -61,7 +61,7 @@ options:
     default: false
     type: bool
     aliases: [ dep_up ]
-    version_added: "2.4.0"
+    version_added: 2.4.0
   release_name:
     description:
       - Release name to manage.
@@ -99,7 +99,7 @@ options:
     default: []
     type: list
     elements: str
-    version_added: '1.1.0'
+    version_added: 1.1.0
   update_repo_cache:
     description:
       - Run C(helm repo update) before the operation. Can be run as part of the package installation or as a separate step (see Examples).
@@ -129,7 +129,7 @@ options:
           - string
           - json
           - file
-    version_added: '2.4.0'
+    version_added: 2.4.0
   reuse_values:
     description:
       - When upgrading package, specifies wether to reuse the last release's values and merge in any overrides from parameters I(release_values),
@@ -137,14 +137,14 @@ options:
       - If I(reset_values) is set to C(True), this is ignored.
     type: bool
     required: false
-    version_added: '2.5.0'
+    version_added: 2.5.0
   reset_values:
     description:
       - When upgrading package, reset the values to the ones built into the chart.
     type: bool
     required: false
     default: True
-    version_added: '2.5.0'
+    version_added: 2.5.0
 
 #Helm options
   disable_hook:
@@ -181,7 +181,7 @@ options:
       - similar to C(wait_timeout) but does not required C(wait) to be activated.
       - Mutually exclusive with C(wait_timeout).
     type: str
-    version_added: "2.3.0"
+    version_added: 2.3.0
   atomic:
     description:
       - If set, the installation process deletes the installation on failure.
@@ -192,12 +192,12 @@ options:
       - Create the release namespace if not present.
     type: bool
     default: False
-    version_added: "0.11.1"
+    version_added: 0.11.1
   post_renderer:
     description:
       - Path to an executable to be used for post rendering.
     type: str
-    version_added: "2.4.0"
+    version_added: 2.4.0
   replace:
     description:
       - Reuse the given name, only if that name is a deleted release which remains in the history.
@@ -205,19 +205,19 @@ options:
       - mutually exclusive with with C(history_max).
     type: bool
     default: False
-    version_added: "1.11.0"
+    version_added: 1.11.0
   skip_crds:
     description:
       - Skip custom resource definitions when installing or upgrading.
     type: bool
     default: False
-    version_added: "1.2.0"
+    version_added: 1.2.0
   history_max:
     description:
       - Limit the maximum number of revisions saved per release.
       - mutually exclusive with with C(replace).
     type: int
-    version_added: "2.2.0"
+    version_added: 2.2.0
 extends_documentation_fragment:
   - kubernetes.core.helm_common_options
 """

--- a/plugins/modules/helm_info.py
+++ b/plugins/modules/helm_info.py
@@ -14,7 +14,7 @@ module: helm_info
 
 short_description: Get information from Helm package deployed inside the cluster
 
-version_added: "0.11.0"
+version_added: 0.11.0
 
 author:
   - Lucas Boisserie (@LucasBoisserie)
@@ -53,7 +53,7 @@ options:
     type: list
     elements: str
     default: []
-    version_added: "2.3.0"
+    version_added: 2.3.0
   get_all_values:
     description:
       - Set to C(True) if you want to get all (computed) values of the release.
@@ -61,7 +61,7 @@ options:
     required: false
     default: false
     type: bool
-    version_added: "2.4.0"
+    version_added: 2.4.0
 extends_documentation_fragment:
   - kubernetes.core.helm_common_options
 """
@@ -123,18 +123,18 @@ status:
       elements: dict
       description: Hooks of the release
       returned: always
-      version_added: "2.4.0"
+      version_added: 2.4.0
     notes:
       type: str
       description: Notes of the release
       returned: always
-      version_added: "2.4.0"
+      version_added: 2.4.0
     manifest:
       type: list
       elements: dict
       description: Manifest of the release
       returned: always
-      version_added: "2.4.0"
+      version_added: 2.4.0
 """
 
 import copy

--- a/plugins/modules/helm_plugin.py
+++ b/plugins/modules/helm_plugin.py
@@ -12,7 +12,7 @@ DOCUMENTATION = r"""
 ---
 module: helm_plugin
 short_description: Manage Helm plugins
-version_added: "1.0.0"
+version_added: 1.0.0
 author:
   - Abhijeet Kasurde (@Akasurde)
 requirements:
@@ -47,7 +47,7 @@ options:
       - Ignored when C(state=absent) or C(state=latest).
     required: false
     type: str
-    version_added: "2.3.0"
+    version_added: 2.3.0
 extends_documentation_fragment:
   - kubernetes.core.helm_common_options
 """

--- a/plugins/modules/helm_plugin_info.py
+++ b/plugins/modules/helm_plugin_info.py
@@ -12,7 +12,7 @@ DOCUMENTATION = r"""
 ---
 module: helm_plugin_info
 short_description: Gather information about Helm plugins
-version_added: "1.0.0"
+version_added: 1.0.0
 author:
   - Abhijeet Kasurde (@Akasurde)
 requirements:

--- a/plugins/modules/helm_pull.py
+++ b/plugins/modules/helm_pull.py
@@ -12,7 +12,7 @@ DOCUMENTATION = r"""
 ---
 module: helm_pull
 short_description: download a chart from a repository and (optionally) unpack it in local directory.
-version_added: "2.4.0"
+version_added: 2.4.0
 author:
   - Aubin Bikouo (@abikouo)
 description:

--- a/plugins/modules/helm_repository.py
+++ b/plugins/modules/helm_repository.py
@@ -14,7 +14,7 @@ module: helm_repository
 
 short_description: Manage Helm repositories.
 
-version_added: "0.11.0"
+version_added: 0.11.0
 
 author:
   - Lucas Boisserie (@LucasBoisserie)
@@ -76,12 +76,12 @@ options:
     description:
     - Provide a URL for accessing the API. Can also be specified via C(K8S_AUTH_HOST) environment variable.
     type: str
-    version_added: "2.3.0"
+    version_added: 2.3.0
   api_key:
     description:
     - Token used to authenticate with the API. Can also be specified via C(K8S_AUTH_API_KEY) environment variable.
     type: str
-    version_added: "2.3.0"
+    version_added: 2.3.0
   validate_certs:
     description:
     - Whether or not to verify the API server's SSL certificates. Can also be specified via C(K8S_AUTH_VERIFY_SSL)
@@ -89,21 +89,21 @@ options:
     type: bool
     aliases: [ verify_ssl ]
     default: True
-    version_added: "2.3.0"
+    version_added: 2.3.0
   ca_cert:
     description:
     - Path to a CA certificate used to authenticate with the API. The full certificate chain must be provided to
       avoid certificate validation errors. Can also be specified via C(K8S_AUTH_SSL_CA_CERT) environment variable.
     type: path
     aliases: [ ssl_ca_cert ]
-    version_added: "2.3.0"
+    version_added: 2.3.0
   context:
     description:
       - Helm option to specify which kubeconfig context to use.
       - If the value is not specified in the task, the value of environment variable C(K8S_AUTH_CONTEXT) will be used instead.
     type: str
     aliases: [ kube_context ]
-    version_added: "2.4.0"
+    version_added: 2.4.0
   kubeconfig:
     description:
       - Helm option to specify kubeconfig path to use.
@@ -111,14 +111,14 @@ options:
       - The configuration can be provided as dictionary.
     type: raw
     aliases: [ kubeconfig_path ]
-    version_added: "2.4.0"
+    version_added: 2.4.0
   force_update:
     description:
     - Whether or not to replace (overwrite) the repo if it already exists.
     type: bool
     aliases: [ force ]
     default: False
-    version_added: "2.4.0"
+    version_added: 2.4.0
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/helm_template.py
+++ b/plugins/modules/helm_template.py
@@ -53,7 +53,7 @@ options:
     default: false
     type: bool
     aliases: [ dep_up ]
-    version_added: "2.4.0"
+    version_added: 2.4.0
   disable_hook:
     description:
       - Prevent hooks from running during install.
@@ -139,7 +139,7 @@ options:
           - string
           - json
           - file
-    version_added: '2.4.0'
+    version_added: 2.4.0
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/k8s_cluster_info.py
+++ b/plugins/modules/k8s_cluster_info.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 DOCUMENTATION = r"""
 module: k8s_cluster_info
 
-version_added: "0.11.1"
+version_added: 0.11.1
 
 short_description: Describe Kubernetes (K8s) cluster, APIs available and their respective versions
 

--- a/plugins/modules/k8s_cp.py
+++ b/plugins/modules/k8s_cp.py
@@ -14,7 +14,7 @@ module: k8s_cp
 
 short_description: Copy files and directories to and from pod.
 
-version_added: "2.2.0"
+version_added: 2.2.0
 
 author:
     - Aubin Bikouo (@abikouo)

--- a/plugins/modules/k8s_drain.py
+++ b/plugins/modules/k8s_drain.py
@@ -15,7 +15,7 @@ module: k8s_drain
 
 short_description: Drain, Cordon, or Uncordon node in k8s cluster
 
-version_added: "2.2.0"
+version_added: 2.2.0
 
 author: Aubin Bikouo (@abikouo)
 

--- a/plugins/modules/k8s_exec.py
+++ b/plugins/modules/k8s_exec.py
@@ -15,7 +15,7 @@ module: k8s_exec
 
 short_description: Execute command in Pod
 
-version_added: "0.10.0"
+version_added: 0.10.0
 
 author: "Tristan de Cacqueray (@tristanC)"
 

--- a/plugins/modules/k8s_log.py
+++ b/plugins/modules/k8s_log.py
@@ -14,7 +14,7 @@ module: k8s_log
 
 short_description: Fetch logs from Kubernetes resources
 
-version_added: "0.10.0"
+version_added: 0.10.0
 
 author:
     - "Fabian von Feilitzsch (@fabianvf)"
@@ -61,26 +61,26 @@ options:
     - A relative time in seconds before the current time from which to show logs.
     required: no
     type: str
-    version_added: '2.2.0'
+    version_added: 2.2.0
   previous:
     description:
     - If C(true), print the logs for the previous instance of the container in a pod if it exists.
     required: no
     type: bool
     default: False
-    version_added: '2.4.0'
+    version_added: 2.4.0
   tail_lines:
     description:
     - A number of lines from the end of the logs to retrieve.
     required: no
     type: int
-    version_added: '2.4.0'
+    version_added: 2.4.0
   all_containers:
     description:
     - If set to C(true), retrieve all containers' logs in the pod(s).
     - mutually exclusive with C(container).
     type: bool
-    version_added: '2.4.0'
+    version_added: 2.4.0
 
 requirements:
   - "python >= 3.9"

--- a/plugins/modules/k8s_rollback.py
+++ b/plugins/modules/k8s_rollback.py
@@ -12,7 +12,7 @@ __metaclass__ = type
 DOCUMENTATION = r"""
 module: k8s_rollback
 short_description: Rollback Kubernetes (K8S) Deployments and DaemonSets
-version_added: "1.0.0"
+version_added: 1.0.0
 author:
     - "Julien Huon (@julienhuon)"
 description:

--- a/plugins/modules/k8s_taint.py
+++ b/plugins/modules/k8s_taint.py
@@ -13,7 +13,7 @@ __metaclass__ = type
 DOCUMENTATION = r"""
 module: k8s_taint
 short_description: Taint a node in a Kubernetes/OpenShift cluster
-version_added: "2.3.0"
+version_added: 2.3.0
 author: Alina Buzachis (@alinabuzachis)
 description:
     - Taint allows a node to refuse Pod to be scheduled unless that Pod has a matching toleration.


### PR DESCRIPTION
##### SUMMARY
Currently is no single style of `version_added`, in some places it's unquoted, somewhere single quote is used, in another places it's double quoted. Moreover, some file had different styles in one single file. 

The aim of this PR is to update whole repo to single style for version_added

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
kustomize
helm
helm_info
helm_plugin
helm_plugin_info
helm_pull
helm_repository
helm_template
k8s_cluster_info
k8s_cp
k8s_drain
k8s_exec
k8s_log
k8s_rollback
k8s_taint

##### ADDITIONAL INFORMATION

The same style is proposed as used in `amazon.aws` collections
