### PR TITLE
Add new workflow to label prs with needs_triage

### DIFF
--- a/.github/workflows/label-new-prs.yaml
+++ b/.github/workflows/label-new-prs.yaml
@@ -1,0 +1,27 @@
+---
+name: label new prs
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - converted_to_draft
+      - ready_for_review
+
+jobs:
+  add_label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Add 'needs_triage' label if the pr is not a draft
+        uses: actions-ecosystem/action-add-labels@v1
+        if: github.event.pull_request.draft == false
+        with:
+          labels: needs_triage
+
+      - name: Remove 'needs_triage' label if the pr is a draft
+        uses: actions-ecosystem/action-remove-labels@v1
+        if: github.event.pull_request.draft == true
+        with:
+          labels: needs_triage


### PR DESCRIPTION
##### SUMMARY
This pr adds a new workflow for labeling new and reopened prs that are not marked as draft. The needs_triage label will be removed if the pr is marked as draft during development and re-added once the pr is marked as ready for review.

After consulting with the team, we decided to label prs in a new workflow to allow for the prs and issues to have different labels in the future.

[ACA-2362](https://issues.redhat.com/browse/ACA-2362)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
github workflow

##### Reported CI Issues
Sanity tests: https://github.com/ansible-collections/kubernetes.core/issues/1046
