### PR TITLE
k8s_cluster_info.py Add warn for resorce missing kind field

### DIFF
--- a/plugins/modules/k8s_cluster_info.py
+++ b/plugins/modules/k8s_cluster_info.py
@@ -178,6 +178,12 @@ def execute_module(module, client):
             if resource.group == ""
             else "/".join([resource.group, resource.group_version.split("/")[-1]])
         )
+
+        kind = getattr(resource, "kind", None)
+        if not kind:
+            module.warn(f"Resource is missing 'kind': {resource}")
+            continue
+
         results[key][resource.kind] = {
             "categories": resource.categories if resource.categories else [],
             "name": resource.name,


### PR DESCRIPTION
##### SUMMARY
 Add warn for resorce missing kind field

##### ISSUE TYPE
Currently k8s_cluster_info.py just assume kind field will always exists; this helps to warn/debug issue when resource is missing kind field
