### PR TITLE
Prepare release 4.0.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Kubernetes Collection Release Notes
 
 .. contents:: Topics
 
+v4.0.1
+======
+
+Release Summary
+---------------
+
+This release updates collection documentation and meta/runtime.yml files to reflect ansible-core version support (support for ``ansible-core<2.15.0`` has been dropped in release ``4.0.0``).
+
 v4.0.0
 ======
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Also needs to be updated in galaxy.yml
-VERSION = 4.0.0
+VERSION = 4.0.1
 
 TEST_ARGS ?= ""
 PYTHON_VERSION ?= `python -c 'import platform; print(".".join(platform.python_version_tuple()[0:2]))'`

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ You can also include it in a `requirements.yml` file and install it via `ansible
 ---
 collections:
   - name: kubernetes.core
-    version: 4.0.0
+    version: 4.0.1
 ```
 
 ### Installing the Kubernetes Python Library

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -896,3 +896,11 @@ releases:
     - k8s-merge_type-removed.yml
     - module_utils-common-remove-deprecated-functions-and-class.yaml
     release_date: '2024-05-24'
+  4.0.1:
+    changes:
+      release_summary: This release updates collection documentation and meta/runtime.yml
+        files to reflect ansible-core version support (support for ``ansible-core<2.15.0``
+        has been dropped in release ``4.0.0``).
+    fragments:
+    - 4.0.1.yaml
+    release_date: '2024-05-29'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -25,7 +25,7 @@ tags:
   - openshift
   - okd
   - cluster
-version: 4.0.0
+version: 4.0.1
 build_ignore:
   - .DS_Store
   - "*.tar.gz"

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: '>=2.14.0'
+requires_ansible: '>=2.15.0'
 
 action_groups:
   helm:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This release update documentation and `meta/runtime.yml` to reflect ansible-core version support.
Release `4.0.0` has dropped `ansible-core<2.15.0` but neither documentation nor `meta/runtime.yml` files were updated.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Release Pull Request
