### PR TITLE
Support for metadata-only fetches in k8s_info module

### DIFF
--- a/changelogs/fragments/20251027-metadata-only-fetches.yaml
+++ b/changelogs/fragments/20251027-metadata-only-fetches.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - k8s_info - Support for metadata-only fetches in k8s_info module (https://github.com/ansible-collections/kubernetes.core/pull/1030)

--- a/plugins/module_utils/args_common.py
+++ b/plugins/module_utils/args_common.py
@@ -144,3 +144,12 @@ DELETE_OPTS_ARG_SPEC = {
         "options": {"resourceVersion": {"type": "str"}, "uid": {"type": "str"}},
     },
 }
+
+METADATA_ONLY_HEADERS_SPEC = dict(
+    accept=dict(type="str"),
+)
+
+METADATA_ONLY_HEADER_VALUES = {
+    "partial_object": "application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1, application/json;q=0.9",
+    "partial_object_list":"application/json;as=PartialObjectMetadataList;g=meta.k8s.io;v=v1, application/json;q=0.9"
+}

--- a/plugins/module_utils/args_common.py
+++ b/plugins/module_utils/args_common.py
@@ -150,6 +150,12 @@ METADATA_ONLY_HEADERS_SPEC = dict(
 )
 
 METADATA_ONLY_HEADER_VALUES = {
-    "partial_object": "application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1, application/json;q=0.9",
-    "partial_object_list":"application/json;as=PartialObjectMetadataList;g=meta.k8s.io;v=v1, application/json;q=0.9"
+    "partial_object": (
+        "application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,"
+        "application/json;q=0.9"
+    ),
+    "partial_object_list": (
+        "application/json;as=PartialObjectMetadataList;g=meta.k8s.io;v=v1,"
+        "application/json;q=0.9"
+    ),
 }

--- a/plugins/module_utils/args_common.py
+++ b/plugins/module_utils/args_common.py
@@ -145,9 +145,9 @@ DELETE_OPTS_ARG_SPEC = {
     },
 }
 
-METADATA_ONLY_HEADERS_SPEC = dict(
-    accept=dict(type="str"),
-)
+METADATA_ONLY_HEADERS_SPEC = {
+    "accept": {"type": "str"},
+}
 
 METADATA_ONLY_HEADER_VALUES = {
     "partial_object": (

--- a/plugins/module_utils/k8s/client.py
+++ b/plugins/module_utils/k8s/client.py
@@ -181,6 +181,7 @@ def _create_headers(module=None, **kwargs):
     header_map = {
         "impersonate_user": "Impersonate-User",
         "impersonate_groups": "Impersonate-Group",
+        "accept": "Accept",
     }
 
     headers = {}

--- a/plugins/modules/k8s_info.py
+++ b/plugins/modules/k8s_info.py
@@ -194,9 +194,9 @@ from ansible_collections.kubernetes.core.plugins.module_utils.ansiblemodule impo
 )
 from ansible_collections.kubernetes.core.plugins.module_utils.args_common import (
     AUTH_ARG_SPEC,
-    WAIT_ARG_SPEC,
     METADATA_ONLY_HEADERS_SPEC,
     METADATA_ONLY_HEADER_VALUES,
+    WAIT_ARG_SPEC,
 )
 from ansible_collections.kubernetes.core.plugins.module_utils.k8s.client import (
     get_api_client,

--- a/plugins/modules/k8s_info.py
+++ b/plugins/modules/k8s_info.py
@@ -53,6 +53,15 @@ options:
     type: list
     elements: str
     version_added: 3.0.0
+  metadata_only:
+    description:
+      - Request metadata only response from the Kubernetes API server.
+      - This feature is useful for clients that only need to check for the existence of an object,
+      - or that only need to read its metadata.
+      - It can significantly reduce the size of the response from the API server.
+    type: bool
+    default: false
+    version_added: 6.3.0
 
 extends_documentation_fragment:
   - kubernetes.core.k8s_auth_options
@@ -135,6 +144,12 @@ EXAMPLES = r"""
     (ocp_bootstrap_status.resources[0].data.status == 'complete')
   retries: 60
   delay: 15
+
+- name: Get a list of all pods metadata only
+  kubernetes.core.k8s_info:
+    kind: Pod
+    metadata_only: true
+  register: pod_metadata_list
 """
 
 RETURN = r"""
@@ -180,6 +195,8 @@ from ansible_collections.kubernetes.core.plugins.module_utils.ansiblemodule impo
 from ansible_collections.kubernetes.core.plugins.module_utils.args_common import (
     AUTH_ARG_SPEC,
     WAIT_ARG_SPEC,
+    METADATA_ONLY_HEADERS_SPEC,
+    METADATA_ONLY_HEADER_VALUES
 )
 from ansible_collections.kubernetes.core.plugins.module_utils.k8s.client import (
     get_api_client,
@@ -224,6 +241,7 @@ def argspec():
             label_selectors=dict(type="list", elements="str", default=[]),
             field_selectors=dict(type="list", elements="str", default=[]),
             hidden_fields=dict(type="list", elements="str"),
+            metadata_only=dict(type="bool", default=False),
         )
     )
     return args
@@ -233,8 +251,24 @@ def main():
     module = AnsibleK8SModule(
         module_class=AnsibleModule, argument_spec=argspec(), supports_check_mode=True
     )
+
+    metadata_only_headers = {}
+    if module.params["metadata_only"]:
+        metadata_only_headers = copy.deepcopy(METADATA_ONLY_HEADERS_SPEC)
+        metadata_only_headers.update(
+            dict(
+                accept=METADATA_ONLY_HEADER_VALUES["partial_object_list"]
+            )
+        )
+        if module.params["name"]:
+            metadata_only_headers.update(
+                dict(
+                    accept=METADATA_ONLY_HEADER_VALUES["partial_object"]
+                )
+            )
+
     try:
-        client = get_api_client(module)
+        client = get_api_client(module, **metadata_only_headers)
         svc = K8sService(client, module)
         execute_module(module, svc)
     except CoreException as e:

--- a/plugins/modules/k8s_info.py
+++ b/plugins/modules/k8s_info.py
@@ -61,7 +61,7 @@ options:
       - It can significantly reduce the size of the response from the API server.
     type: bool
     default: false
-    version_added: 6.3.0
+    version_added: 6.6.0
 
 extends_documentation_fragment:
   - kubernetes.core.k8s_auth_options

--- a/plugins/modules/k8s_info.py
+++ b/plugins/modules/k8s_info.py
@@ -194,8 +194,8 @@ from ansible_collections.kubernetes.core.plugins.module_utils.ansiblemodule impo
 )
 from ansible_collections.kubernetes.core.plugins.module_utils.args_common import (
     AUTH_ARG_SPEC,
-    METADATA_ONLY_HEADERS_SPEC,
     METADATA_ONLY_HEADER_VALUES,
+    METADATA_ONLY_HEADERS_SPEC,
     WAIT_ARG_SPEC,
 )
 from ansible_collections.kubernetes.core.plugins.module_utils.k8s.client import (
@@ -233,16 +233,16 @@ def argspec():
     args = copy.deepcopy(AUTH_ARG_SPEC)
     args.update(WAIT_ARG_SPEC)
     args.update(
-        dict(
-            kind=dict(required=True),
-            api_version=dict(default="v1", aliases=["api", "version"]),
-            name=dict(),
-            namespace=dict(),
-            label_selectors=dict(type="list", elements="str", default=[]),
-            field_selectors=dict(type="list", elements="str", default=[]),
-            hidden_fields=dict(type="list", elements="str"),
-            metadata_only=dict(type="bool", default=False),
-        )
+        {
+            "kind": {"required": True},
+            "api_version": {"default": "v1", "aliases": ["api", "version"]},
+            "name": {},
+            "namespace": {},
+            "label_selectors": {"type": "list", "elements": "str", "default": []},
+            "field_selectors": {"type": "list", "elements": "str", "default": []},
+            "hidden_fields": {"type": "list", "elements": "str"},
+            "metadata_only": {"type": "bool", "default": False},
+        }
     )
     return args
 
@@ -256,11 +256,11 @@ def main():
     if module.params["metadata_only"]:
         metadata_only_headers = copy.deepcopy(METADATA_ONLY_HEADERS_SPEC)
         metadata_only_headers.update(
-            dict(accept=METADATA_ONLY_HEADER_VALUES["partial_object_list"])
+            {"accept": METADATA_ONLY_HEADER_VALUES["partial_object_list"]}
         )
         if module.params["name"]:
             metadata_only_headers.update(
-                dict(accept=METADATA_ONLY_HEADER_VALUES["partial_object"])
+                {"accept": METADATA_ONLY_HEADER_VALUES["partial_object"]}
             )
 
     try:

--- a/plugins/modules/k8s_info.py
+++ b/plugins/modules/k8s_info.py
@@ -196,7 +196,7 @@ from ansible_collections.kubernetes.core.plugins.module_utils.args_common import
     AUTH_ARG_SPEC,
     WAIT_ARG_SPEC,
     METADATA_ONLY_HEADERS_SPEC,
-    METADATA_ONLY_HEADER_VALUES
+    METADATA_ONLY_HEADER_VALUES,
 )
 from ansible_collections.kubernetes.core.plugins.module_utils.k8s.client import (
     get_api_client,
@@ -256,15 +256,11 @@ def main():
     if module.params["metadata_only"]:
         metadata_only_headers = copy.deepcopy(METADATA_ONLY_HEADERS_SPEC)
         metadata_only_headers.update(
-            dict(
-                accept=METADATA_ONLY_HEADER_VALUES["partial_object_list"]
-            )
+            dict(accept=METADATA_ONLY_HEADER_VALUES["partial_object_list"])
         )
         if module.params["name"]:
             metadata_only_headers.update(
-                dict(
-                    accept=METADATA_ONLY_HEADER_VALUES["partial_object"]
-                )
+                dict(accept=METADATA_ONLY_HEADER_VALUES["partial_object"])
             )
 
     try:

--- a/tests/integration/targets/k8s_info/tasks/main.yml
+++ b/tests/integration/targets/k8s_info/tasks/main.yml
@@ -4,3 +4,4 @@
     - wait
     - api-server-caching
     - discovery
+    - metadata-only-fetches

--- a/tests/integration/targets/k8s_info/tasks/metadata-only-fetches.yml
+++ b/tests/integration/targets/k8s_info/tasks/metadata-only-fetches.yml
@@ -19,4 +19,4 @@
 - name: Assert response has kind Node
   assert:
     that:
-      - node_metadata_only_list.resources[0].kind == "Node"
+      - node_full_list.resources[0].kind == "Node"

--- a/tests/integration/targets/k8s_info/tasks/metadata-only-fetches.yml
+++ b/tests/integration/targets/k8s_info/tasks/metadata-only-fetches.yml
@@ -1,0 +1,22 @@
+---
+- name: Retrieve Node list with metadata_only
+  kubernetes.core.k8s_info:
+    kind: Node
+    metadata_only: true
+  register: node_metadata_only_list
+
+- name: Assert response has kind PartialObjectMetadata
+  assert:
+    that:
+      - node_metadata_only_list.resources[0].kind == "PartialObjectMetadata"
+
+- name: Retrieve full Node list
+  kubernetes.core.k8s_info:
+    kind: Node
+    metadata_only: false
+  register: node_full_list
+
+- name: Assert response has kind Node
+  assert:
+    that:
+      - node_metadata_only_list.resources[0].kind == "Node"


### PR DESCRIPTION
##### SUMMARY

This pull request adds support for a new `metadata_only` option in `k8s_info` module, enabling support for K8S API [Metadata-only fetches](https://kubernetes.io/docs/reference/using-api/api-concepts/#metadata-only-fetches).

This helps reducing memory footprint when retrieving large collections of objects.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
k8s_info

##### ADDITIONAL INFORMATION
Added `metadata_only` option in `k8s_info` module, enabling support for K8S API [Metadata-only fetches](https://kubernetes.io/docs/reference/using-api/api-concepts/#metadata-only-fetches).

The `Accept` header used when `metadata_only` option is true also includes a fallback value `application/json;q=0.9` as documented upstream, so that full objects are returned if the API doesn't support partial responses instead of an HTTP 406 error.

Added integration tests to verify the behavior of the `metadata_only` option.

Closes #1022