### PR TITLE
Post release 5.1.0 update

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,37 @@ Kubernetes Collection Release Notes
 
 .. contents:: Topics
 
+v5.1.0
+======
+
+Release Summary
+---------------
+
+This release came with new module ``helm_registry_auth``, improvements to the error messages in the k8s_drain module, new parameter ``insecure_registry`` for ``helm_template`` module and several bug fixes.
+
+Minor Changes
+-------------
+
+- Bump version of ansible-lint to minimum 24.7.0 (https://github.com/ansible-collections/kubernetes.core/pull/765).
+- Parameter insecure_registry added to helm_template as equivalent of insecure-skip-tls-verify (https://github.com/ansible-collections/kubernetes.core/pull/805).
+- k8s_drain - Improve error message for pod disruption budget when draining a node (https://github.com/ansible-collections/kubernetes.core/issues/797).
+
+Bugfixes
+--------
+
+- helm - Helm version checks did not support RC versions. They now accept any version tags. (https://github.com/ansible-collections/kubernetes.core/pull/745).
+- helm_pull - Apply no_log=True to pass_credentials to silence false positive warning. (https://github.com/ansible-collections/kubernetes.core/pull/796).
+- k8s_drain - Fix k8s_drain does not wait for single pod (https://github.com/ansible-collections/kubernetes.core/issues/769).
+- k8s_drain - Fix k8s_drain runs into a timeout when evicting a pod which is part of a stateful set  (https://github.com/ansible-collections/kubernetes.core/issues/792).
+- kubeconfig option should not appear in module invocation log (https://github.com/ansible-collections/kubernetes.core/issues/782).
+- kustomize - kustomize plugin fails with deprecation warnings (https://github.com/ansible-collections/kubernetes.core/issues/639).
+- waiter - Fix waiting for daemonset when desired number of pods is 0. (https://github.com/ansible-collections/kubernetes.core/pull/756).
+
+New Modules
+-----------
+
+- helm_registry_auth - Helm registry authentication module
+
 v5.0.0
 ======
 
@@ -15,6 +46,7 @@ This major release drops support for ``ansible-core<2.15``.
 Minor Changes
 -------------
 
+- connection/kubectl.py - Added an example of using the kubectl connection plugin to the documentation (https://github.com/ansible-collections/kubernetes.core/pull/741).
 - inventory/k8s.py - Defer removal of k8s inventory plugin to version 6.0.0 (https://github.com/ansible-collections/kubernetes.core/pull/734).
 
 Breaking Changes / Porting Guide
@@ -55,18 +87,44 @@ Bugfixes
 - helm - use ``reuse-values`` when running ``helm diff`` command (https://github.com/ansible-collections/kubernetes.core/issues/680).
 - integrations test helm_kubeconfig - set helm version to v3.10.3 to avoid incompatability with new bitnami charts (https://github.com/ansible-collections/kubernetes.core/pull/670).
 
+v3.3.0
+======
+
+Release Summary
+---------------
+
+This release comes with improvements to the error messages in the k8s_drain module and several bug fixes.
+
+Minor Changes
+-------------
+
+- k8s_drain - Improve error message for pod disruption budget when draining a node (https://github.com/ansible-collections/kubernetes.core/issues/797).
+
+Bugfixes
+--------
+
+- helm - Helm version checks did not support RC versions. They now accept any version tags. (https://github.com/ansible-collections/kubernetes.core/pull/745).
+- helm_pull - Apply no_log=True to pass_credentials to silence false positive warning. (https://github.com/ansible-collections/kubernetes.core/pull/796).
+- k8s_drain - Fix k8s_drain does not wait for single pod (https://github.com/ansible-collections/kubernetes.core/issues/769).
+- k8s_drain - Fix k8s_drain runs into a timeout when evicting a pod which is part of a stateful set  (https://github.com/ansible-collections/kubernetes.core/issues/792).
+- kubeconfig option should not appear in module invocation log (https://github.com/ansible-collections/kubernetes.core/issues/782).
+- kustomize - kustomize plugin fails with deprecation warnings (https://github.com/ansible-collections/kubernetes.core/issues/639).
+- waiter - Fix waiting for daemonset when desired number of pods is 0. (https://github.com/ansible-collections/kubernetes.core/pull/756).
+
 v3.2.0
 ======
 
 Release Summary
 ---------------
+
 This release comes with documentation updates.
 
 Minor Changes
 -------------
 
-- inventory/k8s.py - Defer removal of k8s inventory plugin to version 6.0.0 (https://github.com/ansible-collections/kubernetes.core/pull/734).
 - connection/kubectl.py - Added an example of using the kubectl connection plugin to the documentation (https://github.com/ansible-collections/kubernetes.core/pull/741).
+- inventory/k8s.py - Defer removal of k8s inventory plugin to version 5.0 (https://github.com/ansible-collections/kubernetes.core/pull/723).
+- inventory/k8s.py - Defer removal of k8s inventory plugin to version 6.0.0 (https://github.com/ansible-collections/kubernetes.core/pull/734).
 
 v3.1.0
 ======

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Also needs to be updated in galaxy.yml
-VERSION = 6.0.0-dev0
+VERSION = 5.2.0-dev0
 
 TEST_ARGS ?= ""
 PYTHON_VERSION ?= `python -c 'import platform; print(".".join(platform.python_version_tuple()[0:2]))'`

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Also needs to be updated in galaxy.yml
-VERSION = 5.0.0
+VERSION = 5.2.0-dev0
 
 TEST_ARGS ?= ""
 PYTHON_VERSION ?= `python -c 'import platform; print(".".join(platform.python_version_tuple()[0:2]))'`

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Also needs to be updated in galaxy.yml
-VERSION = 5.2.0-dev0
+VERSION = 6.0.0-dev0
 
 TEST_ARGS ?= ""
 PYTHON_VERSION ?= `python -c 'import platform; print(".".join(platform.python_version_tuple()[0:2]))'`

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ You can also include it in a `requirements.yml` file and install it via `ansible
 ---
 collections:
   - name: kubernetes.core
-    version: 5.0.0
+    version: 5.1.0
 ```
 
 ### Installing the Kubernetes Python Library

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -854,6 +854,52 @@ releases:
     - 652-fix-json-patch-action.yml
     - 654-helm-expand-user.yml
     release_date: '2024-05-16'
+  3.2.0:
+    changes:
+      minor_changes:
+      - connection/kubectl.py - Added an example of using the kubectl connection plugin
+        to the documentation (https://github.com/ansible-collections/kubernetes.core/pull/741).
+      - inventory/k8s.py - Defer removal of k8s inventory plugin to version 5.0 (https://github.com/ansible-collections/kubernetes.core/pull/723).
+      - inventory/k8s.py - Defer removal of k8s inventory plugin to version 6.0.0
+        (https://github.com/ansible-collections/kubernetes.core/pull/734).
+      release_summary: This release comes with documentation updates.
+    fragments:
+    - 20240530-defer-removal-and-ansible-core-support-update.yaml
+    - 20240601-doc-example-of-using-kubectl.yaml
+    - 3.2.0.yml
+    - inventory-update_removal_date.yml
+    release_date: '2024-06-14'
+  3.3.0:
+    changes:
+      bugfixes:
+      - helm - Helm version checks did not support RC versions. They now accept any
+        version tags. (https://github.com/ansible-collections/kubernetes.core/pull/745).
+      - helm_pull - Apply no_log=True to pass_credentials to silence false positive
+        warning. (https://github.com/ansible-collections/kubernetes.core/pull/796).
+      - k8s_drain - Fix k8s_drain does not wait for single pod (https://github.com/ansible-collections/kubernetes.core/issues/769).
+      - k8s_drain - Fix k8s_drain runs into a timeout when evicting a pod which is
+        part of a stateful set  (https://github.com/ansible-collections/kubernetes.core/issues/792).
+      - kubeconfig option should not appear in module invocation log (https://github.com/ansible-collections/kubernetes.core/issues/782).
+      - kustomize - kustomize plugin fails with deprecation warnings (https://github.com/ansible-collections/kubernetes.core/issues/639).
+      - waiter - Fix waiting for daemonset when desired number of pods is 0. (https://github.com/ansible-collections/kubernetes.core/pull/756).
+      minor_changes:
+      - k8s_drain - Improve error message for pod disruption budget when draining
+        a node (https://github.com/ansible-collections/kubernetes.core/issues/797).
+      release_summary: This release comes with improvements to the error messages
+        in the k8s_drain module and several bug fixes.
+    fragments:
+    - 20240530-ansible-core-support-update.yaml
+    - 20240611-helm-rc-version.yaml
+    - 20240620-fix-kustomize-plugin-fails-with-deprecation-warnings.yml
+    - 20241102-fix-ci-post-2.18-issue.yaml
+    - 20241213-kubeconfig-set-no_log-true.yaml
+    - 756-fix-daemonset-waiting.yaml
+    - 770-fix-k8s-drain-doesnt-wait-for-single-pod.yaml
+    - 793-fix-k8s-drain-runs-into-timeout.yaml
+    - 796-false-positive-helmull.yaml
+    - 798-drain-pdb-error-message.yaml
+    - readme_template_update.yml
+    release_date: '2025-01-20'
   4.0.0:
     changes:
       bugfixes:
@@ -901,6 +947,8 @@ releases:
       breaking_changes:
       - Remove support for ``ansible-core<2.15`` (https://github.com/ansible-collections/kubernetes.core/pull/737).
       minor_changes:
+      - connection/kubectl.py - Added an example of using the kubectl connection plugin
+        to the documentation (https://github.com/ansible-collections/kubernetes.core/pull/741).
       - inventory/k8s.py - Defer removal of k8s inventory plugin to version 6.0.0
         (https://github.com/ansible-collections/kubernetes.core/pull/734).
       release_summary: This major release drops support for ``ansible-core<2.15``.
@@ -909,3 +957,46 @@ releases:
     - 20240530-defer-removal-and-ansible-core-support-update.yaml
     - 5.0.0.yml
     release_date: '2024-05-31'
+  5.1.0:
+    changes:
+      bugfixes:
+      - helm - Helm version checks did not support RC versions. They now accept any
+        version tags. (https://github.com/ansible-collections/kubernetes.core/pull/745).
+      - helm_pull - Apply no_log=True to pass_credentials to silence false positive
+        warning. (https://github.com/ansible-collections/kubernetes.core/pull/796).
+      - k8s_drain - Fix k8s_drain does not wait for single pod (https://github.com/ansible-collections/kubernetes.core/issues/769).
+      - k8s_drain - Fix k8s_drain runs into a timeout when evicting a pod which is
+        part of a stateful set  (https://github.com/ansible-collections/kubernetes.core/issues/792).
+      - kubeconfig option should not appear in module invocation log (https://github.com/ansible-collections/kubernetes.core/issues/782).
+      - kustomize - kustomize plugin fails with deprecation warnings (https://github.com/ansible-collections/kubernetes.core/issues/639).
+      - waiter - Fix waiting for daemonset when desired number of pods is 0. (https://github.com/ansible-collections/kubernetes.core/pull/756).
+      minor_changes:
+      - Bump version of ansible-lint to minimum 24.7.0 (https://github.com/ansible-collections/kubernetes.core/pull/765).
+      - Parameter insecure_registry added to helm_template as equivalent of insecure-skip-tls-verify
+        (https://github.com/ansible-collections/kubernetes.core/pull/805).
+      - k8s_drain - Improve error message for pod disruption budget when draining
+        a node (https://github.com/ansible-collections/kubernetes.core/issues/797).
+      release_summary: This release came with new module ``helm_registry_auth``, improvements
+        to the error messages in the k8s_drain module, new parameter ``insecure_registry``
+        for ``helm_template`` module and several bug fixes.
+    fragments:
+    - 0-readme.yml
+    - 20240601-doc-example-of-using-kubectl.yaml
+    - 20240611-helm-rc-version.yaml
+    - 20240620-fix-kustomize-plugin-fails-with-deprecation-warnings.yml
+    - 20241102-fix-ci-post-2.18-issue.yaml
+    - 20241103-completly-remove-obsolate-communication-channel.yaml
+    - 20241207-add-insecure-skip-tls-verify-to-helm-template.yaml
+    - 20241213-kubeconfig-set-no_log-true.yaml
+    - 756-fix-daemonset-waiting.yaml
+    - 765-bump-ansible-lint-version.yml
+    - 770-fix-k8s-drain-doesnt-wait-for-single-pod.yaml
+    - 793-fix-k8s-drain-runs-into-timeout.yaml
+    - 796-false-positive-helmull.yaml
+    - 798-drain-pdb-error-message.yaml
+    - readme_template_update.yml
+    modules:
+    - description: Helm registry authentication module
+      name: helm_registry_auth
+      namespace: ''
+    release_date: '2025-01-20'

--- a/changelogs/fragments/0-readme.yml
+++ b/changelogs/fragments/0-readme.yml
@@ -1,3 +1,0 @@
----
-trivial:
-  - README.md - Add Communication section with Forum information.

--- a/changelogs/fragments/20240611-helm-rc-version.yaml
+++ b/changelogs/fragments/20240611-helm-rc-version.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-  - helm - Helm version checks did not support RC versions. They now accept any version tags. (https://github.com/ansible-collections/kubernetes.core/pull/745).

--- a/changelogs/fragments/20240620-fix-kustomize-plugin-fails-with-deprecation-warnings.yml
+++ b/changelogs/fragments/20240620-fix-kustomize-plugin-fails-with-deprecation-warnings.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - kustomize - kustomize plugin fails with deprecation warnings (https://github.com/ansible-collections/kubernetes.core/issues/639).

--- a/changelogs/fragments/20241102-fix-ci-post-2.18-issue.yaml
+++ b/changelogs/fragments/20241102-fix-ci-post-2.18-issue.yaml
@@ -1,3 +1,0 @@
----
-trivial:
-  - Fix GitHub actions issue related to switch milestone and devel branches of ansible to 2.19 (https://github.com/ansible-collections/kubernetes.core/pull/789)

--- a/changelogs/fragments/20241103-completly-remove-obsolate-communication-channel.yaml
+++ b/changelogs/fragments/20241103-completly-remove-obsolate-communication-channel.yaml
@@ -1,3 +1,0 @@
----
-trivial:
-  - README.md - Remove obsolate communication channels (https://github.com/ansible-collections/kubernetes.core/pull/790).

--- a/changelogs/fragments/20241207-add-insecure-skip-tls-verify-to-helm-template.yaml
+++ b/changelogs/fragments/20241207-add-insecure-skip-tls-verify-to-helm-template.yaml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - Parameter insecure_registry added to helm_template as equivalent of insecure-skip-tls-verify (https://github.com/ansible-collections/kubernetes.core/pull/805).

--- a/changelogs/fragments/20241213-kubeconfig-set-no_log-true.yaml
+++ b/changelogs/fragments/20241213-kubeconfig-set-no_log-true.yaml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - kubeconfig option should not appear in module invocation log (https://github.com/ansible-collections/kubernetes.core/issues/782).

--- a/changelogs/fragments/756-fix-daemonset-waiting.yaml
+++ b/changelogs/fragments/756-fix-daemonset-waiting.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-  - waiter - Fix waiting for daemonset when desired number of pods is 0. (https://github.com/ansible-collections/kubernetes.core/pull/756).

--- a/changelogs/fragments/765-bump-ansible-lint-version.yml
+++ b/changelogs/fragments/765-bump-ansible-lint-version.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - Bump version of ansible-lint to minimum 24.7.0 (https://github.com/ansible-collections/kubernetes.core/pull/765).

--- a/changelogs/fragments/770-fix-k8s-drain-doesnt-wait-for-single-pod.yaml
+++ b/changelogs/fragments/770-fix-k8s-drain-doesnt-wait-for-single-pod.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-  - k8s_drain - Fix k8s_drain does not wait for single pod (https://github.com/ansible-collections/kubernetes.core/issues/769).

--- a/changelogs/fragments/793-fix-k8s-drain-runs-into-timeout.yaml
+++ b/changelogs/fragments/793-fix-k8s-drain-runs-into-timeout.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-  - k8s_drain - Fix k8s_drain runs into a timeout when evicting a pod which is part of a stateful set  (https://github.com/ansible-collections/kubernetes.core/issues/792).

--- a/changelogs/fragments/796-false-positive-helmull.yaml
+++ b/changelogs/fragments/796-false-positive-helmull.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-  - helm_pull - Apply no_log=True to pass_credentials to silence false positive warning.. (https://github.com/ansible-collections/kubernetes.core/pull/796).

--- a/changelogs/fragments/798-drain-pdb-error-message.yaml
+++ b/changelogs/fragments/798-drain-pdb-error-message.yaml
@@ -1,2 +1,0 @@
-minor_changes:
-  - k8s_drain - Improve error message for pod disruption budget when draining a node (https://github.com/ansible-collections/kubernetes.core/issues/797).

--- a/changelogs/fragments/readme_template_update.yml
+++ b/changelogs/fragments/readme_template_update.yml
@@ -1,3 +1,0 @@
----
-trivial:
-  - Update the README doc to match https://access.redhat.com/articles/7068606.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -25,7 +25,7 @@ tags:
   - openshift
   - okd
   - cluster
-version: 6.0.0-dev0
+version: 5.2.0-dev0
 build_ignore:
   - .DS_Store
   - "*.tar.gz"

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -25,7 +25,7 @@ tags:
   - openshift
   - okd
   - cluster
-version: 5.0.0
+version: 5.2.0-dev0
 build_ignore:
   - .DS_Store
   - "*.tar.gz"

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -25,7 +25,7 @@ tags:
   - openshift
   - okd
   - cluster
-version: 5.2.0-dev0
+version: 6.0.0-dev0
 build_ignore:
   - .DS_Store
   - "*.tar.gz"


### PR DESCRIPTION
##### SUMMARY
This is a post-5.1.0 documentation update of the `main` branch that includes a cherry-pic of the changelog and an update version to `5.2.0-dev0`. 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- changelog
- galaxy.yml

##### ADDITIONAL INFORMATION

The reason for this version bump is to understand of version when the collection is installed as `ansible-galaxy collection install git+https://github.com/ansible-collections/kubernetes.core.git` and don't mess up the `main` (that may contain some PRs that is not included to any released version) with the released version 5.1.0. 
