### PR TITLE
trivial(doc): post #1090 cosmetic update

### DIFF
--- a/docs/kubernetes.core.helm_info_module.rst
+++ b/docs/kubernetes.core.helm_info_module.rst
@@ -25,7 +25,7 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- helm (https://github.com/helm/helm/releases)
+- helm >= 3.0.0 (https://github.com/helm/helm/releases)
 - yaml (https://pypi.org/project/PyYAML/)
 
 
@@ -268,7 +268,7 @@ Examples
 
 Return Values
 -------------
-Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+Common return values are documented `here <https://docs.ansible.com/projects/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
 
 .. raw:: html
 
@@ -414,6 +414,23 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                     <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>release_values</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">dictionary</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 6.3.0</div>
+                </td>
+                <td>always</td>
+                <td>
+                            <div>Dict of Values used to deploy.</div>
+                    <br/>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
                     <b>revision</b>
                     <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
                     <div style="font-size: small">
@@ -465,12 +482,13 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                     <b>values</b>
                     <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
                     <div style="font-size: small">
-                      <span style="color: purple">string</span>
+                      <span style="color: purple">dictionary</span>
                     </div>
                 </td>
                 <td>always</td>
                 <td>
                             <div>Dict of Values used to deploy</div>
+                            <div>This return value has been deprecated and will be removed in a release after 2027-01-08. Use RV(status.release_values) instead.</div>
                     <br/>
                 </td>
             </tr>

--- a/docs/kubernetes.core.helm_module.rst
+++ b/docs/kubernetes.core.helm_module.rst
@@ -25,7 +25,7 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- helm (https://github.com/helm/helm/releases)
+- helm >= 3.0.0 (https://github.com/helm/helm/releases)
 - yaml (https://pypi.org/project/PyYAML/)
 
 
@@ -660,7 +660,7 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>When upgrading, Helm will ignore the check for helm annotations and take ownership of the existing resources</div>
+                        <div>Helm will ignore the check for helm annotations and take ownership of the existing resources</div>
                         <div>This feature requires helm &gt;= 3.17.0</div>
                 </td>
             </tr>
@@ -920,7 +920,7 @@ Examples
 
 Return Values
 -------------
-Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+Common return values are documented `here <https://docs.ansible.com/projects/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
 
 .. raw:: html
 
@@ -1030,6 +1030,23 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                     <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>release_values</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">dictionary</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 6.3.0</div>
+                </td>
+                <td>always</td>
+                <td>
+                            <div>Dict of Values used to deploy.</div>
+                    <br/>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
                     <b>revision</b>
                     <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
                     <div style="font-size: small">
@@ -1081,12 +1098,13 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                     <b>values</b>
                     <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
                     <div style="font-size: small">
-                      <span style="color: purple">string</span>
+                      <span style="color: purple">dictionary</span>
                     </div>
                 </td>
                 <td>always</td>
                 <td>
-                            <div>Dict of Values used to deploy</div>
+                            <div>Dict of Values used to deploy.</div>
+                            <div>This return value has been deprecated and will be removed in a release after 2027-01-08. Use RV(status.release_values) instead.</div>
                     <br/>
                 </td>
             </tr>

--- a/docs/kubernetes.core.helm_plugin_info_module.rst
+++ b/docs/kubernetes.core.helm_plugin_info_module.rst
@@ -25,7 +25,7 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- helm (https://github.com/helm/helm/releases)
+- helm >= 3.0.0 (https://github.com/helm/helm/releases)
 
 
 Parameters
@@ -196,7 +196,7 @@ Examples
 
 Return Values
 -------------
-Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+Common return values are documented `here <https://docs.ansible.com/projects/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
 
 .. raw:: html
 

--- a/docs/kubernetes.core.helm_plugin_module.rst
+++ b/docs/kubernetes.core.helm_plugin_module.rst
@@ -25,7 +25,7 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- helm (https://github.com/helm/helm/releases)
+- helm >= 3.0.0 (https://github.com/helm/helm/releases)
 
 
 Parameters
@@ -231,6 +231,28 @@ Parameters
                         <div style="font-size: small; color: darkgreen"><br/>aliases: verify_ssl</div>
                 </td>
             </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>verify</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 6.4.0</div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Verify the plugin signature before installing.</div>
+                        <div>This option requires helm version &gt;= 4.0.0</div>
+                        <div>Used with <em>state=present</em>.</div>
+                </td>
+            </tr>
     </table>
     <br/>
 
@@ -272,7 +294,7 @@ Examples
 
 Return Values
 -------------
-Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+Common return values are documented `here <https://docs.ansible.com/projects/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
 
 .. raw:: html
 

--- a/docs/kubernetes.core.helm_pull_module.rst
+++ b/docs/kubernetes.core.helm_pull_module.rst
@@ -27,7 +27,7 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- helm >= 3.0, <4.0.0 (https://github.com/helm/helm/releases)
+- helm >= 3.0.0 (https://github.com/helm/helm/releases)
 
 
 Parameters

--- a/docs/kubernetes.core.helm_registry_auth_module.rst
+++ b/docs/kubernetes.core.helm_registry_auth_module.rst
@@ -25,7 +25,7 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- helm (https://github.com/helm/helm/releases) >= 3.8.0, <4.0.0
+- helm (https://github.com/helm/helm/releases) >= 3.8.0
 
 
 Parameters
@@ -149,6 +149,27 @@ Parameters
                 <td>
                         <div>Password for the registry.</div>
                         <div style="font-size: small; color: darkgreen"><br/>aliases: repo_password</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>plain_http</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 6.4.0</div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                    <li>yes</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Use insecure HTTP connections for <code>helm registry login</code>.</div>
+                        <div>Requires Helm &gt;= 3.18.0</div>
                 </td>
             </tr>
             <tr>

--- a/docs/kubernetes.core.helm_repository_module.rst
+++ b/docs/kubernetes.core.helm_repository_module.rst
@@ -25,7 +25,7 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- helm (https://github.com/helm/helm/releases)
+- helm >= 3.0.0 (https://github.com/helm/helm/releases)
 - yaml (https://pypi.org/project/PyYAML/)
 
 
@@ -336,7 +336,7 @@ Examples
 
 Return Values
 -------------
-Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+Common return values are documented `here <https://docs.ansible.com/projects/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
 
 .. raw:: html
 

--- a/docs/kubernetes.core.helm_template_module.rst
+++ b/docs/kubernetes.core.helm_template_module.rst
@@ -20,6 +20,13 @@ Synopsis
 
 
 
+Requirements
+------------
+The below requirements are needed on the host that executes this module.
+
+- helm >= 3.0.0 (https://github.com/helm/helm/releases)
+- yaml (https://pypi.org/project/PyYAML/)
+
 
 Parameters
 ----------
@@ -430,7 +437,7 @@ Examples
 
 Return Values
 -------------
-Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+Common return values are documented `here <https://docs.ansible.com/projects/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
 
 .. raw:: html
 

--- a/tests/integration/targets/helm_v3_15_4/play.yaml
+++ b/tests/integration/targets/helm_v3_15_4/play.yaml
@@ -1,4 +1,4 @@
-- name: Run tests for Helm v4.0.0
+- name: Run tests for Helm v3.15.4
   hosts: all
   connection: local
   gather_facts: true

--- a/tests/integration/targets/helm_v3_16_0/play.yaml
+++ b/tests/integration/targets/helm_v3_16_0/play.yaml
@@ -1,4 +1,4 @@
-- name: Run tests for Helm v4.0.0
+- name: Run tests for Helm v3.16.0
   hosts: all
   connection: local
   gather_facts: true

--- a/tests/integration/targets/helm_v3_17_0/play.yaml
+++ b/tests/integration/targets/helm_v3_17_0/play.yaml
@@ -1,4 +1,4 @@
-- name: Run tests for Helm v4.0.0
+- name: Run tests for Helm v3.17.0
   hosts: all
   connection: local
   gather_facts: true


### PR DESCRIPTION
##### SUMMARY
Name of the Helm plays in the integration test framework test updated to reflect the actual version of Helm (addressed comments https://github.com/ansible-collections/kubernetes.core/pull/1090#pullrequestreview-3902997721) 

Updated documentation for the modules updated in the PR with the https://github.com/ansible-network/collection_prep, as per CONTRIBUTING.md

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- tests/integration/targets/helm_v3_*/play.yaml
- docs/kubernetes.core.helm*.rst

##### ADDITIONAL INFORMATION
Only cosmetic changes in this PR, so the label `skip-changelog` is suggested
