### PR TITLE
Added support for subresources.

### DIFF
--- a/plugins/module_utils/k8s/runner.py
+++ b/plugins/module_utils/k8s/runner.py
@@ -136,6 +136,7 @@ def perform_action(svc, definition: Dict, params: Dict) -> Dict:
     kind = definition.get("kind")
     api_version = definition.get("apiVersion")
     hidden_fields = params.get("hidden_fields")
+    subresource = params.get("subresource")
 
     result = {"changed": False, "result": {}}
     instance = {}
@@ -144,7 +145,19 @@ def perform_action(svc, definition: Dict, params: Dict) -> Dict:
     resource = svc.find_resource(kind, api_version, fail=True)
     definition["kind"] = resource.kind
     definition["apiVersion"] = resource.group_version
-    existing = svc.retrieve(resource, definition)
+
+    if subresource and subresource is not None:
+        if subresource not in resource.subresources.keys():
+            raise CoreException("The resource {resource} doesn't support the subresource {subresource}".format(
+                    resource=resource.kind,
+                    subresource=subresource,
+                )
+            )
+
+        existing = svc.retrieve(resource.subresources[subresource], definition)
+        resource = resource.subresources[subresource]
+    else:
+        existing = svc.retrieve(resource, definition)
 
     if state == "absent":
         if exists(existing) and existing.kind.endswith("List"):

--- a/plugins/modules/k8s.py
+++ b/plugins/modules/k8s.py
@@ -193,6 +193,11 @@ options:
     type: list
     elements: str
     version_added: 3.0.0
+  subresource:
+    description:
+      - Provide a C(subresource) to run your definition against.
+    type: str
+    version_added: 6.1.0
 
 requirements:
   - "python >= 3.9"
@@ -481,6 +486,7 @@ def argspec():
     )
     argument_spec["delete_all"] = dict(type="bool", default=False, aliases=["all"])
     argument_spec["hidden_fields"] = dict(type="list", elements="str")
+    argument_spec["subresource"] = dict(type="str", default=None)
 
     return argument_spec
 


### PR DESCRIPTION
##### SUMMARY
Added the option `subresources` to the `kubernetes.core.k8s` module, to support subresources.

##### ISSUE TYPE
- Feature Pull Request

##### ADDITIONAL INFORMATION
Check below the test I ran by approving a CSR by using the 'approval' subresource of the 'certificatesigningrequest' resource.

Added the CSR
```bash
cat <<EOF | kubectl apply -f -
apiVersion: certificates.k8s.io/v1
kind: CertificateSigningRequest
metadata:
  name: yorick-test
spec:
  request: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0KTUlJRFZqQ0NBYjRDQVFBd0VURVBNQTBHQTFVRUF3d0dlVzl5YVdOck1JSUJvakFOQmdrcWhraUc5dzBCQVFFRgpBQU9DQVk4QU1JSUJpZ0tDQVlFQXZXWGlIZlc4VHVQRVZUai8xcmFaREE3K0sxWVhwZThDd0MyMDJxYnJyMlY4Ck1xSHQ3T1ZPV3RFZ1N1RlRvOHRDRTRUT0JqUTB4Y1p2K0tDSlhrT2xGTmFTcVF5M3ZWeFd5L2V4YnVMcGpza00KUWErMzFEZG5tNDgydi9RUGl5cDd3VEtIMlJwODNFNlFjSHcwdU1KNDA3YUEwTUpuTENhOG1aeVRWdEVUWWJ3YwowQnZ5M010L0NiWFlHV1FVSXg1aWdWMW1HNHJtb0ZHMWwrVVZHNzBYcHdMKys4U09MUnlqM3JTVzdNb3laSml1CjQ5a2JYTmtqTjJxZmVXTWd3T1Z5ZEpBbVIrYzQ4LzNLbndub1pjQXp5YlBiUXdRK0tITDAzekdBdTdMNGgzUUoKUDV3Y2xMYjFPMEI1VzI4V29kMDZsNUNYeFZGV1JvMFllTk16L2FZVitTSGdSd3hTeGgzbm9PbnpIZFF1QzlYTgpvQ2ZrQlBuWDMvcUVoc0syS2w5N2VjYWpMaUFaRUJ0REJNQkpqbDVFdnAySTBJNkxRY29JTHlibzNlWlVWelZxClhEM2x0cm1MQklpWGpUQ09ONmhQeUo2aWtIdWdSbi80MjZJeFp6MTByQ24zMUNUdGJTYlU4T1FoWnZrdlpPa0MKdmlYenBOYU51UEx1QWtHNENKQXhBZ01CQUFHZ0FEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FZRUFOK3VZcFpregpObURyc2NwYU92NWViQUlLeHNYVnRUaldBTkR3a1RSNml6RFFuRVhpQmttdEFnUkhPeFo2dmVKWFlMZ1kyMFRjClN1YlJYT2Nrdk95U1hKSzBHbkQ0U2xnYnRMNUE1cTZIWHhLN0oyMVlGbGU1M3hGQ3ZKOXRkaisrWVRlVmRKYTIKSW9kSHlJOXFNVFRuTWVhUWg3aDJtTEk0NkI0YlBua2cyUTQzSmNIcGthdnM1SGFHWmw4VWJRc3VIeDRRSkVaTgovTDhiSWs5NnFyWTQ3aE40eGtCMTV4RlJGU1loeExSTXpMd2pKdWpGL0lrblU0SlBJdFFub3k4VXlTUWNlUFpHCkkzc1hsQmkwOFkwdStuNEVQaDZZRU1jTW9QL0QycE5SSWpab3RVZXowbWNLNCt3RmYraW1ZUXRwQitMNkcyVksKLy9MTU9SY1ZLWmRnWVoyYnZkUEUrQzdxVXV4SDBGbnVUdWZucmhVY3Zaa1hBUW9SVllVRHFpaVFLTkp6QjZWRgo0Q043U1R2bnA4ck96YmRRL1hWS2ZrQ2Zib0N4NnkyRE9jVUdqOWVtNEZ0VVBpTWltQ3dqT0dsMW54NTR4dGs2CmFCNGFxcm9VMk1qR2V6V2pVZkYrZDdiR1VkWDdsK1BJcCs4eW5DVklHdVcxV3lDQlRZMWlVT3l3Ci0tLS0tRU5EIENFUlRJRklDQVRFIFJFUVVFU1QtLS0tLQo=
  signerName: kubernetes.io/kube-apiserver-client
  usages:
  - client auth
EOF
```
Output
```bash
certificatesigningrequest.certificates.k8s.io/yorick-test created
```

Pull the CSR info
```bash
cat << EOF | ansible-playbook /dev/stdin
- name: Get CSR subresource.
  hosts: localhost
  gather_facts: False
  tasks:

  - kubernetes.core.k8s_info:
      kubeconfig: '~/.kube/config'
      api_version: certificates.k8s.io/v1
      kind: certificatesigningrequests
      name: yorick-test
    register: yorick_test

  - ansible.builtin.debug:
      msg: "{{ yorick_test | json_query('resources[].{name: metadata.name, status: status}') | to_nice_json }}"
EOF
```
Output
```bash
PLAY [Get CSR subresource.] **********************************************************************************************************************************

TASK [kubernetes.core.k8s_info] ******************************************************************************************************************************
Sunday 27 July 2025  02:34:51 +0200 (0:00:00.010)       0:00:00.010 ***********
ok: [localhost]

TASK [ansible.builtin.debug] *********************************************************************************************************************************
Sunday 27 July 2025  02:34:55 +0200 (0:00:03.970)       0:00:03.980 ***********
ok: [localhost] => {}

MSG:

[
    {
        "name": "yorick-test",
        "status": {}
    }
]

PLAY RECAP ***************************************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

Playbook run took 0 days, 0 hours, 0 minutes, 4 seconds
```

Approve the CSR
```bash
cat << EOF | ansible-playbook /dev/stdin
- name: Update CSR subresource.
  hosts: localhost
  gather_facts: False
  tasks:

  - kubernetes.core.k8s:
      kubeconfig: '~/.kube/config'
      state: patched
      merge_type: merge
      subresource: approval
      definition:
        apiVersion: certificates.k8s.io/v1
        kind: certificatesigningrequests
        metadata:
          name: yorick-test
        status:
          conditions:
          - lastTransitionTime: "2025-07-27T02:12:22Z"
            lastUpdateTime: "2025-07-27T02:12:22Z"
            message: Approval yorick test
            reason: Approved
            status: "True"
            type: Approved
    register: yorick_test

  - kubernetes.core.k8s_info:
      kubeconfig: '~/.kube/config'
      api_version: certificates.k8s.io/v1
      kind: certificatesigningrequests
      name: yorick-test
    register: yorick_test

  - ansible.builtin.debug:
      msg: "{{ yorick_test | json_query('resources[].{name: metadata.name, status: status}') | to_nice_json }}"
EOF
```
Output
```bash
PLAY [Update CSR subresource.] *******************************************************************************************************************************

TASK [kubernetes.core.k8s] ***********************************************************************************************************************************
Sunday 27 July 2025  02:35:35 +0200 (0:00:00.010)       0:00:00.010 ***********
--- before
+++ after
@@ -15,9 +15,44 @@
                 "manager": "kubectl-client-side-apply",
                 "operation": "Update",
                 "time": "2025-07-27T00:34:31Z"
+            },
+            {
+                "apiVersion": "certificates.k8s.io/v1",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                    "f:status": {
+                        "f:conditions": {
+                            ".": {},
+                            "k:{\"type\":\"Approved\"}": {
+                                ".": {},
+                                "f:lastTransitionTime": {},
+                                "f:lastUpdateTime": {},
+                                "f:message": {},
+                                "f:reason": {},
+                                "f:status": {},
+                                "f:type": {}
+                            }
+                        }
+                    }
+                },
+                "manager": "OpenAPI-Generator",
+                "operation": "Update",
+                "subresource": "approval",
+                "time": "2025-07-27T00:35:38Z"
             }
         ],
-        "resourceVersion": "26759657"
+        "resourceVersion": "26761740"
     },
-    "status": {}
+    "status": {
+        "conditions": [
+            {
+                "lastTransitionTime": "2025-07-27T02:12:22Z",
+                "lastUpdateTime": "2025-07-27T02:12:22Z",
+                "message": "Approval yorick test",
+                "reason": "Approved",
+                "status": "True",
+                "type": "Approved"
+            }
+        ]
+    }
 }

changed: [localhost]

TASK [kubernetes.core.k8s_info] ******************************************************************************************************************************
Sunday 27 July 2025  02:35:39 +0200 (0:00:04.067)       0:00:04.078 ***********
ok: [localhost]

TASK [ansible.builtin.debug] *********************************************************************************************************************************
Sunday 27 July 2025  02:35:39 +0200 (0:00:00.814)       0:00:04.893 ***********
ok: [localhost] => {}

MSG:

[
    {
        "name": "yorick-test",
        "status": {
            "certificate": "...",
            "conditions": [
                {
                    "lastTransitionTime": "2025-07-27T02:12:22Z",
                    "lastUpdateTime": "2025-07-27T02:12:22Z",
                    "message": "Approval yorick test",
                    "reason": "Approved",
                    "status": "True",
                    "type": "Approved"
                }
            ]
        }
    }
]

PLAY RECAP ***************************************************************************************************************************************************
localhost                  : ok=3    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

Playbook run took 0 days, 0 hours, 0 minutes, 4 seconds
```
Double-check, using the `oc` command
```bash
oc get csr yorick-test
NAME          AGE   SIGNERNAME                            REQUESTOR      REQUESTEDDURATION   CONDITION
yorick-test   18m   kubernetes.io/kube-apiserver-client   system:admin   <none>              Approved,Issued
```