### PR TITLE
Fix the integration test for helm_registry_auth with helm >= 3.18.0 and clarify idempotency.

### DIFF
--- a/changelogs/fragments/20250605-fix-helm_registry_auth-integration_test.yaml
+++ b/changelogs/fragments/20250605-fix-helm_registry_auth-integration_test.yaml
@@ -1,2 +1,2 @@
-minor:
+minor_changes:
   - Module helm_registry_auth do not support idempotency with `helm >= 2.18.0` (https://github.com/ansible-collections/kubernetes.core/pull/946)

--- a/changelogs/fragments/20250605-fix-helm_registry_auth-integration_test.yaml
+++ b/changelogs/fragments/20250605-fix-helm_registry_auth-integration_test.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - Module helm_registry_auth do not support idempotency with `helm >= 2.18.0` (https://github.com/ansible-collections/kubernetes.core/pull/946)
+  - Module helm_registry_auth do not support idempotency with `helm >= 3.18.0` (https://github.com/ansible-collections/kubernetes.core/pull/946)

--- a/changelogs/fragments/20250605-fix-helm_registry_auth-integration_test.yaml
+++ b/changelogs/fragments/20250605-fix-helm_registry_auth-integration_test.yaml
@@ -1,0 +1,2 @@
+minor:
+  - Module helm_registry_auth do not support idempotency with `helm >= 2.18.0` (https://github.com/ansible-collections/kubernetes.core/pull/946)

--- a/docs/kubernetes.core.helm_registry_auth_module.rst
+++ b/docs/kubernetes.core.helm_registry_auth_module.rst
@@ -170,6 +170,7 @@ Parameters
                         <div>Desired state of the registry.</div>
                         <div>If set to V(present) attempt to log in to the remote registry server using the URL specified in O(host).</div>
                         <div>If set to V(absent) attempt to log out from the remote registry server using the URL specified in O(host).</div>
+                        <div>As helm &gt;= 2.18.0 resports sucessfull logout even if the user is not logged in, this module will report a change regardless of the current state.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/kubernetes.core.helm_registry_auth_module.rst
+++ b/docs/kubernetes.core.helm_registry_auth_module.rst
@@ -170,7 +170,7 @@ Parameters
                         <div>Desired state of the registry.</div>
                         <div>If set to V(present) attempt to log in to the remote registry server using the URL specified in O(host).</div>
                         <div>If set to V(absent) attempt to log out from the remote registry server using the URL specified in O(host).</div>
-                        <div>As helm &gt;= 2.18.0 resports sucessfull logout even if the user is not logged in, this module will report a change regardless of the current state.</div>
+                        <div>As helm &gt;= 2.18.0 reports successful logout even if the user is not logged in, this module will report a change regardless of the current state.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/kubernetes.core.helm_registry_auth_module.rst
+++ b/docs/kubernetes.core.helm_registry_auth_module.rst
@@ -170,7 +170,7 @@ Parameters
                         <div>Desired state of the registry.</div>
                         <div>If set to V(present) attempt to log in to the remote registry server using the URL specified in O(host).</div>
                         <div>If set to V(absent) attempt to log out from the remote registry server using the URL specified in O(host).</div>
-                        <div>As helm &gt;= 2.18.0 reports successful logout even if the user is not logged in, this module will report a change regardless of the current state.</div>
+                        <div>As helm &gt;= 3.18.0 reports successful logout even if the user is not logged in, this module will report a change regardless of the current state.</div>
                 </td>
             </tr>
             <tr>

--- a/plugins/modules/helm_registry_auth.py
+++ b/plugins/modules/helm_registry_auth.py
@@ -31,7 +31,7 @@ options:
       - Desired state of the registry.
       - If set to V(present) attempt to log in to the remote registry server using the URL specified in O(host).
       - If set to V(absent) attempt to log out from the remote registry server using the URL specified in O(host).
-      - As helm >= 2.18.0 resports sucessfull logout even if the user is not logged in, this module will report a change regardless of the current state.
+      - As helm >= 2.18.0 reports successful logout even if the user is not logged in, this module will report a change regardless of the current state.
     required: false
     default: present
     choices: ['present', 'absent']

--- a/plugins/modules/helm_registry_auth.py
+++ b/plugins/modules/helm_registry_auth.py
@@ -31,7 +31,7 @@ options:
       - Desired state of the registry.
       - If set to V(present) attempt to log in to the remote registry server using the URL specified in O(host).
       - If set to V(absent) attempt to log out from the remote registry server using the URL specified in O(host).
-      - As helm >= 2.18.0 reports successful logout even if the user is not logged in, this module will report a change regardless of the current state.
+      - As helm >= 3.18.0 reports successful logout even if the user is not logged in, this module will report a change regardless of the current state.
     required: false
     default: present
     choices: ['present', 'absent']

--- a/plugins/modules/helm_registry_auth.py
+++ b/plugins/modules/helm_registry_auth.py
@@ -130,6 +130,9 @@ failed:
 from ansible_collections.kubernetes.core.plugins.module_utils.helm import (
     AnsibleHelmModule,
 )
+from ansible_collections.kubernetes.core.plugins.module_utils.version import (
+    LooseVersion,
+)
 
 
 def arg_spec():
@@ -231,6 +234,13 @@ def main():
                 stderr=err,
                 command=helm_cmd,
             )
+
+    helm_version = module.get_helm_version()
+    if LooseVersion(helm_version) >= LooseVersion("3.18.0") and state == "absent":
+        # https://github.com/ansible-collections/kubernetes.core/issues/944
+        module.warn(
+            "The helm_registry_auth is not idempotent with helm >= 3.18.0, always report a change."
+        )
 
     module.exit_json(changed=changed, stdout=out, stderr=err, command=helm_cmd)
 

--- a/plugins/modules/helm_registry_auth.py
+++ b/plugins/modules/helm_registry_auth.py
@@ -31,6 +31,7 @@ options:
       - Desired state of the registry.
       - If set to V(present) attempt to log in to the remote registry server using the URL specified in O(host).
       - If set to V(absent) attempt to log out from the remote registry server using the URL specified in O(host).
+      - As helm >= 2.18.0 resports sucessfull logout even if the user is not logged in, this module will report a change regardless of the current state.
     required: false
     default: present
     choices: ['present', 'absent']

--- a/tests/integration/targets/helm_registry_auth/tasks/main.yaml
+++ b/tests/integration/targets/helm_registry_auth/tasks/main.yaml
@@ -137,8 +137,7 @@
       # Helm binary prints the message to stderr
       ansible.builtin.assert:
         that:
-          - "'push access denied' in _save_chart.stderr"
-          - "'authorization failed' in _save_chart.stderr"
+          - "'push access denied' in _save_chart.stderr or 'basic credential not found' in _save_chart.stderr"
           - "_save_chart.rc != 0"
           - "'localhost:{{ registry_port }}' not in _config_json.content | b64decode"
 

--- a/tests/integration/targets/helm_registry_auth/tasks/main.yaml
+++ b/tests/integration/targets/helm_registry_auth/tasks/main.yaml
@@ -112,15 +112,15 @@
       when: _helm_version.stdout is ansible.builtin.version('v3.18.0', '<')
       block:
 
-      - name: Test logout idempotency
-        helm_registry_auth:
-          host: localhost:{{ registry_port }}
-          state: absent
-        register: _helm_registry_auth_logout_idempotency
+        - name: Test logout idempotency
+          helm_registry_auth:
+            host: localhost:{{ registry_port }}
+            state: absent
+          register: _helm_registry_auth_logout_idempotency
 
-      - name: Assert logout operation did not report change
-        ansible.builtin.assert:
-          that: _helm_registry_auth_logout_idempotency is not changed
+        - name: Assert logout operation did not report change
+          ansible.builtin.assert:
+            that: _helm_registry_auth_logout_idempotency is not changed
 
     - name: Ensure that not able to push to the registry
       ansible.builtin.shell: >-

--- a/tests/integration/targets/helm_registry_auth/tasks/main.yaml
+++ b/tests/integration/targets/helm_registry_auth/tasks/main.yaml
@@ -108,15 +108,19 @@
       assert:
         that: "'Removing login credentials' in _helm_registry_auth_logout.stderr"
 
-    - name: Test logout idempotency
-      helm_registry_auth:
-        host: localhost:{{ registry_port }}
-        state: absent
-      register: _helm_registry_auth_logout_idempotency
+    - name: Test idempotency of logout with helm < 3.18.0
+      when: _helm_version.stdout is ansible.builtin.version('v3.18.0', '<')
+      block:
 
-    - name: Assert logout operation did not report change
-      ansible.builtin.assert:
-        that: _helm_registry_auth_logout_idempotency is not changed
+      - name: Test logout idempotency
+        helm_registry_auth:
+          host: localhost:{{ registry_port }}
+          state: absent
+        register: _helm_registry_auth_logout_idempotency
+
+      - name: Assert logout operation did not report change
+        ansible.builtin.assert:
+          that: _helm_registry_auth_logout_idempotency is not changed
 
     - name: Ensure that not able to push to the registry
       ansible.builtin.shell: >-

--- a/tests/integration/targets/helm_registry_auth/tasks/main.yaml
+++ b/tests/integration/targets/helm_registry_auth/tasks/main.yaml
@@ -158,7 +158,8 @@
     - name: Assert that the registry is not logged in and auth data is not saved
       ansible.builtin.assert:
         that:
-          - "'401 Unauthorized' in _helm_registry_auth_wrong.stderr"
+          - "'401' in _helm_registry_auth_wrong.stderr"
+          - "'unauthorized' in _helm_registry_auth_wrong.stderr | lower"
           - "'{{ wrong_password }}' not in _helm_registry_auth_correct.command"
           - "'{{ wrong_password }}' not in _helm_registry_auth_correct.stdout"
           - "'{{ wrong_password }}' not in _helm_registry_auth_correct.stderr"


### PR DESCRIPTION
##### SUMMARY
Fix the integration test for `helm_registry_auth` with `helm >= 3.18.0` and clarify idempotency.

Fixes #944 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
helm_registry_auth

##### ADDITIONAL INFORMATION

Caused by the changes in helm starting from 3.18.0