### PR TITLE
update version to 3.0.1 in galaxy.yml

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -25,7 +25,7 @@ tags:
   - openshift
   - okd
   - cluster
-version: 3.0.0
+version: 3.0.1
 build_ignore:
   - .DS_Store
   - "*.tar.gz"


### PR DESCRIPTION
##### SUMMARY

Bump `kubernetes.core` version in `galaxy.yml` to 3.0.1 to avoid inconsistency between output of `ansible-galaxy` (version 3.0.0 in the output) and `CHANGELOG.rst` (that is 3.0.1) when installated from branch `stable-3` (directly with `type: git` or using tar.gz file) even version 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Ansible Galaxy

##### ADDITIONAL INFORMATION
Additional information and output in issue #709 

Shortly:
```
# /root/.ansible/collections/ansible_collections
Collection      Version
--------------- -------
kubernetes.core 3.0.0
root@ec13eacdd5bd:/# cat  /root/.ansible/collections/ansible_collections/kubernetes/core/CHANGELOG.rst | head -n 10
===================================
Kubernetes Collection Release Notes
===================================

.. contents:: Topics

v3.0.1
======

Release Summary
root@ec13eacdd5bd:/#
```
