### PR TITLE
Doc: update changelog with release 3.2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -55,6 +55,19 @@ Bugfixes
 - helm - use ``reuse-values`` when running ``helm diff`` command (https://github.com/ansible-collections/kubernetes.core/issues/680).
 - integrations test helm_kubeconfig - set helm version to v3.10.3 to avoid incompatability with new bitnami charts (https://github.com/ansible-collections/kubernetes.core/pull/670).
 
+v3.2.0
+======
+
+Release Summary
+---------------
+This release comes with documentation updates.
+
+Minor Changes
+-------------
+
+- inventory/k8s.py - Defer removal of k8s inventory plugin to version 6.0.0 (https://github.com/ansible-collections/kubernetes.core/pull/734).
+- connection/kubectl.py - Added an example of using the kubectl connection plugin to the documentation (https://github.com/ansible-collections/kubernetes.core/pull/741).
+
 v3.1.0
 ======
 


### PR DESCRIPTION
##### SUMMARY

Minor/cosmetic documentation change with adding release 3.2.0 to changelog for master as the release is from `stable-3` branch

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME

CHANGELOG.md

##### ADDITIONAL INFORMATION

Most probably this PR should be backported to the `stable-5` branch after the merge to the main and should be with a `skip-changelog` tag. 