### PR TITLE
trivial doc: replace 2.5.0 with 3.0.0

### DIFF
--- a/docs/kubernetes.core.helm_module.rst
+++ b/docs/kubernetes.core.helm_module.rst
@@ -443,7 +443,7 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">boolean</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 2.5.0</div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 3.0.0</div>
                 </td>
                 <td>
                         <ul style="margin: 0; padding: 0"><b>Choices:</b>
@@ -463,7 +463,7 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">boolean</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 2.5.0</div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 3.0.0</div>
                 </td>
                 <td>
                         <ul style="margin: 0; padding: 0"><b>Choices:</b>

--- a/docs/kubernetes.core.k8s_drain_module.rst
+++ b/docs/kubernetes.core.k8s_drain_module.rst
@@ -423,7 +423,7 @@ Parameters
                         <span style="color: purple">list</span>
                          / <span style="color: purple">elements=string</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 2.5.0</div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 3.0.0</div>
                 </td>
                 <td>
                 </td>

--- a/docs/kubernetes.core.k8s_info_module.rst
+++ b/docs/kubernetes.core.k8s_info_module.rst
@@ -168,7 +168,7 @@ Parameters
                         <span style="color: purple">list</span>
                          / <span style="color: purple">elements=string</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 2.5.0</div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 3.0.0</div>
                 </td>
                 <td>
                 </td>

--- a/docs/kubernetes.core.k8s_module.rst
+++ b/docs/kubernetes.core.k8s_module.rst
@@ -216,7 +216,7 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">boolean</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 2.5.0</div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 3.0.0</div>
                 </td>
                 <td>
                         <ul style="margin: 0; padding: 0"><b>Choices:</b>
@@ -389,7 +389,7 @@ Parameters
                         <span style="color: purple">list</span>
                          / <span style="color: purple">elements=string</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 2.5.0</div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 3.0.0</div>
                 </td>
                 <td>
                 </td>

--- a/plugins/modules/helm.py
+++ b/plugins/modules/helm.py
@@ -137,14 +137,14 @@ options:
       - If I(reset_values) is set to C(True), this is ignored.
     type: bool
     required: false
-    version_added: 2.5.0
+    version_added: 3.0.0
   reset_values:
     description:
       - When upgrading package, reset the values to the ones built into the chart.
     type: bool
     required: false
     default: True
-    version_added: 2.5.0
+    version_added: 3.0.0
 
 #Helm options
   disable_hook:

--- a/plugins/modules/k8s.py
+++ b/plugins/modules/k8s.py
@@ -181,7 +181,7 @@ options:
     - This parameter can be used with C(label_selectors) to restrict the resources to be deleted.
     type: bool
     default: false
-    version_added: 2.5.0
+    version_added: 3.0.0
     aliases:
     - all
   hidden_fields:
@@ -191,7 +191,7 @@ options:
       - Only field definitions that don't reference list items are supported (so V(spec.containers[0]) would not work)
     type: list
     elements: str
-    version_added: 2.5.0
+    version_added: 3.0.0
 
 requirements:
   - "python >= 3.9"

--- a/plugins/modules/k8s_drain.py
+++ b/plugins/modules/k8s_drain.py
@@ -47,7 +47,7 @@ options:
       - This option has effect only when C(state) is set to I(drain).
     type: list
     elements: str
-    version_added: 2.5.0
+    version_added: 3.0.0
     aliases:
     - label_selectors
   delete_options:

--- a/plugins/modules/k8s_info.py
+++ b/plugins/modules/k8s_info.py
@@ -51,7 +51,7 @@ options:
       - Only field definitions that don't reference list items are supported (so V(spec.containers[0]) would not work)
     type: list
     elements: str
-    version_added: 2.5.0
+    version_added: 3.0.0
 
 extends_documentation_fragment:
   - kubernetes.core.k8s_auth_options


### PR DESCRIPTION
##### SUMMARY
Some parameters were added to the master in time where the latest version was 2.4.0 with `version_added: 2.5.0`, however the next version after 2.4.0 was a 3.0.0.

So, with this trivial doc PR (that most probably doesn't require a changelog fragment and including to changelog) I replacing  `version_added: 2.5.0` to  `version_added: 3.0.0` for:

- `reuse_values` in `kubernetes.core.helm` module
- `reset_values` in `kubernetes.core.helm` module
- `delete_all` in  `kubernetes.core.k8s` module
- `hidden_fields`  in  `kubernetes.core.k8s` module
- `hidden_fields`   in  `kubernetes.core.k8s_info` module

All of them are introduced in `kubernetes.core` 3.0.0

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- helm
- k8s
- 8s_info
- 
##### ADDITIONAL INFORMATION
PR to be backported to `stable-3` and `stable-5`