### PR TITLE
Update pod deletion conditions for local storage used in a daemon set pod

### DIFF
--- a/changelogs/fragments/20260306-k8s_drain-delete-logic-fixes-for-daemonsets.yaml
+++ b/changelogs/fragments/20260306-k8s_drain-delete-logic-fixes-for-daemonsets.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - k8s_drain - Fix logic for handling pods with local storage to correctly check for empty_dir volumes in replicated pods and pods managed by DaemonSets (https://github.com/ansible-collections/kubernetes.core/pull/1095).

--- a/plugins/modules/k8s_drain.py
+++ b/plugins/modules/k8s_drain.py
@@ -214,21 +214,24 @@ def filter_pods(pods, force, ignore_daemonset, delete_emptydir_data):
             to_delete.append((pod.metadata.namespace, pod.metadata.name))
             continue
 
-        # Pod with local storage cannot be deleted
-        if pod.spec.volumes and any(vol.empty_dir for vol in pod.spec.volumes):
-            localStorage.append((pod.metadata.namespace, pod.metadata.name))
-            continue
-
         # Check replicated Pod
         owner_ref = pod.metadata.owner_references
         if not owner_ref:
-            unmanaged.append((pod.metadata.namespace, pod.metadata.name))
+            # Pod with local storage cannot be deleted
+            if pod.spec.volumes and any(vol.empty_dir for vol in pod.spec.volumes):
+                localStorage.append((pod.metadata.namespace, pod.metadata.name))
+            else:
+                unmanaged.append((pod.metadata.namespace, pod.metadata.name))
         else:
             for owner in owner_ref:
                 if owner.kind == "DaemonSet":
                     daemonSet.append((pod.metadata.namespace, pod.metadata.name))
                 else:
-                    to_delete.append((pod.metadata.namespace, pod.metadata.name))
+                    # Pod with local storage cannot be deleted
+                    if pod.spec.volumes and any(vol.empty_dir for vol in pod.spec.volumes):
+                        localStorage.append((pod.metadata.namespace, pod.metadata.name))
+                    else:
+                        to_delete.append((pod.metadata.namespace, pod.metadata.name))
 
     warnings, errors, info = [], [], []
     if unmanaged:

--- a/plugins/modules/k8s_drain.py
+++ b/plugins/modules/k8s_drain.py
@@ -200,7 +200,7 @@ def format_dynamic_api_exc(exc):
         return "%s Reason: %s" % (exc.status, exc.reason)
 
 
-def filter_pods(pods, force, ignore_daemonset, delete_emptydir_data):  
+def filter_pods(pods, force, ignore_daemonset, delete_emptydir_data):
     k8s_kind_mirror = "kubernetes.io/config.mirror"
     daemonSet, unmanaged, mirror, localStorage, to_delete = [], [], [], [], []
     for pod in pods:
@@ -215,9 +215,12 @@ def filter_pods(pods, force, ignore_daemonset, delete_emptydir_data):
             continue
 
         # Check replicated Pod
-        has_local_storage = bool(pod.spec.volumes and any(vol.empty_dir for vol in pod.spec.volumes))
-        is_daemonset_managed = any(owner.kind == "DaemonSet" for owner in owner_ref or [])
-        
+        owner_ref = pod.metadata.owner_references or []
+        has_local_storage = bool(
+            pod.spec.volumes and any(vol.empty_dir for vol in pod.spec.volumes)
+        )
+        is_daemonset_managed = any(owner.kind == "DaemonSet" for owner in owner_ref)
+
         if is_daemonset_managed:
             daemonSet.append((pod.metadata.namespace, pod.metadata.name))
         elif has_local_storage:

--- a/plugins/modules/k8s_drain.py
+++ b/plugins/modules/k8s_drain.py
@@ -200,7 +200,7 @@ def format_dynamic_api_exc(exc):
         return "%s Reason: %s" % (exc.status, exc.reason)
 
 
-def filter_pods(pods, force, ignore_daemonset, delete_emptydir_data):
+def filter_pods(pods, force, ignore_daemonset, delete_emptydir_data):  
     k8s_kind_mirror = "kubernetes.io/config.mirror"
     daemonSet, unmanaged, mirror, localStorage, to_delete = [], [], [], [], []
     for pod in pods:
@@ -215,23 +215,17 @@ def filter_pods(pods, force, ignore_daemonset, delete_emptydir_data):
             continue
 
         # Check replicated Pod
-        owner_ref = pod.metadata.owner_references
-        if not owner_ref:
-            # Pod with local storage cannot be deleted
-            if pod.spec.volumes and any(vol.empty_dir for vol in pod.spec.volumes):
-                localStorage.append((pod.metadata.namespace, pod.metadata.name))
-            else:
-                unmanaged.append((pod.metadata.namespace, pod.metadata.name))
+        has_local_storage = bool(pod.spec.volumes and any(vol.empty_dir for vol in pod.spec.volumes))
+        is_daemonset_managed = any(owner.kind == "DaemonSet" for owner in owner_ref or [])
+        
+        if is_daemonset_managed:
+            daemonSet.append((pod.metadata.namespace, pod.metadata.name))
+        elif has_local_storage:
+            localStorage.append((pod.metadata.namespace, pod.metadata.name))
+        elif not owner_ref:
+            unmanaged.append((pod.metadata.namespace, pod.metadata.name))
         else:
-            for owner in owner_ref:
-                if owner.kind == "DaemonSet":
-                    daemonSet.append((pod.metadata.namespace, pod.metadata.name))
-                else:
-                    # Pod with local storage cannot be deleted
-                    if pod.spec.volumes and any(vol.empty_dir for vol in pod.spec.volumes):
-                        localStorage.append((pod.metadata.namespace, pod.metadata.name))
-                    else:
-                        to_delete.append((pod.metadata.namespace, pod.metadata.name))
+            to_delete.append((pod.metadata.namespace, pod.metadata.name))
 
     warnings, errors, info = [], [], []
     if unmanaged:


### PR DESCRIPTION
Refactor pod deletion logic to handle local storage in daemon set pods correctly.

##### SUMMARY
The usage of volumes/storage has to be evaluated in both scenarios: replicated and non-replicated pods.

The fact that a pod is controlled by DaemonSet should be prioritised over the fact that uses local storage. 

Fixes #622

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
k8s_drain

##### ADDITIONAL INFORMATION
if you deploy any daemonset using volumes and then want to drain a node with:

```yaml
 delete_options:
       delete_emptydir_data: true
       ignore_daemonsets: true
```

you will run into issues... in my case I can tell Kube-OVN and KubeVirt DaemonSets get wrongly handled...
