### PR TITLE
Clean up test namespace

### DIFF
--- a/tests/integration/targets/helm_set_values/tasks/main.yml
+++ b/tests/integration/targets/helm_set_values/tasks/main.yml
@@ -104,3 +104,11 @@
     file:
       state: absent
       path: "{{ ymlfile.path }}"
+    ignore_errors: true
+
+  - name: Delete namespace
+    k8s:
+      state: absent
+      kind: namespace
+      name: "{{ helm_namespace }}"
+    ignore_errors: true


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The helm_set_values test target did not clean up its namespace which is leading to unstable tests in the k8s_drain target.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
