### PR TITLE
Add the PR head as reference to the checkout action of the splitter job.

### DIFF
--- a/changelogs/fragments/20250808-bugfix-workflow-splitter-ref.yaml
+++ b/changelogs/fragments/20250808-bugfix-workflow-splitter-ref.yaml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - checkout the head of the pull request for the splitter checkout-action, so it's able to test new integration tests during the PR check-workflows already (https://github.com/ansible-collections/kubernetes.core/pull/981).


### PR DESCRIPTION
##### SUMMARY
During the workflow checks of one of my previous pull requests, I ran into an error as result of a new integration test that was added in the main branch but which was not present in my pull request (https://github.com/ansible-collections/kubernetes.core/actions/runs/16787189478/job/47540604109). I'd find out that the reference for the repository checkout for the splitter job was not set and therefor it referenced to the `main` branch.

With this change, the head of the pull request is used as reference for the repository checkout action, in the splitter job. This way it will not fail when someone creates a PR that doesn't have newly added integration tests that were added to the `main` branch in the meantime. It also adds that newly added integration tests will be tested during the PR workflow checks already.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
bugfix in the workflow

##### ADDITIONAL INFORMATION
n/a
