### PR TITLE
Remove ansible install step from kubevirt GHA

### DIFF
--- a/.github/workflows/integration-tests-kubevirt.yaml
+++ b/.github/workflows/integration-tests-kubevirt.yaml
@@ -72,14 +72,6 @@ jobs:
           path: ${{ env.kubevirt }}
           ref: main
 
-      # Install ansible
-      - name: Install ansible-core (${{ env.ansible_version }})
-        run: >-
-          python3 -m pip install
-          https://github.com/ansible/ansible/archive/${{ env.ansible_version }}.tar.gz
-          --disable-pip-version-check
-        shell: bash
-
       - name: Build and install kubevirt.core collection
         id: install-kubevirt
         uses: ansible-network/github_actions/.github/actions/build_install_collection@main


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Ansible 2.17 is already included in the ubuntu-latest runner image, so there's no need for a separate install step. It was broken in any case because the python version being used was too low for ansible 2.18.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
