### PR TITLE
Update ignore for sanity test for 2.21

### DIFF
--- a/tests/sanity/ignore-2.21.txt
+++ b/tests/sanity/ignore-2.21.txt
@@ -29,3 +29,6 @@ plugins/modules/k8s_taint.py validate-modules:return-syntax-error
 tests/integration/targets/helm_diff/files/test-chart-reuse-values/templates/configmap.yaml yamllint!skip
 tests/integration/targets/helm_registry_auth/tasks/main.yaml yamllint!skip
 tests/integration/targets/helm_diff/files/test-chart-deployment-time/templates/configmap.yaml yamllint!skip
+plugins/modules/helm.py validate-modules:bad-return-value-key
+plugins/modules/helm_info.py validate-modules:bad-return-value-key
+plugins/modules/k8s.py validate-modules:bad-return-value-key


### PR DESCRIPTION
##### SUMMARY

Ignore report bad-return-value-key for return values that cannot be accessed with Jinja's dot notation for ansible-core 2.21 (current `devel` and `milestone`)

References:
- Ref: https://forum.ansible.com/t/ansible-test-validate-modules-sanity-test-report-bad-return-values-that-cannot-be-accessed-with-jinjas-dot-notation/44833
- https://github.com/ansible/ansible/pull/86079
- 
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
CI/Tests