### PR TITLE
Minor updates to changelog to match stable-6 and main

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,15 +28,15 @@ This release includes minor changes, bug fixes and also bumps ``ansible-lint`` v
 Minor Changes
 -------------
 
-- kubernetes.core - Bump version of ``ansible-lint`` to ``25.1.2`` (https://github.com/ansible-collections/kubernetes.core/pull/919).
+- Bump version of ``ansible-lint`` to 25.1.2 (https://github.com/ansible-collections/kubernetes.core/pull/919).
 - action/k8s_info - update templating mechanism with changes from ``ansible-core 2.19`` (https://github.com/ansible-collections/kubernetes.core/pull/888).
 - helm - add ``reset_then_reuse_values`` support to helm module (https://github.com/ansible-collections/kubernetes.core/issues/803).
-- helm - add support for ``insecure_skip_tls_verify`` option to helm and ``helm_repository`` (https://github.com/ansible-collections/kubernetes.core/issues/694).
+- helm - add support for ``insecure_skip_tls_verify`` option to helm and helm_repository(https://github.com/ansible-collections/kubernetes.core/issues/694).
 
 Bugfixes
 --------
 
-- module_utils/k8s/service - Fix issue when trying to delete resource using ``delete_options`` and ``check_mode=true`` (https://github.com/ansible-collections/kubernetes.core/issues/892).
+- module_utils/k8s/service - fix issue when trying to delete resource using ``delete_options`` and ``check_mode=true`` (https://github.com/ansible-collections/kubernetes.core/issues/892).
 
 v5.2.0
 ======

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -977,7 +977,7 @@ releases:
       - kustomize - kustomize plugin fails with deprecation warnings (https://github.com/ansible-collections/kubernetes.core/issues/639).
       - waiter - Fix waiting for daemonset when desired number of pods is 0. (https://github.com/ansible-collections/kubernetes.core/pull/756).
       minor_changes:
-      - Bump version of ansible-lint to minimum 24.7.0 (https://github.com/ansible-collections/kubernetes.core/pull/765).
+      - Bump version of ``ansible-lint`` to minimum 24.7.0 (https://github.com/ansible-collections/kubernetes.core/pull/765).
       - Parameter insecure_registry added to helm_template as equivalent of insecure-skip-tls-verify
         (https://github.com/ansible-collections/kubernetes.core/pull/805).
       - k8s_drain - Improve error message for pod disruption budget when draining


### PR DESCRIPTION
This will make all `stable-5` changelog content match `main` and `stable-6` so there will no longer be formatting issues when doing release work in the future (basically a manual backport of #989).