### PR TITLE
Update README.md with removing outdated communication channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,10 +266,6 @@ If you encounter issues or have questions, you can submit a support request thro
 
 See the [raw generated changelog](https://github.com/ansible-collections/kubernetes.core/blob/main/CHANGELOG.rst).
 
-## More Information
-
-For more information about Ansible's Kubernetes integration, join the `#ansible-kubernetes` channel on [libera.chat](https://libera.chat/) IRC, and browse the resources in the [Kubernetes Working Group](https://github.com/ansible/community/wiki/Kubernetes) Community wiki page.
-
 ## Code of Conduct
 
 We follow the [Ansible Code of Conduct](https://docs.ansible.com/ansible/devel/community/code_of_conduct.html) in all our interactions within this project.

--- a/changelogs/fragments/20241103-completly-remove-obsolate-communication-channel.yaml
+++ b/changelogs/fragments/20241103-completly-remove-obsolate-communication-channel.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - README.md - Remove obsolate communication channels (https://github.com/ansible-collections/kubernetes.core/pull/790).


### PR DESCRIPTION
##### SUMMARY

As part of the consolidating Ansible discussion platforms and communication channels was decided to use the Ansible forum as the main place for questions and discussion.

Reference: https://forum.ansible.com/t/proposal-consolidating-ansible-discussion-platforms/6812

As part of this change, the IRC channel was removed by the PRs #778 and #774.

However, the README.md file wasn't fully cleaned up from the outdated information.

The `#ansible-kubernetes` channel on [libera.chat](https://libera.chat/) IRC isn't used by maintainers and contributors anymore. 

The Wiki page on the https://github.com/ansible/community/ was deprecated a long time ago

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
README.md
