### PR TITLE
[CI Fix] Remove `ansible.module_utils.six` imports

### DIFF
--- a/changelogs/fragments/20250922-remove-ansible-six-imports.yaml
+++ b/changelogs/fragments/20250922-remove-ansible-six-imports.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Remove ``ansible.module_utils.six`` imports to avoid warnings (https://github.com/ansible-collections/kubernetes.core/pull/998).

--- a/plugins/action/k8s_info.py
+++ b/plugins/action/k8s_info.py
@@ -22,7 +22,6 @@ from ansible.errors import (
 )
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.module_utils.parsing.convert_bool import boolean
-from ansible.module_utils.six import iteritems, string_types
 from ansible.plugins.action import ActionBase
 
 try:
@@ -100,7 +99,7 @@ class ActionModule(ActionBase):
             "trim_blocks": True,
             "lstrip_blocks": False,
         }
-        if isinstance(template, string_types):
+        if isinstance(template, str):
             # treat this as raw_params
             template_param["path"] = template
         elif isinstance(template, dict):
@@ -120,7 +119,7 @@ class ActionModule(ActionBase):
             ):
                 if s_type in template_args:
                     value = ensure_type(template_args[s_type], "string")
-                    if value is not None and not isinstance(value, string_types):
+                    if value is not None and not isinstance(value, str):
                         raise AnsibleActionFail(
                             "%s is expected to be a string, but got %s instead"
                             % (s_type, type(value))
@@ -196,7 +195,7 @@ class ActionModule(ActionBase):
             )
 
         template_params = []
-        if isinstance(template, string_types) or isinstance(template, dict):
+        if isinstance(template, str) or isinstance(template, dict):
             template_params.append(self.get_template_args(template))
         elif isinstance(template, list):
             for element in template:
@@ -246,7 +245,7 @@ class ActionModule(ActionBase):
                 # add ansible 'template' vars
                 temp_vars = copy.deepcopy(task_vars)
                 overrides = {}
-                for key, value in iteritems(template_item):
+                for key, value in template_item.items():
                     if hasattr(self._templar.environment, key):
                         if value is not None:
                             overrides[key] = value
@@ -303,7 +302,7 @@ class ActionModule(ActionBase):
             )
 
     def get_kubeconfig(self, kubeconfig, remote_transport, new_module_args):
-        if isinstance(kubeconfig, string_types):
+        if isinstance(kubeconfig, str):
             # find the kubeconfig in the expected search path
             if not remote_transport:
                 # kubeconfig is local

--- a/plugins/module_utils/args_common.py
+++ b/plugins/module_utils/args_common.py
@@ -1,12 +1,10 @@
 from __future__ import absolute_import, division, print_function
 
-from ansible.module_utils.six import string_types
-
 __metaclass__ = type
 
 
 def list_dict_str(value):
-    if isinstance(value, (list, dict, string_types)):
+    if isinstance(value, (list, dict, str)):
         return value
     raise TypeError
 

--- a/plugins/module_utils/helm.py
+++ b/plugins/module_utils/helm.py
@@ -15,7 +15,6 @@ import tempfile
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils.six import string_types
 from ansible_collections.kubernetes.core.plugins.module_utils.version import (
     LooseVersion,
 )
@@ -113,7 +112,7 @@ class AnsibleHelmModule(object):
         kubeconfig_content = None
         kubeconfig = self.params.get("kubeconfig")
         if kubeconfig:
-            if isinstance(kubeconfig, string_types):
+            if isinstance(kubeconfig, str):
                 with open(os.path.expanduser(kubeconfig)) as fd:
                     kubeconfig_content = yaml.safe_load(fd)
             elif isinstance(kubeconfig, dict):

--- a/plugins/module_utils/k8s/client.py
+++ b/plugins/module_utils/k8s/client.py
@@ -5,7 +5,6 @@ import hashlib
 import os
 from typing import Any, Dict, List, Optional
 
-from ansible.module_utils.six import iteritems, string_types
 from ansible_collections.kubernetes.core.plugins.module_utils.args_common import (
     AUTH_ARG_MAP,
     AUTH_ARG_SPEC,
@@ -115,7 +114,7 @@ def _load_config(auth: Dict) -> None:
         "persist_config": auth.get("persist_config"),
     }
     if kubeconfig:
-        if isinstance(kubeconfig, string_types):
+        if isinstance(kubeconfig, str):
             kubernetes.config.load_kube_config(config_file=kubeconfig, **optional_arg)
         elif isinstance(kubeconfig, dict):
             kubernetes.config.load_kube_config_from_dict(
@@ -163,7 +162,7 @@ def _create_configuration(auth: Dict):
     except AttributeError:
         configuration = kubernetes.client.Configuration()
 
-    for key, value in iteritems(auth):
+    for key, value in auth.items():
         if key in AUTH_ARG_MAP.keys() and value is not None:
             if key == "api_key":
                 setattr(

--- a/plugins/module_utils/k8s/resource.py
+++ b/plugins/module_utils/k8s/resource.py
@@ -4,7 +4,6 @@
 import os
 from typing import Dict, Iterable, List, Optional, Union, cast
 
-from ansible.module_utils.six import string_types
 from ansible.module_utils.urls import Request
 
 try:
@@ -78,11 +77,11 @@ def create_definitions(params: Dict) -> List[ResourceDefinition]:
 def from_yaml(definition: Union[str, List, Dict]) -> Iterable[Dict]:
     """Load resource definitions from a yaml definition."""
     definitions: List[Dict] = []
-    if isinstance(definition, string_types):
+    if isinstance(definition, str):
         definitions += yaml.safe_load_all(definition)
     elif isinstance(definition, list):
         for item in definition:
-            if isinstance(item, string_types):
+            if isinstance(item, str):
                 definitions += yaml.safe_load_all(item)
             else:
                 definitions.append(item)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -10,7 +10,6 @@ import ansible.module_utils.basic
 import pytest
 from ansible.module_utils._text import to_bytes
 from ansible.module_utils.common._collections_compat import MutableMapping
-from ansible.module_utils.six import string_types
 
 
 @pytest.fixture
@@ -20,7 +19,7 @@ def stdin(mocker, request):
     old_argv = sys.argv
     sys.argv = ["ansible_unittest"]
 
-    if isinstance(request.param, string_types):
+    if isinstance(request.param, str):
         args = request.param
     elif isinstance(request.param, MutableMapping):
         if "ANSIBLE_MODULE_ARGS" not in request.param:


### PR DESCRIPTION
##### SUMMARY
This PR is essentially attempting Option B from issue #996 (Option A is implemented [here](https://github.com/ansible-collections/kubernetes.core/pull/997)); this code update accounts for the recent merge of [sanity: warn on ansible.module_utils.six imports #85651](https://github.com/ansible/ansible/pull/85651).
