### PR TITLE
775 document proxy configurations

### DIFF
--- a/plugins/lookup/k8s.py
+++ b/plugins/lookup/k8s.py
@@ -91,7 +91,7 @@ DOCUMENTATION = """
         - The comma separated list of hosts/domains/IP/CIDR that shouldn't go through proxy.
           Can also be specified via K8S_AUTH_NO_PROXY environment variable.
         - Please note that this module does not pick up typical proxy settings from the environment (e.g. NO_PROXY).
-        - This feature requires kubernetes>=19.15.0. 
+        - This feature requires kubernetes>=19.15.0.
           When kubernetes library is less than 19.15.0, it fails even if no_proxy is set correctly.
         type: str
       password:


### PR DESCRIPTION
##### SUMMARY
Added documentation for no_proxy, proxy, and proxy_headers parameters that were missing from the k8s lookup plugin. These parameters are already implemented in the codebase but were not documented.

no_proxy: Comma separated list of hosts that shouldn't use proxy
proxy: HTTP proxy URL for connections
proxy_headers: Dictionary of proxy headers with suboptions for proxy_basic_auth, basic_auth, and user_agent
Fixes #775 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
k8s lookup


#### Additional comment

This is a reissue of https://github.com/ansible-collections/kubernetes.core/pull/993, which was lost during the latest release due to me PR incorrectly from my fork's main branch. Linter errors on the previous PR should already be resolved. 
This had the backport-5, backport-6 and skip-changelog labels.

```
