### PR TITLE
k8s - remove support for merge_type=json

### DIFF
--- a/changelogs/fragments/k8s-merge_type-removed.yml
+++ b/changelogs/fragments/k8s-merge_type-removed.yml
@@ -1,0 +1,2 @@
+removed_features:
+  - k8s - Support for ``merge_type=json`` has been removed in version 4.0.0. Please use ``kubernetes.core.k8s_json_patch`` instead.

--- a/changelogs/fragments/k8s-merge_type-removed.yml
+++ b/changelogs/fragments/k8s-merge_type-removed.yml
@@ -1,2 +1,2 @@
 removed_features:
-  - k8s - Support for ``merge_type=json`` has been removed in version 4.0.0. Please use ``kubernetes.core.k8s_json_patch`` instead.
+  - k8s - Support for ``merge_type=json`` has been removed in version 4.0.0. Please use ``kubernetes.core.k8s_json_patch`` instead (https://github.com/ansible-collections/kubernetes.core/pull/722).

--- a/plugins/module_utils/k8s/service.py
+++ b/plugins/module_utils/k8s/service.py
@@ -145,12 +145,6 @@ class K8sService:
         namespace: str,
         merge_type: str = None,
     ) -> Tuple[Dict, List[str]]:
-        if merge_type == "json":
-            self.module.deprecate(
-                msg="json as a merge_type value is deprecated. Please use the k8s_json_patch module instead.",
-                version="4.0.0",
-                collection_name="kubernetes.core",
-            )
         try:
             params = dict(name=name, namespace=namespace, serialize=False)
             if merge_type:

--- a/plugins/modules/k8s.py
+++ b/plugins/modules/k8s.py
@@ -57,15 +57,14 @@ options:
     - Whether to override the default patch merge approach with a specific type. By default, the strategic
       merge will typically be used.
     - For example, Custom Resource Definitions typically aren't updatable by the usual strategic merge. You may
-      want to use C(merge) if you see "strategic merge patch format is not supported"
+      want to use C(merge) if you see "strategic merge patch format is not supported".
     - See U(https://kubernetes.io/docs/tasks/run-application/update-api-object-kubectl-patch/#use-a-json-merge-patch-to-update-a-deployment)
     - If more than one C(merge_type) is given, the merge_types will be tried in order. This defaults to
       C(['strategic-merge', 'merge']), which is ideal for using the same parameters on resource kinds that
       combine Custom Resources and built-in resources.
-    - mutually exclusive with C(apply)
-    - I(merge_type=json) is deprecated and will be removed in version 4.0.0. Please use M(kubernetes.core.k8s_json_patch) instead.
+    - Mutually exclusive with C(apply).
+    - I(merge_type=json) has been removed in version 4.0.0. Please use M(kubernetes.core.k8s_json_patch) instead.
     choices:
-    - json
     - merge
     - strategic-merge
     type: list
@@ -101,7 +100,7 @@ options:
     - C(apply) compares the desired resource definition with the previously supplied resource definition,
       ignoring properties that are automatically generated
     - C(apply) works better with Services than 'force=yes'
-    - mutually exclusive with C(merge_type)
+    - Mutually exclusive with C(merge_type).
     default: False
     type: bool
   template:
@@ -460,7 +459,7 @@ def argspec():
     argument_spec.update(copy.deepcopy(AUTH_ARG_SPEC))
     argument_spec.update(copy.deepcopy(WAIT_ARG_SPEC))
     argument_spec["merge_type"] = dict(
-        type="list", elements="str", choices=["json", "merge", "strategic-merge"]
+        type="list", elements="str", choices=["merge", "strategic-merge"]
     )
     argument_spec["validate"] = dict(type="dict", default=None, options=validate_spec())
     argument_spec["append_hash"] = dict(type="bool", default=False)


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Support for `merge_type=json` has been removed in version 4.0.0. Please use `kubernetes.core.k8s_json_patch` instead.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
k8s.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
