### PR TITLE
Update ansible-lint GHA

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -21,4 +21,4 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run ansible-lint
-        uses: ansible/ansible-lint@v6.21.0
+        uses: ansible/ansible-lint@v24.2.3


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There seems to be a bug in older versions of ansible-lint where pinning to a version for the GHA still installs the main branch.

See https://github.com/ansible/ansible-lint/pull/3762 for more info.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
