### PR TITLE
ci: remove cloud.common and turbo mode from testing matrix

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -49,7 +49,6 @@ jobs:
     if: ${{ needs.splitter.outputs.test_targets != '' }}
     env:
       source: "./source"
-      cloud_common: "./cloudcommon"
       ansible_posix: "./ansible_posix"
       community_general: "./community_general"
     strategy:
@@ -60,7 +59,6 @@ jobs:
         python-version:
           - "3.12"
         enable-turbo-mode:
-          - true
           - false
         workflow-id: ${{ fromJson(needs.splitter.outputs.test_jobs) }}
     name: "integration-py${{ matrix.python-version }}-${{ matrix.ansible-version }}-${{ matrix.workflow-id }}-enable_turbo=${{ matrix.enable-turbo-mode }}"
@@ -106,13 +104,6 @@ jobs:
           install_python_dependencies: true
           source_path: ${{ env.source }}
 
-      - name: checkout ansible-collections/cloud.common
-        uses: ansible-network/github_actions/.github/actions/checkout_dependency@main
-        with:
-          repository: ansible-collections/cloud.common
-          path: ${{ env.cloud_common }}
-          ref: main
-
       - name: checkout ansible-collections/ansible.posix
         uses: ansible-network/github_actions/.github/actions/checkout_dependency@main
         with:
@@ -126,12 +117,6 @@ jobs:
           repository: ansible-collections/community.general
           path: ${{ env.community_general }}
           ref: main
-
-      - name: install cloud.common collection
-        uses: ansible-network/github_actions/.github/actions/build_install_collection@main
-        with:
-          install_python_dependencies: true
-          source_path: ${{ env.cloud_common }}
 
       - name: install ansible.posix collection
         uses: ansible-network/github_actions/.github/actions/build_install_collection@main


### PR DESCRIPTION
##### SUMMARY
The cloud.common collection is incompatible with ansible-core >= 2.19.0. With the current testing matrix using Python 3.12 and the ansible milestone (currently 2.22), this incompatibility causes integration tests to fail.

This commit removes the installation of the cloud.common collection and removes turbo mode from the testing matrix to fix CI test runs.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

`.github/workflows/integration-tests.yaml`

##### ADDITIONAL INFORMATION

Fixes the issue that led to failed CI in #1101