### PR TITLE
fix shields.io badges in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kubernetes Collection for Ansible
 
-[![CI](https://github.com/ansible-collections/kubernetes.core/workflows/CI/badge.svg?event=push)](https://github.com/ansible-collections/kubernetes.core/actions) [![Codecov](https://img.shields.io/codecov/c/github/ansible-collections/kubernetes.core)](https://codecov.io/gh/ansible-collections/kubernetes.core)
+[![Linters](https://img.shields.io/github/actions/workflow/status/ansible-collections/kubernetes.core/linters.yaml?label=linters)](https://github.com/ansible-collections/kubernetes.core/actions/workflows/linters.yaml) [![Integration tests](https://img.shields.io/github/actions/workflow/status/ansible-collections/kubernetes.core/integration-tests.yaml?label=integration%20tests)](https://github.com/ansible-collections/kubernetes.core/actions/workflows/integration-tests.yaml) [![Sanity tests](https://img.shields.io/github/actions/workflow/status/ansible-collections/kubernetes.core/sanity-tests.yaml?label=sanity%20tests)](https://github.com/ansible-collections/kubernetes.core/actions/workflows/sanity-tests.yaml) [![Unit tests](https://img.shields.io/github/actions/workflow/status/ansible-collections/kubernetes.core/unit-tests.yaml?label=unit%20tests)](https://github.com/ansible-collections/kubernetes.core/actions/workflows/unit-tests.yaml) [![Codecov](https://img.shields.io/codecov/c/github/ansible-collections/kubernetes.core)](https://app.codecov.io/gh/ansible-collections/kubernetes.core)
 
 This repository hosts the `kubernetes.core` (formerly known as `community.kubernetes`) Ansible Collection.
 

--- a/changelogs/fragments/20240613-fix-README-bagdes.yaml
+++ b/changelogs/fragments/20240613-fix-README-bagdes.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - README.md - fixed badges in README.md (https://github.com/ansible-collections/kubernetes.core/pull/749)

--- a/changelogs/fragments/20240613-fix-README-bagdes.yaml
+++ b/changelogs/fragments/20240613-fix-README-bagdes.yaml
@@ -1,2 +1,0 @@
-minor_changes:
-  - README.md - fixed badges in README.md (https://github.com/ansible-collections/kubernetes.core/pull/749)


### PR DESCRIPTION
##### SUMMARY
This PR fixes shields.io badges in `README.md`. It's just cosmetic bugfix

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
README.md

##### ADDITIONAL INFORMATION
Current README.md:
![image](https://github.com/ansible-collections/kubernetes.core/assets/22106917/c4cbf974-de4d-4b0f-9406-d7b6a96a5c9a)

This PR:
![image](https://github.com/ansible-collections/kubernetes.core/assets/22106917/0b40a597-a456-476a-94a6-e7ea961c8722)

