### PR TITLE
[Manual Backport][stable-5] Update `README`  to communicate that `stable-4` is no longer supported #926

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For more information about communication, see the [Ansible communication guide](
 ## Requirements
 
 <!--start requires_ansible-->
-## Ansible version compatibility
+## Ansible Version Compatibility
 
 This collection has been tested against following Ansible versions: **>=2.15.0**.
 
@@ -42,27 +42,27 @@ Note: Python2 is deprecated from [1st January 2020](https://www.python.org/doc/s
 
 This collection supports Kubernetes versions >= 1.24.
 
-### Included content
+### Included Content
 
 Click on the name of a plugin or module to view that content's documentation:
 
 <!--start collection content-->
-### Connection plugins
+### Connection Plugins
 Name | Description
 --- | ---
 [kubernetes.core.kubectl](https://github.com/ansible-collections/kubernetes.core/blob/main/docs/kubernetes.core.kubectl_connection.rst)|Execute tasks in pods running on Kubernetes.
 
-### K8s filter plugins
+### K8s filter Plugins
 Name | Description
 --- | ---
 kubernetes.core.k8s_config_resource_name|Generate resource name for the given resource of type ConfigMap, Secret
 
-### Inventory plugins
+### Inventory Plugins
 Name | Description
 --- | ---
 [kubernetes.core.k8s](https://github.com/ansible-collections/kubernetes.core/blob/main/docs/kubernetes.core.k8s_inventory.rst)|Kubernetes (K8s) inventory source
 
-### Lookup plugins
+### Lookup Plugins
 Name | Description
 --- | ---
 [kubernetes.core.k8s](https://github.com/ansible-collections/kubernetes.core/blob/main/docs/kubernetes.core.k8s_lookup.rst)|Query the K8s API
@@ -183,7 +183,7 @@ If upgrading older playbooks which were built prior to Ansible 2.10 and this col
 
 For documentation on how to use individual modules and other content included in this collection, please see the links in the 'Included content' section earlier in this README.
 
-## Ansible Turbo mode Tech Preview
+## Ansible Turbo Mode Tech Preview
 
 
 The ``kubernetes.core`` collection supports Ansible Turbo mode as a tech preview via the ``cloud.common`` collection. By default, this feature is disabled. To enable Turbo mode for modules, set the environment variable `ENABLE_TURBO_MODE=1` on the managed node. For example:
@@ -202,7 +202,7 @@ defined in the playbook using `environment` keyword as above, you must set it us
 
 Please read more about Ansible Turbo mode - [here](https://github.com/ansible-collections/kubernetes.core/blob/main/docs/ansible_turbo_mode.rst).
 
-## Contributing to this collection
+## Contributing to this Collection
 
 If you want to develop new content for this collection or improve what's already here, the easiest way to work on the collection is to clone it into one of the configured [`COLLECTIONS_PATHS`](https://docs.ansible.com/ansible/latest/reference_appendices/config.html#collections-paths), and work on it there.
 
@@ -252,6 +252,8 @@ The process for uploading a supported release to Automation Hub is documented se
 
 <!--List available communication channels. In addition to channels specific to your collection, we also recommend to use the following ones.-->
 
+> **Note:** The `stable-4` branch, which handles all `4.x.y` releases of this collection, is no longer supported. This means that no backports nor releases will be performed on the `stable-4` branch.
+
 We announce releases and important changes through Ansible's [The Bullhorn newsletter](https://github.com/ansible/community/wiki/News#the-bullhorn). Be sure you are [subscribed](https://eepurl.com/gZmiEP).
 
 We take part in the global quarterly [Ansible Contributor Summit](https://github.com/ansible/community/wiki/Contributor-Summit) virtually or in-person. Track [The Bullhorn newsletter](https://eepurl.com/gZmiEP) and join us.
@@ -263,7 +265,7 @@ For the latest supported versions, refer to the release notes below.
 If you encounter issues or have questions, you can submit a support request through the following channels:
  - GitHub Issues: Report bugs, request features, or ask questions by opening an issue in the [GitHub repository]((https://github.com/ansible-collections/kubernetes.core/).
 
-## Release notes
+## Release Notes
 
 See the [raw generated changelog](https://github.com/ansible-collections/kubernetes.core/blob/main/CHANGELOG.rst).
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Resolves [ACA-2383](https://issues.redhat.com/browse/ACA-2383) and #918.

Adjusting the changes made in #926 per #930.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
[README.md](https://github.com/ansible-collections/kubernetes.core/blob/main/README.md)

##### ADDITIONAL INFORMATION
Also made some minor capitalization edits.