### PR TITLE
Prepare release 3.3.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,18 +4,40 @@ Kubernetes Collection Release Notes
 
 .. contents:: Topics
 
+v3.3.0
+======
+
+Minor Changes
+-------------
+
+- inventory/k8s.py - Defer removal of k8s inventory plugin to version 5.0 (https://github.com/ansible-collections/kubernetes.core/pull/723).
+- inventory/k8s.py - Defer removal of k8s inventory plugin to version 6.0.0 (https://github.com/ansible-collections/kubernetes.core/pull/734).
+- k8s_drain - Improve error message for pod disruption budget when draining a node (https://github.com/ansible-collections/kubernetes.core/issues/797).
+
+Bugfixes
+--------
+
+- helm - Helm version checks did not support RC versions. They now accept any version tags. (https://github.com/ansible-collections/kubernetes.core/pull/745).
+- helm_pull - Apply no_log=True to pass_credentials to silence false positive warning.. (https://github.com/ansible-collections/kubernetes.core/pull/796).
+- k8s_drain - Fix k8s_drain does not wait for single pod (https://github.com/ansible-collections/kubernetes.core/issues/769).
+- k8s_drain - Fix k8s_drain runs into a timeout when evicting a pod which is part of a stateful set  (https://github.com/ansible-collections/kubernetes.core/issues/792).
+- kubeconfig option should not appear in module invocation log (https://github.com/ansible-collections/kubernetes.core/issues/782).
+- kustomize - kustomize plugin fails with deprecation warnings (https://github.com/ansible-collections/kubernetes.core/issues/639).
+- waiter - Fix waiting for daemonset when desired number of pods is 0. (https://github.com/ansible-collections/kubernetes.core/pull/756).
+
 v3.2.0
 ======
 
 Release Summary
 ---------------
+
 This release comes with documentation updates.
 
 Minor Changes
 -------------
 
-- inventory/k8s.py - Defer removal of k8s inventory plugin to version 6.0.0 (https://github.com/ansible-collections/kubernetes.core/pull/734).
 - connection/kubectl.py - Added an example of using the kubectl connection plugin to the documentation (https://github.com/ansible-collections/kubernetes.core/pull/741).
+- inventory/k8s.py - Defer removal of k8s inventory plugin to version 6.0.0 (https://github.com/ansible-collections/kubernetes.core/pull/734).
 
 v3.1.0
 ======

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Also needs to be updated in galaxy.yml
-VERSION = 3.2.0
+VERSION = 3.3.0
 
 TEST_ARGS ?= ""
 PYTHON_VERSION ?= `python -c 'import platform; print(".".join(platform.python_version_tuple()[0:2]))'`

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ You can also include it in a `requirements.yml` file and install it via `ansible
 ---
 collections:
   - name: kubernetes.core
-    version: 3.2.0
+    version: 3.3.0
 ```
 
 ### Installing the Kubernetes Python Library

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -857,11 +857,45 @@ releases:
   3.2.0:
     changes:
       minor_changes:
-      - inventory/k8s.py - Defer removal of k8s inventory plugin to version 6.0.0 (https://github.com/ansible-collections/kubernetes.core/pull/734).
-      - connection/kubectl.py - Added an example of using the kubectl connection plugin to the documentation (https://github.com/ansible-collections/kubernetes.core/pull/741).
+      - connection/kubectl.py - Added an example of using the kubectl connection plugin
+        to the documentation (https://github.com/ansible-collections/kubernetes.core/pull/741).
+      - inventory/k8s.py - Defer removal of k8s inventory plugin to version 6.0.0
+        (https://github.com/ansible-collections/kubernetes.core/pull/734).
+      - inventory/k8s.py - Defer removal of k8s inventory plugin to version 5.0 (https://github.com/ansible-collections/kubernetes.core/pull/723).
       release_summary: This release comes with documentation updates.
     fragments:
     - 20240530-defer-removal-and-ansible-core-support-update.yaml
     - 20240601-doc-example-of-using-kubectl.yaml
+    - inventory-update_removal_date.yml
     - 3.2.0.yml
     release_date: '2024-06-14'
+  3.3.0:
+    changes:
+      bugfixes:
+      - helm - Helm version checks did not support RC versions. They now accept any
+        version tags. (https://github.com/ansible-collections/kubernetes.core/pull/745).
+      - helm_pull - Apply no_log=True to pass_credentials to silence false positive
+        warning. (https://github.com/ansible-collections/kubernetes.core/pull/796).
+      - k8s_drain - Fix k8s_drain does not wait for single pod (https://github.com/ansible-collections/kubernetes.core/issues/769).
+      - k8s_drain - Fix k8s_drain runs into a timeout when evicting a pod which is
+        part of a stateful set  (https://github.com/ansible-collections/kubernetes.core/issues/792).
+      - kubeconfig option should not appear in module invocation log (https://github.com/ansible-collections/kubernetes.core/issues/782).
+      - kustomize - kustomize plugin fails with deprecation warnings (https://github.com/ansible-collections/kubernetes.core/issues/639).
+      - waiter - Fix waiting for daemonset when desired number of pods is 0. (https://github.com/ansible-collections/kubernetes.core/pull/756).
+      minor_changes:
+      - k8s_drain - Improve error message for pod disruption budget when draining
+        a node (https://github.com/ansible-collections/kubernetes.core/issues/797).
+      release_summary: This release comes with improvements to the error messages in the k8s_drain module and several bug fixes.
+    fragments:
+    - 20240530-ansible-core-support-update.yaml
+    - 20240611-helm-rc-version.yaml
+    - 20240620-fix-kustomize-plugin-fails-with-deprecation-warnings.yml
+    - 20241102-fix-ci-post-2.18-issue.yaml
+    - 20241213-kubeconfig-set-no_log-true.yaml
+    - 756-fix-daemonset-waiting.yaml
+    - 770-fix-k8s-drain-doesnt-wait-for-single-pod.yaml
+    - 793-fix-k8s-drain-runs-into-timeout.yaml
+    - 796-false-positive-helmull.yaml
+    - 798-drain-pdb-error-message.yaml
+    - readme_template_update.yml
+    release_date: '2025-01-22'

--- a/changelogs/fragments/20240530-ansible-core-support-update.yaml
+++ b/changelogs/fragments/20240530-ansible-core-support-update.yaml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - inventory/k8s.py - Defer removal of k8s inventory plugin to version 6.0.0 (https://github.com/ansible-collections/kubernetes.core/pull/734).

--- a/changelogs/fragments/20240611-helm-rc-version.yaml
+++ b/changelogs/fragments/20240611-helm-rc-version.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-  - helm - Helm version checks did not support RC versions. They now accept any version tags. (https://github.com/ansible-collections/kubernetes.core/pull/745).

--- a/changelogs/fragments/20240620-fix-kustomize-plugin-fails-with-deprecation-warnings.yml
+++ b/changelogs/fragments/20240620-fix-kustomize-plugin-fails-with-deprecation-warnings.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - kustomize - kustomize plugin fails with deprecation warnings (https://github.com/ansible-collections/kubernetes.core/issues/639).

--- a/changelogs/fragments/20241102-fix-ci-post-2.18-issue.yaml
+++ b/changelogs/fragments/20241102-fix-ci-post-2.18-issue.yaml
@@ -1,3 +1,0 @@
----
-trivial:
-  - Fix GitHub actions issue related to switch milestone and devel branches of ansible to 2.19 (https://github.com/ansible-collections/kubernetes.core/pull/789)

--- a/changelogs/fragments/20241213-kubeconfig-set-no_log-true.yaml
+++ b/changelogs/fragments/20241213-kubeconfig-set-no_log-true.yaml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - kubeconfig option should not appear in module invocation log (https://github.com/ansible-collections/kubernetes.core/issues/782).

--- a/changelogs/fragments/756-fix-daemonset-waiting.yaml
+++ b/changelogs/fragments/756-fix-daemonset-waiting.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-  - waiter - Fix waiting for daemonset when desired number of pods is 0. (https://github.com/ansible-collections/kubernetes.core/pull/756).

--- a/changelogs/fragments/770-fix-k8s-drain-doesnt-wait-for-single-pod.yaml
+++ b/changelogs/fragments/770-fix-k8s-drain-doesnt-wait-for-single-pod.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-  - k8s_drain - Fix k8s_drain does not wait for single pod (https://github.com/ansible-collections/kubernetes.core/issues/769).

--- a/changelogs/fragments/793-fix-k8s-drain-runs-into-timeout.yaml
+++ b/changelogs/fragments/793-fix-k8s-drain-runs-into-timeout.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-  - k8s_drain - Fix k8s_drain runs into a timeout when evicting a pod which is part of a stateful set  (https://github.com/ansible-collections/kubernetes.core/issues/792).

--- a/changelogs/fragments/796-false-positive-helmull.yaml
+++ b/changelogs/fragments/796-false-positive-helmull.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-  - helm_pull - Apply no_log=True to pass_credentials to silence false positive warning.. (https://github.com/ansible-collections/kubernetes.core/pull/796).

--- a/changelogs/fragments/798-drain-pdb-error-message.yaml
+++ b/changelogs/fragments/798-drain-pdb-error-message.yaml
@@ -1,2 +1,0 @@
-minor_changes:
-  - k8s_drain - Improve error message for pod disruption budget when draining a node (https://github.com/ansible-collections/kubernetes.core/issues/797).

--- a/changelogs/fragments/inventory-update_removal_date.yml
+++ b/changelogs/fragments/inventory-update_removal_date.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - inventory/k8s.py - Defer removal of k8s inventory plugin to version 5.0 (https://github.com/ansible-collections/kubernetes.core/pull/723).

--- a/changelogs/fragments/readme_template_update.yml
+++ b/changelogs/fragments/readme_template_update.yml
@@ -1,3 +1,0 @@
----
-trivial:
-  - Update the README doc to match https://access.redhat.com/articles/7068606.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -25,7 +25,7 @@ tags:
   - openshift
   - okd
   - cluster
-version: 3.2.0
+version: 3.3.0
 build_ignore:
   - .DS_Store
   - "*.tar.gz"


### PR DESCRIPTION
##### SUMMARY
Version 3.3.0 of ansible-collection kubernetes.core came with several improvements and bugfixes

##### ISSUE TYPE

- New release pull request

##### Changelog
Minor Changes
-------------

- k8s_drain - Improve error message for pod disruption budget when draining a node (https://github.com/ansible-collections/kubernetes.core/issues/797).

Bugfixes
--------

- helm - Helm version checks did not support RC versions. They now accept any version tags. (https://github.com/ansible-collections/kubernetes.core/pull/745).
- helm_pull - Apply no_log=True to pass_credentials to silence false positive warning.. (https://github.com/ansible-collections/kubernetes.core/pull/796).
- k8s_drain - Fix k8s_drain does not wait for single pod (https://github.com/ansible-collections/kubernetes.core/issues/769).
- k8s_drain - Fix k8s_drain runs into a timeout when evicting a pod which is part of a stateful set  (https://github.com/ansible-collections/kubernetes.core/issues/792).
- kubeconfig option should not appear in module invocation log (https://github.com/ansible-collections/kubernetes.core/issues/782).
- kustomize - kustomize plugin fails with deprecation warnings (https://github.com/ansible-collections/kubernetes.core/issues/639).
- waiter - Fix waiting for daemonset when desired number of pods is 0. (https://github.com/ansible-collections/kubernetes.core/pull/756).

##### ADDITIONAL INFORMATION

Collection kubernets.core version 3.3.0 is compatible with ansible-core>=2.14.0
