### PR TITLE
Cherry-pick to stable-3: Fix linters in CI (#873)

### DIFF
--- a/.ansible-lint-ignore
+++ b/.ansible-lint-ignore
@@ -1,0 +1,5 @@
+# https://docs.ansible.com/ansible-lint/docs/rules/
+# no-changed-when is not requried for examples
+plugins/connection/kubectl.py no-changed-when
+# false positive result
+plugins/connection/kubectl.py var-naming[no-reserved]

--- a/.ansible-lint-ignore
+++ b/.ansible-lint-ignore
@@ -3,3 +3,5 @@
 plugins/connection/kubectl.py no-changed-when
 # false positive result
 plugins/connection/kubectl.py var-naming[no-reserved]
+# stable-3 branch support ansible-core>=2.14.0
+meta/runtime.yml meta-runtime[unsupported-version]

--- a/.config/ansible-lint-ignore.txt
+++ b/.config/ansible-lint-ignore.txt
@@ -1,3 +1,0 @@
-# no-changed-when is not requried for examples
-plugins/connection/kubectl.py no-changed-when
-meta/runtime.yml meta-runtime[unsupported-version]

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ changelogs/.plugin-cache.yaml
 tests/output
 tests/integration/cloud-config-*
 .cache
+.ansible
 
 # Helm charts
 tests/integration/*-chart-*.tgz

--- a/.yamllint
+++ b/.yamllint
@@ -5,16 +5,24 @@ rules:
   braces:
     max-spaces-inside: 1
     level: error
+
   brackets:
     max-spaces-inside: 1
     level: error
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: false
   document-start: disable
   line-length: disable
   truthy: disable
   indentation:
     spaces: 2
     indent-sequences: consistent
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true
 ignore: |
   .cache
   .tox
+  .ansible
   tests/output

--- a/tests/integration/targets/k8s_manifest_url/tasks/main.yml
+++ b/tests/integration/targets/k8s_manifest_url/tasks/main.yml
@@ -23,7 +23,7 @@
         - name: Update directory permissions
           file:
             path: "{{ manifests_dir.path }}"
-            mode: 0755
+            mode: '0755'
 
         - name: Create manifests files
           copy:

--- a/tests/integration/targets/lookup_kustomize/tasks/main.yml
+++ b/tests/integration/targets/lookup_kustomize/tasks/main.yml
@@ -45,7 +45,7 @@
     - name: make script as executable
       file:
         path: "{{ tmp_dir_path }}/install_kustomize.sh"
-        mode: 0755
+        mode: '0755'
 
     - name: Install kustomize
       command: "{{ tmp_dir_path }}/install_kustomize.sh"


### PR DESCRIPTION
SUMMARY
It seems that recent updates in linters break CI. Closes #874 ISSUE TYPE

Bugfix Pull Request

COMPONENT NAME
CI
ADDITIONAL INFORMATION

It's cherry-pick #873 to stable-3 as patch bot failed

Reviewed-by: Mike Graves <mgraves@redhat.com>
Reviewed-by: Yuriy Novostavskiy
