### PR TITLE
Reapply "Remove kubeconfig value from module invocation log (#826)"

### DIFF
--- a/changelogs/fragments/20250411-kubeconfig-no_log-revert.yaml
+++ b/changelogs/fragments/20250411-kubeconfig-no_log-revert.yaml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - kubeconfig option should return the full manifest output (https://github.com/ansible-collections/kubernetes.core/issues/870).

--- a/plugins/module_utils/args_common.py
+++ b/plugins/module_utils/args_common.py
@@ -18,7 +18,7 @@ AUTH_PROXY_HEADERS_SPEC = dict(
 )
 
 AUTH_ARG_SPEC = {
-    "kubeconfig": {"type": "raw"},
+    "kubeconfig": {"type": "raw", "no_log": True},
     "context": {},
     "host": {},
     "api_key": {"no_log": True},

--- a/plugins/module_utils/helm_args_common.py
+++ b/plugins/module_utils/helm_args_common.py
@@ -16,6 +16,7 @@ HELM_AUTH_ARG_SPEC = dict(
         type="raw",
         aliases=["kubeconfig_path"],
         fallback=(env_fallback, ["K8S_AUTH_KUBECONFIG"]),
+        no_log=True,
     ),
     host=dict(type="str", fallback=(env_fallback, ["K8S_AUTH_HOST"])),
     ca_cert=dict(


### PR DESCRIPTION
This reverts commit 1705ced1b5e7b2374877d2a5f9d7c400b59ca2b0 (i.e., reapplies the changes from https://github.com/ansible-collections/kubernetes.core/pull/826); this is a temporary fix for #782 as it will re-introduce #870, which will need to be re-opened. 