### PR TITLE
[PR #903/d4fc22c7 backport][stable-3] Bugfix: fix unit-source for pre-release of ansible-core 2.20 (devel and milestone branch)

### DIFF
--- a/tests/unit/module_utils/test_core.py
+++ b/tests/unit/module_utils/test_core.py
@@ -44,8 +44,8 @@ def test_warn_on_k8s_version(monkeypatch, stdin, capfd):
     assert return_value.get("warnings") is not None
     warnings = return_value["warnings"]
     assert len(warnings) == 1
-    assert "kubernetes" in warnings[0]
-    assert MINIMAL_K8S_VERSION in warnings[0]
+    assert "kubernetes" in str(warnings[0])
+    assert MINIMAL_K8S_VERSION in str(warnings[0])
 
 
 dependencies = [


### PR DESCRIPTION
**This is a backport of PR #903 as merged into main (d4fc22c74e9c90ecfc4313166fb678734b794244).**

##### SUMMARY
CI fix for #904 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests/unit

##### ADDITIONAL INFORMATION
