### PR TITLE
Doc update following #971

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ tests/integration/*-chart-*.tgz
 # ansible-test generated file
 tests/integration/inventory
 tests/integration/*-*.yml
+
+# VS Code settings
+.vscode/

--- a/docs/kubernetes.core.k8s_cp_module.rst
+++ b/docs/kubernetes.core.k8s_cp_module.rst
@@ -512,6 +512,7 @@ Notes
 
 .. note::
    - the tar binary is required on the container when copying from local filesystem to pod.
+   - the (init) container has to be started before you copy files or directories to it.
    - To avoid SSL certificate validation errors when ``validate_certs`` is *True*, the full certificate chain for the API server must be provided via ``ca_cert`` or in the kubeconfig file.
 
 


### PR DESCRIPTION
##### SUMMARY
In the PR #971, support for copying files to initContainers, and this change includes a minor update for DOCUMENTATION for the k8s_cp module; however, `docs/kubernetes.core.k8s_cp_module.rst` wasn't updated, and it's a trivial change following the Updating documentation section of the CONTRIBUTING.md

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/kubernetes.core.k8s_cp_module.rst

##### ADDITIONAL INFORMATION
As it is a trivial change and related to #971, I didn't created a chnagelog fragment and suggest adding `skip-changelog` label.

To be backported to `stable-5` and `stable-6`
