### PR TITLE
Ensure integration tests are ok with ansible-core 2.19

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -56,6 +56,7 @@ jobs:
       matrix:
         ansible-version:
           - milestone
+          - devel
         python-version:
           - "3.12"
         enable-turbo-mode:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Closes #914 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Ensure the integration tests suite are running successfully with `ansible-core 2.19`