### PR TITLE
Update `dev` version to `7.0.0-dev0` after `6.0.0` release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Also needs to be updated in galaxy.yml
-VERSION = 6.0.0-dev0
+VERSION = 7.0.0-dev0
 
 TEST_ARGS ?= ""
 PYTHON_VERSION ?= `python -c 'import platform; print(".".join(platform.python_version_tuple()[0:2]))'`

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -25,7 +25,7 @@ tags:
   - openshift
   - okd
   - cluster
-version: 6.0.0-dev0
+version: 7.0.0-dev0
 build_ignore:
   - .DS_Store
   - "*.tar.gz"


### PR DESCRIPTION
##### SUMMARY
Updating the `dev` version listed in `Makefile` and `galaxy.yml` since [6.0.0](https://github.com/ansible-collections/kubernetes.core/pull/933) has been released.