### PR TITLE
Handle empty template output gracefully

### DIFF
--- a/changelogs/fragments/20250108-fix-empty-template-output.yaml
+++ b/changelogs/fragments/20250108-fix-empty-template-output.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- k8s_info - Handle empty template output gracefully by returning ``changed=false`` instead of failing when Jinja2 template renders to an empty string (https://github.com/ansible-collections/kubernetes.core/issues/1042).

--- a/plugins/action/k8s_info.py
+++ b/plugins/action/k8s_info.py
@@ -329,13 +329,6 @@ class ActionModule(ActionBase):
                 "a string or dict expected, but got %s instead" % type(kubeconfig)
             )
 
-    @staticmethod
-    def _fail_with_error(result, error):
-        result["failed"] = True
-        result["msg"] = to_text(error)
-        result["exception"] = traceback.format_exc()
-        return result
-
     def run(self, tmp=None, task_vars=None):
         """handler for k8s options"""
         if task_vars is None:
@@ -357,7 +350,10 @@ class ActionModule(ActionBase):
             try:
                 self.get_kubeconfig(kubeconfig, remote_transport, new_module_args)
             except AnsibleError as e:
-                return self._fail_with_error(result, e)
+                result["failed"] = True
+                result["msg"] = to_text(e)
+                result["exception"] = traceback.format_exc()
+                return result
 
         # find the file in the expected search path
         src = self._task.args.get("src", None)
@@ -377,7 +373,10 @@ class ActionModule(ActionBase):
                 # find in expected paths
                 src = self._find_needle("files", src)
             except AnsibleError as e:
-                return self._fail_with_error(result, e)
+                result["failed"] = True
+                result["msg"] = to_text(e)
+                result["exception"] = traceback.format_exc()
+                return result
 
         if src:
             new_module_args["src"] = src

--- a/plugins/action/k8s_info.py
+++ b/plugins/action/k8s_info.py
@@ -329,6 +329,13 @@ class ActionModule(ActionBase):
                 "a string or dict expected, but got %s instead" % type(kubeconfig)
             )
 
+    @staticmethod
+    def _fail_with_error(result, error):
+        result["failed"] = True
+        result["msg"] = to_text(error)
+        result["exception"] = traceback.format_exc()
+        return result
+
     def run(self, tmp=None, task_vars=None):
         """handler for k8s options"""
         if task_vars is None:
@@ -350,10 +357,7 @@ class ActionModule(ActionBase):
             try:
                 self.get_kubeconfig(kubeconfig, remote_transport, new_module_args)
             except AnsibleError as e:
-                result["failed"] = True
-                result["msg"] = to_text(e)
-                result["exception"] = traceback.format_exc()
-                return result
+                return self._fail_with_error(result, e)
 
         # find the file in the expected search path
         src = self._task.args.get("src", None)
@@ -373,10 +377,7 @@ class ActionModule(ActionBase):
                 # find in expected paths
                 src = self._find_needle("files", src)
             except AnsibleError as e:
-                result["failed"] = True
-                result["msg"] = to_text(e)
-                result["exception"] = traceback.format_exc()
-                return result
+                return self._fail_with_error(result, e)
 
         if src:
             new_module_args["src"] = src

--- a/plugins/action/k8s_info.py
+++ b/plugins/action/k8s_info.py
@@ -391,7 +391,8 @@ class ActionModule(ActionBase):
 
         local_path = self._task.args.get("local_path")
         state = self._task.args.get("state", None)
-        if local_path and state == "to_pod" and not remote_transport:
+        is_local_pod_upload = local_path and state == "to_pod" and not remote_transport
+        if is_local_pod_upload:
             new_module_args["local_path"] = self.get_file_realpath(local_path)
 
         # Execute the k8s_* module.

--- a/tests/integration/targets/k8s_template/tasks/main.yml
+++ b/tests/integration/targets/k8s_template/tasks/main.yml
@@ -238,7 +238,55 @@
           - resource.result.results | selectattr('changed') | list | length == 1
           - resource.result.results | selectattr('error', 'defined') | list | length == 1
 
+    - name: Apply template where all items are disabled (empty output)
+      kubernetes.core.k8s:
+        state: present
+        template:
+          path: "conditional_empty.j2"
+      vars:
+        items:
+          - name: test1
+            enabled: false
+          - name: test2
+            enabled: false
+        k8s_pod_namespace: "{{ template_namespace }}"
+      register: r
+
+    - name: Check that empty template succeeds with no changes
+      assert:
+        that:
+          - r is successful
+          - r is not changed
+
+    - name: Apply template where some items are enabled
+      kubernetes.core.k8s:
+        state: present
+        template:
+          path: "conditional_empty.j2"
+      vars:
+        items:
+          - name: conditional-configmap-1
+            enabled: true
+          - name: conditional-configmap-2
+            enabled: false
+        k8s_pod_namespace: "{{ template_namespace }}"
+      register: r
+
+    - name: Check that partial template creates resources
+      assert:
+        that:
+          - r is successful
+          - r is changed
+
   always:
+    - name: Cleanup conditional configmap
+      kubernetes.core.k8s:
+        state: absent
+        kind: ConfigMap
+        name: conditional-configmap-1
+        namespace: "{{ template_namespace }}"
+      ignore_errors: true
+
     - name: Remove namespace (Cleanup)
       kubernetes.core.k8s:
         kind: Namespace

--- a/tests/integration/targets/k8s_template/templates/conditional_empty.j2
+++ b/tests/integration/targets/k8s_template/templates/conditional_empty.j2
@@ -1,0 +1,12 @@
+{% for item in items %}
+{% if item.enabled %}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ item.name }}"
+  namespace: "{{ k8s_pod_namespace }}"
+data:
+  key: value
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
##### SUMMARY

When using `kubernetes.core.k8s` module with the `template` parameter, if the Jinja2 template renders to an empty string (e.g., all conditionals evaluate to false), the task now succeeds with `changed=false` instead of failing.

Fixes #1042

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

k8s (action plugin)

##### ADDITIONAL INFORMATION

**Before (main branch):**
```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "AttributeError: 'NoneType' object has no attribute 'read'"}
```

**After (this PR):**
```
ok: [localhost] => {"changed": false, "failed": false}
```