### PR TITLE
Added create_only param to ignore existing objects

### DIFF
--- a/plugins/module_utils/k8s/runner.py
+++ b/plugins/module_utils/k8s/runner.py
@@ -175,6 +175,10 @@ def perform_action(svc, definition: Dict, params: Dict) -> Dict:
         if params.get("apply"):
             instance, warnings = svc.apply(resource, definition, existing)
             result["method"] = "apply"
+        elif existing and params.get("create_only", False):
+            instance = existing.to_dict()
+            result["changed"] = False
+            result["method"] = "create"
         elif not existing:
             if state == "patched":
                 result.setdefault("warnings", []).append(

--- a/plugins/modules/k8s.py
+++ b/plugins/modules/k8s.py
@@ -52,6 +52,11 @@ options:
     - If set to C(yes), and I(state) is C(present), an existing object will be replaced.
     type: bool
     default: no
+  create_only:
+    description:
+    - If set to C(yes), an object will be created if it doesn't exist, no objects will be updated.
+    type: bool
+    default: no
   merge_type:
     description:
     - Whether to override the default patch merge approach with a specific type. By default, the strategic
@@ -229,6 +234,19 @@ EXAMPLES = r"""
           targetPort: 8000
           name: port-8000-tcp
           port: 8000
+
+- name: Create a Secret but do not update existing
+  kubernetes.core.k8s:
+    state: present
+    create_only: yes
+    definition:
+      kind: Secret
+      metadata:
+        name: passwords
+        namespace: testing
+      data:
+        admin: "{{ lookup('community.general.random_string', length=12, base64=true) }}"
+        database: "{{ lookup('community.general.random_string', length=12, base64=true) }}"
 
 - name: Remove an existing Service object
   kubernetes.core.k8s:
@@ -473,6 +491,7 @@ def argspec():
         default="present", choices=["present", "absent", "patched"]
     )
     argument_spec["force"] = dict(type="bool", default=False)
+    argument_spec["create_only"] = dict(type="bool", default=False)
     argument_spec["label_selectors"] = dict(type="list", elements="str")
     argument_spec["generate_name"] = dict()
     argument_spec["server_side_apply"] = dict(

--- a/tests/unit/module_utils/test_runner.py
+++ b/tests/unit/module_utils/test_runner.py
@@ -167,6 +167,20 @@ modified_def["metadata"]["labels"]["environment"] = "testing"
             (definition, []),
             {"changed": True, "method": "create", "result": definition},
         ),
+        (
+            "create",
+            {"create_only": True},
+            modified_def,
+            (modified_def, []),
+            {"changed": False, "method": "create", "result": modified_def},
+        ),
+        (
+            "create",
+            {"create_only": True},
+            {},
+            (definition, []),
+            {"changed": True, "method": "create", "result": definition},
+        ),
     ],
 )
 def test_perform_action(action, params, existing, instance_warnings, expected):


### PR DESCRIPTION
##### SUMMARY
Instead of checking for existing resources before creating a new resource to avoid modifying it each time e.g.

```
k8s_info:
  kind: Secret
  name: my-auto-generated-psk
  namespace: project-1
register: existing_secret

k8s:
  state: present
  definition:
    kind: Secret
    metadata:
      name: my-auto-generated-psk
      namespace: project-1
    data:
      admin: "{{ lookup('community.general.random_string', length=15, base64=true) }}"
when: existing_secret.resources == []
register: new_secret

set_fact:
  # check for existing and new resource, consolidate into one fact for later use
  admin_psk: "{{ (existing_secret.resources | default([new_secret.result])) | first }}"
```


This new `create_only` param reduces this to a single task

```
k8s:
  state: present
  create_only: true
  definition:
    kind: Secret
    metadata:
      name: my-auto-generated-psk
      namespace: project-1
    data:
      admin: "{{ lookup('community.general.random_string', length=15, base64=true) }}"
register: admin_psk
```

Otherwise this task would recreate the secret's data each time. This is especially useful with `register` as the original resource can be used in subsequent tasks without checking for existing or new. It is also beneficial in ansible operators.


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
k8s create_only param

##### ADDITIONAL INFORMATION
A couple of unit test cases added