### PR TITLE
Update/correct `stable-6` changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ v6.1.0
 Release Summary
 ---------------
 
-This release includes a fix for kubeconfig output, added ``plain_http`` and ``take_ownership`` parameters for helm modules, support for ``hidden_fields`` in ``k8s_json_patch``, documented lack of idempotency support in ``helm_registry_auth`` with ``helm ≥ 3.18.0``, and improved ``k8s_rollback`` test coverage.
+This release adds ``plain_http`` and ``take_ownership`` parameters for helm modules, support for ``hidden_fields`` in ``k8s_json_patch``, documented lack of idempotency support in ``helm_registry_auth`` with ``helm ≥ 3.18.0``, and improved ``k8s_rollback`` test coverage.
 
 Minor Changes
 -------------

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1067,8 +1067,7 @@ releases:
         (https://github.com/ansible-collections/kubernetes.core/pull/934).
       - helm_template - Parameter plain_http added for working with insecure OCI registries
         (https://github.com/ansible-collections/kubernetes.core/pull/934).
-      release_summary: "This release includes a fix for kubeconfig output, added ``plain_http``
-        and ``take_ownership`` parameters for helm modules, support for ``hidden_fields``
+      release_summary: "This release adds ``plain_http`` and ``take_ownership`` parameters for helm modules, support for ``hidden_fields``
         in ``k8s_json_patch``, documented lack of idempotency support in ``helm_registry_auth``
         with ``helm \u2265 3.18.0``, and improved ``k8s_rollback`` test coverage."
     fragments:


### PR DESCRIPTION
##### SUMMARY

A part of the changelog referring to reverted changes was left in; this PR updates the changelog files to accurately reflect the state of `stable-6`/`6.1.0` release.