### PR TITLE
chore(CI): prevent patchback bot from labeling new PRs

### DIFF
--- a/.github/workflows/label-new-prs.yaml
+++ b/.github/workflows/label-new-prs.yaml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   add_label:
+    if: github.actor != 'patchback[bot]'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
##### SUMMARY
Currently, the patchback bot creates PRs with cherry-picks of PRs that are labeled with `stable-*` label, and this PR (as any new PR) gets labeled as `needs_triage`. This is unnecessary as it intentional PR created by the CI job. 

This pull request introduces a small update to ensure that the workflow only runs if the pull request is not created by the `patchback[bot]` user to avoid unnecessary labels.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
.github/workflows/label-new-prs.yaml

##### ADDITIONAL INFORMATION
No changelog is required 
