### PR TITLE
Update README to remove information about backports

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,8 +248,6 @@ The process for uploading a supported release to Automation Hub is documented se
 <!--List available communication channels. In addition to channels specific to your collection, we also recommend to use the following ones.-->
 
 > **Note:** The `stable-4` branch, which handles all `4.x.y` releases of this collection, is no longer supported. This means that no backports nor releases will be performed on the `stable-4` branch.
->
-> All new features and bugfixes will be included in `stable-5` and `stable-6` branches (versions `5.x.y` and `6.x.y`, respectively), and only bugfixes will be backported to `stable-3` (which handles `3.x.y` releases).
 
 We announce releases and important changes through Ansible's [The Bullhorn newsletter](https://github.com/ansible/community/wiki/News#the-bullhorn). Be sure you are [subscribed](https://eepurl.com/gZmiEP).
 


### PR DESCRIPTION
Per [this comment](https://github.com/ansible-collections/kubernetes.core/pull/926#issuecomment-2881255303), I am removing information about backports that were added in https://github.com/ansible-collections/kubernetes.core/pull/926; per the [Cloud Content Handbook page on backports](https://github.com/ansible-collections/cloud-content-handbook/blob/main/backport_changes.md#when-to-backport), we will only be backporting to the two latest versions, and since mentioning specific branches and versions in this collection's README in this manner will add to future maintenance/upkeep burden, I opted to remove this line entirely.

I will be creating a separate PR to manually backport the new README information to `stable-5`.
