### PR TITLE
Make k8s_drain work when only one pod is present

### DIFF
--- a/changelogs/fragments/770-fix-k8s-drain-doesnt-wait-for-single-pod.yaml
+++ b/changelogs/fragments/770-fix-k8s-drain-doesnt-wait-for-single-pod.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - k8s_drain - Fix k8s_drain does not wait for single pod (https://github.com/ansible-collections/kubernetes.core/issues/769).

--- a/plugins/modules/k8s_drain.py
+++ b/plugins/modules/k8s_drain.py
@@ -291,16 +291,17 @@ class K8sDrainAnsible(object):
             return (datetime.now() - start).seconds
 
         response = None
-        pod = pods.pop()
+        pod = None
         while (_elapsed_time() < wait_timeout or wait_timeout == 0) and pods:
             if not pod:
-                pod = pods.pop()
+                pod = pods[-1]
             try:
                 response = self._api_instance.read_namespaced_pod(
                     namespace=pod[0], name=pod[1]
                 )
                 if not response:
                     pod = None
+                    del pods[-1]
                 time.sleep(wait_sleep)
             except ApiException as exc:
                 if exc.reason != "Not Found":
@@ -308,6 +309,7 @@ class K8sDrainAnsible(object):
                         msg="Exception raised: {0}".format(exc.reason)
                     )
                 pod = None
+                del pods[-1]
             except Exception as e:
                 self._module.fail_json(msg="Exception raised: {0}".format(to_native(e)))
         if not pods:


### PR DESCRIPTION
##### SUMMARY
Fixes #769 .

`k8s_drain` was not checking if a pod has been deleted when there was only one pod on the node to be drained.

The list of pods, `pods`, was being "popped" before the first iteration of the `while` loop:

```python
        pod = pods.pop()
        while (_elapsed_time() < wait_timeout or wait_timeout == 0) and pods:
```
When `pods` contains only one element, the `while` loop is skipped.

<!--- Describe the change below, including rationale and design decisions -->



<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
k8s_drain

