### PR TITLE
Add api_versions to helm_template

### DIFF
--- a/docs/kubernetes.core.helm_template_module.rst
+++ b/docs/kubernetes.core.helm_template_module.rst
@@ -35,6 +35,23 @@ Parameters
             <tr>
                 <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>api_versions</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=string</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">[]</div>
+                </td>
+                <td>
+                        <div>Additional Kubernetes API versions used for Capabilities.APIVersions</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>binary_path</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/plugins/modules/helm_template.py
+++ b/plugins/modules/helm_template.py
@@ -22,6 +22,13 @@ description:
   - Render chart templates to an output directory or as text of concatenated yaml documents.
 
 options:
+  api_versions:
+    description:
+      - Additional Kubernetes API versions used for Capabilities.APIVersions
+    required: false
+    type: list
+    elements: str
+    default: []
   binary_path:
     description:
       - The path of a helm binary to use.
@@ -236,6 +243,7 @@ def template(
     values_files=None,
     include_crds=False,
     set_values=None,
+    api_versions=None,
 ):
     cmd += " template "
 
@@ -285,6 +293,10 @@ def template(
     if set_values:
         cmd += " " + set_values
 
+    if api_versions:
+        for api_version in api_versions:
+            cmd += " --api-versions " + api_version
+
     return cmd
 
 
@@ -307,6 +319,7 @@ def main():
             values_files=dict(type="list", default=[], elements="str"),
             update_repo_cache=dict(type="bool", default=False),
             set_values=dict(type="list", elements="dict"),
+            api_versions=dict(type="list", default=[], elements="str")
         ),
         supports_check_mode=True,
     )
@@ -327,6 +340,7 @@ def main():
     values_files = module.params.get("values_files")
     update_repo_cache = module.params.get("update_repo_cache")
     set_values = module.params.get("set_values")
+    api_versions = module.params.get("api_versions")
 
     if not IMP_YAML:
         module.fail_json(msg=missing_required_lib("yaml"), exception=IMP_YAML_ERR)
@@ -357,6 +371,7 @@ def main():
         values_files=values_files,
         include_crds=include_crds,
         set_values=set_values_args,
+        api_versions=api_versions,
     )
 
     if not check_mode:

--- a/tests/unit/modules/test_helm_template.py
+++ b/tests/unit/modules/test_helm_template.py
@@ -170,3 +170,31 @@ def test_template_with_disablehook():
     args, unknown = parser.parse_known_args(mytemplate.split())
 
     assert args.no_hooks is True
+
+
+def test_template_with_api_versions():
+    my_chart_ref = "testref"
+    helm_cmd = "helm"
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("cmd")
+    parser.add_argument("template")
+    # to "simulate" helm template options, include two optional parameters NAME and CHART.
+    # if parsed string contains only one parameter, the value will be passed
+    # to CHART and NAME will be set to default value "release-name" as in helm template
+    parser.add_argument("NAME", nargs="?", default="release-name")
+    parser.add_argument("CHART", nargs="+")
+    parser.add_argument("--api-versions", action="append")
+
+    service_monitor_api_version = "monitoring.coreos.com/v1/ServiceMonitor"
+    openshift_project_api_version = "project.openshift.io/v1/Project"
+    api_versions = [service_monitor_api_version, openshift_project_api_version]
+
+    mytemplate = template(
+        cmd=helm_cmd, chart_ref=my_chart_ref, api_versions=api_versions
+    )
+
+    args, unknown = parser.parse_known_args(mytemplate.split())
+    assert len(args.api_versions) == 2
+    assert args.api_versions[0] == service_monitor_api_version
+    assert args.api_versions[1] == openshift_project_api_version


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Allows passing of additional Kubernetes API versions to `helm template` such that chart templates that are gated on `Capabilities.APIVersions` having e.g. CRDs can render those templates rather than them being blank.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

helm_template
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Inspired by https://github.com/ansible-collections/kubernetes.core/pull/587#issuecomment-1720319382

Setup:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
$ cat helm_template_test/Chart.yaml 
apiVersion: 2
name: ansible-test
version: 0.0.0-dev

$ cat helm_template_test/templates/capabilities.yaml 
{{- if $.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor" }}
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: {{ $.Release.Name }}-haproxy
  namespace: {{ $.Release.Namespace }}
spec:
  endpoints:
  - interval: 30s
    port: haproxy-metrics
  selector:
    matchLabels:
      app.kubernetes.io/instance: haproxy
{{- end }}
```

Before:
```
$ cat helm_template_test.yaml 
---
- hosts: localhost
  connection: local
  tasks:
  - kubernetes.core.helm_template:
      release_name: ansible-test
      release_namespace: ansible
      chart_ref: helm_template_test
    register: helm_templates

  - debug:
      msg: "{{ helm_templates.stdout }}"

$ ansible-playbook helm_template_test.yaml    
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [localhost] *********************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] ***************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [kubernetes.core.helm_template] *************************************************************************************************************************************************************************************************
changed: [localhost]

TASK [debug] *************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "\n"
}

PLAY RECAP ***************************************************************************************************************************************************************************************************************************
localhost                  : ok=3    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0  
```

After:
```
$ cat helm_template_test.yaml 
---
- hosts: localhost
  connection: local
  tasks:
  - kubernetes.core.helm_template:
      release_name: ansible-test
      release_namespace: ansible
      chart_ref: helm_template_test
      api_versions:
      - monitoring.coreos.com/v1/ServiceMonitor
    register: helm_templates

  - debug:
      msg: "{{ helm_templates.stdout }}"

$ ansible-playbook helm_template_test.yaml
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [localhost] *********************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] ***************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [kubernetes.core.helm_template] *************************************************************************************************************************************************************************************************
changed: [localhost]

TASK [debug] *************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "---\n# Source: ansible-test/templates/capabilities.yaml\napiVersion: monitoring.coreos.com/v1\nkind: ServiceMonitor\nmetadata:\n  name: ansible-test-haproxy\n  namespace: ansible\nspec:\n  endpoints:\n  - interval: 30s\n    port: haproxy-metrics\n  selector:\n    matchLabels:\n      app.kubernetes.io/instance: haproxy\n"
}

PLAY RECAP ***************************************************************************************************************************************************************************************************************************
localhost                  : ok=3    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```