### PR TITLE
docs: add until example to k8s_info

### DIFF
--- a/docs/kubernetes.core.k8s_info_module.rst
+++ b/docs/kubernetes.core.k8s_info_module.rst
@@ -701,6 +701,21 @@ Examples
         wait_sleep: 10
         wait_timeout: 360
 
+    - name: Wait for OpenShift bootstrap to complete
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: ConfigMap
+        name: bootstrap
+        namespace: kube-system
+      register: ocp_bootstrap_status
+      until: >
+        ocp_bootstrap_status.resources is defined and
+        (ocp_bootstrap_status.resources | length > 0) and
+        (ocp_bootstrap_status.resources[0].data.status is defined) and
+        (ocp_bootstrap_status.resources[0].data.status == 'complete')
+      retries: 60
+      delay: 15
+
 
 
 Return Values

--- a/plugins/modules/k8s_info.py
+++ b/plugins/modules/k8s_info.py
@@ -120,6 +120,21 @@ EXAMPLES = r"""
     namespace: default
     wait_sleep: 10
     wait_timeout: 360
+
+- name: Wait for OpenShift bootstrap to complete
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: ConfigMap
+    name: bootstrap
+    namespace: kube-system
+  register: ocp_bootstrap_status
+  until: >
+    ocp_bootstrap_status.resources is defined and
+    (ocp_bootstrap_status.resources | length > 0) and
+    (ocp_bootstrap_status.resources[0].data.status is defined) and
+    (ocp_bootstrap_status.resources[0].data.status == 'complete')
+  retries: 60
+  delay: 15
 """
 
 RETURN = r"""


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

I would liked to have an example like this when I was using the documentation.

The concrete example helps you to check when the OpenShift bootstrap process is done.  Instead of running the command `openshift-install wait-for bootstrap-complete`, we use the Ansible way of using a module.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

- `kubernetes.core.k8s_info`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
N/A.
```
