### PR TITLE
Add missing proxy parameters to k8s lookup plugin documentation

### DIFF
--- a/plugins/lookup/k8s.py
+++ b/plugins/lookup/k8s.py
@@ -86,10 +86,42 @@ DOCUMENTATION = """
         description:
         - Provide a username for authenticating with the API. Can also be specified via K8S_AUTH_USERNAME environment
           variable.
+      no_proxy:
+        description:
+        - The comma separated list of hosts/domains/IP/CIDR that shouldn't go through proxy. Can also be specified via K8S_AUTH_NO_PROXY environment variable.
+        - Please note that this module does not pick up typical proxy settings from the environment (e.g. NO_PROXY).
+        - This feature requires kubernetes>=19.15.0. When kubernetes library is less than 19.15.0, it fails even if no_proxy is set correctly.
+        type: str
       password:
         description:
         - Provide a password for authenticating with the API. Can also be specified via K8S_AUTH_PASSWORD environment
           variable.
+      proxy:
+        description:
+        - The URL of an HTTP proxy to use for the connection. Can also be specified via K8S_AUTH_PROXY environment variable.
+        - Please note that this module does not pick up typical proxy settings from the environment (e.g. HTTP_PROXY).
+        type: str
+      proxy_headers:
+        description:
+        - The Header used for the HTTP proxy.
+        - Documentation can be found here U(https://urllib3.readthedocs.io/en/latest/reference/urllib3.util.html?highlight=proxy_headers#urllib3.util.make_headers).
+        type: dict
+        suboptions:
+          proxy_basic_auth:
+            type: str
+            description:
+            - Colon-separated username:password for proxy basic authentication header.
+            - Can also be specified via K8S_AUTH_PROXY_HEADERS_PROXY_BASIC_AUTH environment.
+          basic_auth:
+            type: str
+            description:
+            - Colon-separated username:password for basic authentication header.
+            - Can also be specified via K8S_AUTH_PROXY_HEADERS_BASIC_AUTH environment.
+          user_agent:
+            type: str
+            description:
+            - String representing the user-agent you want, such as foo/1.0.
+            - Can also be specified via K8S_AUTH_PROXY_HEADERS_USER_AGENT environment.
       client_cert:
         description:
         - Path to a certificate used to authenticate with the API. Can also be specified via K8S_AUTH_CERT_FILE


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added documentation for no_proxy, proxy, and proxy_headers parameters that were missing from the k8s lookup plugin. These parameters are already implemented in the codebase but were not documented.

- no_proxy: Comma separated list of hosts that shouldn't use proxy
- proxy: HTTP proxy URL for connections
- proxy_headers: Dictionary of proxy headers with suboptions for proxy_basic_auth, basic_auth, and user_agent

Fixes #775 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
k8s lookup
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
