### PR TITLE
Prepare version 3.2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,19 @@ Kubernetes Collection Release Notes
 
 .. contents:: Topics
 
+v3.2.0
+======
+
+Release Summary
+---------------
+This release comes with documentation updates.
+
+Minor Changes
+-------------
+
+- inventory/k8s.py - Defer removal of k8s inventory plugin to version 6.0.0 (https://github.com/ansible-collections/kubernetes.core/pull/734).
+- connection/kubectl.py - Added an example of using the kubectl connection plugin to the documentation (https://github.com/ansible-collections/kubernetes.core/pull/741).
+
 v3.1.0
 ======
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Also needs to be updated in galaxy.yml
-VERSION = 3.0.0
+VERSION = 3.2.0
 
 TEST_ARGS ?= ""
 PYTHON_VERSION ?= `python -c 'import platform; print(".".join(platform.python_version_tuple()[0:2]))'`

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ You can also include it in a `requirements.yml` file and install it via `ansible
 ---
 collections:
   - name: kubernetes.core
-    version: 3.0.0
+    version: 3.2.0
 ```
 
 ### Installing the Kubernetes Python Library

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -854,3 +854,14 @@ releases:
     - 652-fix-json-patch-action.yml
     - 654-helm-expand-user.yml
     release_date: '2024-05-16'
+  3.2.0:
+    changes:
+      minor_changes:
+      - inventory/k8s.py - Defer removal of k8s inventory plugin to version 6.0.0 (https://github.com/ansible-collections/kubernetes.core/pull/734).
+      - connection/kubectl.py - Added an example of using the kubectl connection plugin to the documentation (https://github.com/ansible-collections/kubernetes.core/pull/741).
+      release_summary: This release comes with documentation updates.
+    fragments:
+    - 20240530-defer-removal-and-ansible-core-support-update.yaml
+    - 20240601-doc-example-of-using-kubectl.yaml
+    - 3.2.0.yml
+    release_date: '2024-06-14'

--- a/changelogs/fragments/20240601-doc-example-of-using-kubectl.yaml
+++ b/changelogs/fragments/20240601-doc-example-of-using-kubectl.yaml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - connection/kubectl.py - Added an example of using the kubectl connection plugin to the documentation (https://github.com/ansible-collections/kubernetes.core/pull/741).

--- a/docs/kubernetes.core.k8s_inventory.rst
+++ b/docs/kubernetes.core.k8s_inventory.rst
@@ -17,7 +17,7 @@ DEPRECATED
 ----------
 :Removed in collection release after 
 :Why: As discussed in https://github.com/ansible-collections/kubernetes.core/issues/31, we decided to
-remove the k8s inventory plugin in release 4.0.0.
+remove the k8s inventory plugin in release 6.0.0.
 
 :Alternative: Use :ref:`kubernetes.core.k8s_info <kubernetes.core.k8s_info_module>` and :ref:`ansible.builtin.add_host <ansible.builtin.add_host_module>` instead.
 
@@ -357,7 +357,7 @@ Status
 ------
 
 
-- This inventory will be removed in version 4.0.0. *[deprecated]*
+- This inventory will be removed in version 6.0.0. *[deprecated]*
 - For more information see `DEPRECATED`_.
 
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -25,7 +25,7 @@ tags:
   - openshift
   - okd
   - cluster
-version: 3.1.0
+version: 3.2.0
 build_ignore:
   - .DS_Store
   - "*.tar.gz"


### PR DESCRIPTION
##### SUMMARY
Prepare version 3.2.0

##### ISSUE TYPE
- New Version Pull Request

##### ADDITIONAL INFORMATION
The current version of a major Ansible (Ansible 10) includes a collection version 3.1.0, meaning that the minor version (i.e. Ansible 10.1) will pick versions from the `stable-3` branch. Hence, a recent [documentation update](https://github.com/ansible-collections/kubernetes.core/pull/741) will not be in Ansible and Ansible [documentation site/kubernetes.core collection chapter](https://docs.ansible.com/ansible/latest/collections/kubernetes/core/index.html) until a new minor version released from `stable-3` branch.

This PR also includes changes in `README.md` and `Makefile` that were missed in 3.1.0