### PR TITLE
helm_pull: Silence false no_log warning

### DIFF
--- a/changelogs/fragments/796-false-positive-helmull.yaml
+++ b/changelogs/fragments/796-false-positive-helmull.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - helm_pull - Apply no_log=True to pass_credentials to silence false positive warning.. (https://github.com/ansible-collections/kubernetes.core/pull/796).

--- a/plugins/modules/helm_pull.py
+++ b/plugins/modules/helm_pull.py
@@ -189,7 +189,7 @@ def main():
         repo_password=dict(
             type="str", no_log=True, aliases=["password", "chart_repo_password"]
         ),
-        pass_credentials=dict(type="bool", default=False, no_log=True),
+        pass_credentials=dict(type="bool", default=False, no_log=False),
         skip_tls_certs_check=dict(type="bool", default=False),
         chart_devel=dict(type="bool"),
         untar_chart=dict(type="bool", default=False),

--- a/plugins/modules/helm_pull.py
+++ b/plugins/modules/helm_pull.py
@@ -189,7 +189,7 @@ def main():
         repo_password=dict(
             type="str", no_log=True, aliases=["password", "chart_repo_password"]
         ),
-        pass_credentials=dict(type="bool", default=False),
+        pass_credentials=dict(type="bool", default=False, no_log=True),
         skip_tls_certs_check=dict(type="bool", default=False),
         chart_devel=dict(type="bool"),
         untar_chart=dict(type="bool", default=False),

--- a/tests/integration/targets/helm_pull/tasks/main.yml
+++ b/tests/integration/targets/helm_pull/tasks/main.yml
@@ -180,6 +180,7 @@
               - '"--username ansible" in _result.command'
               - '"--password ***" in _result.command'
               - '"--keyring pubring.gpg" in _result.command'
+              - '"Module did not set no_log for pass_credentials" not in _result.warnings'
 
         - name: Download chart using chart_ref
           helm_pull:

--- a/tests/integration/targets/helm_pull/tasks/main.yml
+++ b/tests/integration/targets/helm_pull/tasks/main.yml
@@ -180,7 +180,7 @@
               - '"--username ansible" in _result.command'
               - '"--password ***" in _result.command'
               - '"--keyring pubring.gpg" in _result.command'
-              - '"Module did not set no_log for pass_credentials" not in _result.warnings'
+              - '"Module did not set no_log for pass_credentials" not in _result.stderr'
 
         - name: Download chart using chart_ref
           helm_pull:


### PR DESCRIPTION
##### SUMMARY
Apply no_log=True to pass_credentials to silence false positive warning.

Fixes similar issue to: https://github.com/ansible-collections/kubernetes.core/pull/423

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelog/fragements/796-false-positive-helmull.yaml
plugins/modules/helm_pull.py

```
