### PR TITLE
helm: Accept release candidate versions for compatibility checks

### DIFF
--- a/changelogs/fragments/20240611-helm-rc-version.yaml
+++ b/changelogs/fragments/20240611-helm-rc-version.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - helm - Helm version checks did not support RC versions. They now accept any version tags. (https://github.com/ansible-collections/kubernetes.core/pull/745).

--- a/plugins/module_utils/helm.py
+++ b/plugins/module_utils/helm.py
@@ -184,10 +184,10 @@ class AnsibleHelmModule(object):
     def get_helm_version(self):
         command = self.get_helm_binary() + " version"
         rc, out, err = self.run_command(command)
-        m = re.match(r'version.BuildInfo{Version:"v([0-9\.]*)",', out)
+        m = re.match(r'version.BuildInfo{Version:"v([^"]*)",', out)
         if m:
             return m.group(1)
-        m = re.match(r'Client: &version.Version{SemVer:"v([0-9\.]*)", ', out)
+        m = re.match(r'Client: &version.Version{SemVer:"v([^"]*)", ', out)
         if m:
             return m.group(1)
         return None

--- a/plugins/module_utils/helm.py
+++ b/plugins/module_utils/helm.py
@@ -184,10 +184,10 @@ class AnsibleHelmModule(object):
     def get_helm_version(self):
         command = self.get_helm_binary() + " version"
         rc, out, err = self.run_command(command)
-        m = re.match(r'version.BuildInfo{Version:"v([^"]*)",', out)
+        m = re.match(r'version.BuildInfo{Version:"v(.*?)",', out)
         if m:
             return m.group(1)
-        m = re.match(r'Client: &version.Version{SemVer:"v([^"]*)", ', out)
+        m = re.match(r'Client: &version.Version{SemVer:"v(.*?)", ', out)
         if m:
             return m.group(1)
         return None

--- a/tests/unit/module_utils/test_helm.py
+++ b/tests/unit/module_utils/test_helm.py
@@ -200,6 +200,10 @@ def test_module_get_values(_ansible_helm_module, no_values, get_all):
             'version.BuildInfo{Version:"v3.10.3", GitCommit:7870ab3ed4135f136eec, GoVersion:"go1.18.9"}',
             "3.10.3",
         ),
+        (
+            'version.BuildInfo{Version:"v3.15.0-rc.1", GitCommit:"d7afa3b6b432c09a02cd07342e908ba5bed34940", GitTreeState:"clean", GoVersion:"go1.22.4"}',
+            "3.15.0-rc.1",
+        ),
         ('Client: &version.Version{SemVer:"v3.12.3", ', "3.12.3"),
         ('Client: &version.Version{SemVer:"v3.12.3"', None),
     ],


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

If the helm CLI version includes `-rc.1` for example, the version checks fails due to an incomplete regex.
The error can be triggered if you use [helm v3.15.0-rc.1](https://github.com/helm/helm/releases/tag/v3.15.0-rc.1) for example, and [apply a helm chart with `wait: true` ](https://github.com/ansible-collections/kubernetes.core/blob/main/plugins/modules/helm.py#L806-L807)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
helm
helm_pull

##### ADDITIONAL INFORMATION