### PR TITLE
Fix k8s_drain runs into timeout with pods from stateful sets.

### DIFF
--- a/changelogs/fragments/793-fix-k8s-drain-runs-into-timeout.yaml
+++ b/changelogs/fragments/793-fix-k8s-drain-runs-into-timeout.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - k8s_drain - Fix k8s_drain runs into a timeout when evicting a pod which is part of a stateful set  (https://github.com/ansible-collections/kubernetes.core/issues/792).

--- a/plugins/module_utils/helm.py
+++ b/plugins/module_utils/helm.py
@@ -77,7 +77,6 @@ def write_temp_kubeconfig(server, validate_certs=True, ca_cert=None, kubeconfig=
 
 
 class AnsibleHelmModule(object):
-
     """
     An Ansible module class for Kubernetes.core helm modules
     """

--- a/plugins/modules/k8s_drain.py
+++ b/plugins/modules/k8s_drain.py
@@ -299,7 +299,9 @@ class K8sDrainAnsible(object):
                 response = self._api_instance.read_namespaced_pod(
                     namespace=pod[0], name=pod[1]
                 )
-                if not response:
+                if not response or response.spec.node_name != self._module.params.get(
+                    "name"
+                ):
                     pod = None
                     del pods[-1]
                 time.sleep(wait_sleep)


### PR DESCRIPTION
##### SUMMARY


Fixes #792 .

The function `wait_for_pod_deletion` in k8s_drain never checks on which node a pod is actually running:

```python
            try:
                response = self._api_instance.read_namespaced_pod(
                    namespace=pod[0], name=pod[1]
                )
                if not response:
                    pod = None
                time.sleep(wait_sleep)
```
This means that if a pod is successfully evicted and restarted with the same name on a new node, `k8s_drain` does not notice and thinks that the original pod is still running. This is the case for pods which are part of a stateful set.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
`k8s_drain`

