### PR TITLE
Add automatic labeling for new triage issues

### DIFF
--- a/.github/workflows/label-new-issues.yaml
+++ b/.github/workflows/label-new-issues.yaml
@@ -1,0 +1,18 @@
+---
+name: label new issues
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+
+jobs:
+  add_label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+    steps:
+      - uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: needs_triage


### PR DESCRIPTION
##### SUMMARY
Copied automation script for tagging new issues from the main AWS collection.

See [2231](https://issues.redhat.com/browse/ACA-2231)!
```
