### PR TITLE
Fix incorrect assertion in `helm_pull` integration test

### DIFF
--- a/tests/integration/targets/helm_pull/tasks/main.yml
+++ b/tests/integration/targets/helm_pull/tasks/main.yml
@@ -47,7 +47,7 @@
           assert:
             that:
               - _result is failed
-              - _result.msg == "This module requires helm >= 3.0.0, current version is 2.3.0"
+              - _result.msg == "Helm version must be >=3.0.0,<4.0.0, current version is 2.3.0"
 
       vars:
         helm_path: "{{ temp_dir }}/2.3.0/linux-amd64/helm"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The error message emitted for incorrect helm version [has changed](https://github.com/ansible-collections/kubernetes.core/pull/1039/files#diff-431933ff8d6b93866cb00408ed1e8a633fe4cacee835382bb3a88e40b6edffbeL224-L229) since the merge of #1039. This PR updates the related assertion in the `helm_pull` integration test
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

