### PR TITLE
Revert "Remove kubeconfig value from module invocation log (#826)"

### DIFF
--- a/changelogs/fragments/20250411-kubeconfig-no_log-revert.yaml
+++ b/changelogs/fragments/20250411-kubeconfig-no_log-revert.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - kubeconfig option should return the full manifest output (https://github.com/ansible-collections/kubernetes.core/issues/870).

--- a/plugins/module_utils/args_common.py
+++ b/plugins/module_utils/args_common.py
@@ -18,7 +18,7 @@ AUTH_PROXY_HEADERS_SPEC = dict(
 )
 
 AUTH_ARG_SPEC = {
-    "kubeconfig": {"type": "raw", "no_log": True},
+    "kubeconfig": {"type": "raw"},
     "context": {},
     "host": {},
     "api_key": {"no_log": True},

--- a/plugins/module_utils/helm_args_common.py
+++ b/plugins/module_utils/helm_args_common.py
@@ -16,7 +16,6 @@ HELM_AUTH_ARG_SPEC = dict(
         type="raw",
         aliases=["kubeconfig_path"],
         fallback=(env_fallback, ["K8S_AUTH_KUBECONFIG"]),
-        no_log=True,
     ),
     host=dict(type="str", fallback=(env_fallback, ["K8S_AUTH_HOST"])),
     ca_cert=dict(


### PR DESCRIPTION
This reverts commit 6efabd3418cbee9b96430d8374bf16738e48b04e.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #870
A better solution is necessary to address #782. The current code makes getting manifests practically unusable. We need to revert this commit until a better solution is found.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
kubeconfig

