### PR TITLE
add validate-modules:bad-return-value-key to ignore list

### DIFF
--- a/tests/sanity/ignore-2.20.txt
+++ b/tests/sanity/ignore-2.20.txt
@@ -1,12 +1,12 @@
-plugins/module_utils/client/discovery.py import-3.11!skip
 plugins/module_utils/client/discovery.py import-3.12!skip
 plugins/module_utils/client/discovery.py import-3.13!skip
-plugins/module_utils/client/resource.py import-3.11!skip
+plugins/module_utils/client/discovery.py import-3.14!skip
 plugins/module_utils/client/resource.py import-3.12!skip
 plugins/module_utils/client/resource.py import-3.13!skip
-plugins/module_utils/k8sdynamicclient.py import-3.11!skip
+plugins/module_utils/client/resource.py import-3.14!skip
 plugins/module_utils/k8sdynamicclient.py import-3.12!skip
 plugins/module_utils/k8sdynamicclient.py import-3.13!skip
+plugins/module_utils/k8sdynamicclient.py import-3.14!skip
 plugins/module_utils/version.py pylint!skip
 plugins/modules/k8s.py validate-modules:parameter-type-not-in-doc
 plugins/modules/k8s_scale.py validate-modules:parameter-type-not-in-doc

--- a/tests/sanity/ignore-2.21.txt
+++ b/tests/sanity/ignore-2.21.txt
@@ -29,3 +29,6 @@ plugins/modules/k8s_taint.py validate-modules:return-syntax-error
 tests/integration/targets/helm_diff/files/test-chart-reuse-values/templates/configmap.yaml yamllint!skip
 tests/integration/targets/helm_registry_auth/tasks/main.yaml yamllint!skip
 tests/integration/targets/helm_diff/files/test-chart-deployment-time/templates/configmap.yaml yamllint!skip
+plugins/modules/helm.py validate-modules:bad-return-value-key
+plugins/modules/helm_info.py validate-modules:bad-return-value-key
+plugins/modules/k8s.py validate-modules:bad-return-value-key

--- a/tests/sanity/ignore-2.21.txt
+++ b/tests/sanity/ignore-2.21.txt
@@ -1,12 +1,12 @@
-plugins/module_utils/client/discovery.py import-3.11!skip
 plugins/module_utils/client/discovery.py import-3.12!skip
 plugins/module_utils/client/discovery.py import-3.13!skip
-plugins/module_utils/client/resource.py import-3.11!skip
+plugins/module_utils/client/discovery.py import-3.14!skip
 plugins/module_utils/client/resource.py import-3.12!skip
 plugins/module_utils/client/resource.py import-3.13!skip
-plugins/module_utils/k8sdynamicclient.py import-3.11!skip
+plugins/module_utils/client/resource.py import-3.14!skip
 plugins/module_utils/k8sdynamicclient.py import-3.12!skip
 plugins/module_utils/k8sdynamicclient.py import-3.13!skip
+plugins/module_utils/k8sdynamicclient.py import-3.14!skip
 plugins/module_utils/version.py pylint!skip
 plugins/modules/k8s.py validate-modules:parameter-type-not-in-doc
 plugins/modules/k8s_scale.py validate-modules:parameter-type-not-in-doc


### PR DESCRIPTION
##### SUMMARY
Return value key 'values', 'items', and 'keys' are not recommended for module return keys, and starting from 2.21, they will raise a warning in the ansible-test, ref. https://github.com/ansible/ansible/pull/86079

The proper way is to rename return values in the modules:
- plugins/modules/helm.py
- plugins/modules/helm_info.py
- plugins/modules/k8s.py

However, to keep backward compatibility, we need to keep them in the current `stable-6` and `stable-5` branches, and this commit is to stabilize CI for the time being.

A CI-only commit does not require a changelog. Tags `skip-changelog`, `backport-6`, and `backport-5` to be added.
  
Resolve: #1050

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
CI only
