### PR TITLE
Fix helm tests

### DIFF
--- a/tests/integration/targets/helm/tasks/main.yml
+++ b/tests/integration/targets/helm/tasks/main.yml
@@ -4,4 +4,4 @@
   loop_control:
     loop_var: helm_version
   with_items:
-    - "v3.7.0"
+    - "v3.8.0"

--- a/tests/integration/targets/helm/tasks/test_helm_reuse_values.yml
+++ b/tests/integration/targets/helm/tasks/test_helm_reuse_values.yml
@@ -17,8 +17,7 @@
     - name: Initial chart installation
       helm:
         binary_path: "{{ helm_binary }}"
-        chart_ref: redis
-        chart_repo_url: https://charts.bitnami.com/bitnami
+        chart_ref: oci://registry-1.docker.io/bitnamicharts/redis
         release_name: test-redis
         release_namespace: "{{ helm_namespace }}"
         create_namespace: true
@@ -42,8 +41,7 @@
     - name: Upgrade chart using reuse_values=true
       helm:
         binary_path: "{{ helm_binary }}"
-        chart_ref: redis
-        chart_repo_url: https://charts.bitnami.com/bitnami
+        chart_ref: oci://registry-1.docker.io/bitnamicharts/redis
         release_name: test-redis
         release_namespace: "{{ helm_namespace }}"
         reuse_values: true

--- a/tests/integration/targets/helm/tasks/tests_chart.yml
+++ b/tests/integration/targets/helm/tasks/tests_chart.yml
@@ -374,8 +374,8 @@
         chart_ref: "{{ chart_source }}"
         chart_version: "{{ chart_source_version | default(omit) }}"
         disable_hook: True
-        release_name: "MyRelease"
-        release_namespace: "MyReleaseNamespace"
+        release_name: "myrelease"
+        release_namespace: "myreleasenamespace"
         show_only:
           - "templates/configmap.yaml"
         release_values:
@@ -388,7 +388,7 @@
           - result is changed
           - result is not failed
           - result.rc == 0
-          - result.command is match(helm_binary+" template MyRelease "+chart_source)
+          - result.command is match(helm_binary+" template myrelease "+chart_source)
           - result.stdout is search("ThisValue")
       when: chart_source is search("test-chart")
       # limit assertion of test result to controlled (local) chart_source

--- a/tests/integration/targets/helm_pull/tasks/main.yml
+++ b/tests/integration/targets/helm_pull/tasks/main.yml
@@ -203,9 +203,8 @@
         - name: Download chart using untar_chart
           helm_pull:
             binary_path: "{{ helm_path }}"
-            chart_ref: redis
+            chart_ref: "oci://registry-1.docker.io/bitnamicharts/redis"
             destination: "{{ destination }}"
-            repo_url: "https://charts.bitnami.com/bitnami"
             untar_chart: true
           register: _result
 

--- a/tests/integration/targets/helm_set_values/tasks/main.yml
+++ b/tests/integration/targets/helm_set_values/tasks/main.yml
@@ -1,8 +1,7 @@
 - name: Install helm using set_values parameters
   helm:
     binary_path: "{{ helm_binary }}"
-    chart_ref: mariadb
-    chart_repo_url: https://charts.bitnami.com/bitnami
+    chart_ref: oci://registry-1.docker.io/bitnamicharts/mariadb
     release_name: test-mariadb
     release_namespace: "{{ helm_namespace }}"
     create_namespace: true
@@ -36,8 +35,7 @@
 - name: Install helm using set_values parameters
   helm:
     binary_path: "{{ helm_binary }}"
-    chart_ref: apache
-    chart_repo_url: https://charts.bitnami.com/bitnami
+    chart_ref: oci://registry-1.docker.io/bitnamicharts/apache
     release_name: test-apache
     release_namespace: "{{ helm_namespace }}"
     create_namespace: true
@@ -79,8 +77,7 @@
   - name: Install helm using set_values parameters
     helm:
       binary_path: "{{ helm_binary }}"
-      chart_ref: minio
-      chart_repo_url: https://charts.bitnami.com/bitnami
+      chart_ref: oci://registry-1.docker.io/bitnamicharts/minio
       release_name: test-minio
       release_namespace: "{{ helm_namespace }}"
       create_namespace: true

--- a/tests/integration/targets/install_helm/defaults/main.yml
+++ b/tests/integration/targets/install_helm/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-helm_version: v3.7.0
+helm_version: v3.8.0
 helm_install_path: /tmp/helm
 helm_default_archive_name: "helm-{{ helm_version }}-{{ ansible_system | lower }}-amd64.tar.gz"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Some of the charts we've used for testing are no longer available at the old helm repository urls, as they've been moved to oci registries. This updates those charts.

In the longer term, we should find a better way to handle these kinds of test fixtures, probably by switching to local charts as much as possible.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
