### PR TITLE
updating helm version regex for more support

### DIFF
--- a/plugins/module_utils/helm.py
+++ b/plugins/module_utils/helm.py
@@ -185,7 +185,7 @@ class AnsibleHelmModule(object):
     def get_helm_version(self):
         command = self.get_helm_binary() + " version"
         rc, out, err = self.run_command(command)
-        m = re.match(r'version.BuildInfo{Version:"v(.*?)",', out)
+        m = re.match(r'version.BuildInfo{Version:"v?(.*?)",', out)
         if m:
             return m.group(1)
         m = re.match(r'Client: &version.Version{SemVer:"v(.*?)", ', out)


### PR DESCRIPTION
##### SUMMARY
Not all versions of helm output their version info with the format:

```
version.BuildInfo{Version:"vX.X.X", ....}
```

some (specifically 3.16.4) use:

```
version.BuildInfo{Version:"X.X.X", ....}
```

This causes this function to return `None`, instead of the version string. I've update the regex to support either format.


##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME

This is an update to `plugins/module_utils/helm.py`

##### ADDITIONAL INFORMATION

When using the output of `get_helm_version` to create a `LooseVersion`:

https://github.com/ansible-collections/kubernetes.core/blob/main/plugins/module_utils/_version.py#L306

If the version does not match the regex, `None` will be returned, but the object will still be created. 

If the object is then compared with a pinned version, like in this example:

https://github.com/ansible-collections/kubernetes.core/blob/main/plugins/modules/helm.py#L808

without verifying the "version" attribute exists (ie verifying `get_helm_version` returned a string), the program will crash.

`LooseVersion` could also be updated to throw an error when None is passed to its constructor and/or `get_helm_version` could be updated to throw an error when the program can't regex for the system version.

