### PR TITLE
ci: conditionally test turbo mode and cloud.common

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -55,13 +55,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ansible-version:
-          - milestone
+        ansible-version: ["2.18", "milestone"]
+        enable-turbo-mode: [true, false]
+        exclude:
+          - ansible-version: "milestone"
+            enable-turbo-mode: true
         python-version:
           - "3.12"
-        enable-turbo-mode:
-          - true
-          - false
         workflow-id: ${{ fromJson(needs.splitter.outputs.test_jobs) }}
     name: "integration-py${{ matrix.python-version }}-${{ matrix.ansible-version }}-${{ matrix.workflow-id }}-enable_turbo=${{ matrix.enable-turbo-mode }}"
     steps:
@@ -107,6 +107,7 @@ jobs:
           source_path: ${{ env.source }}
 
       - name: checkout ansible-collections/cloud.common
+        if: ${{ matrix.enable-turbo-mode == true }}
         uses: ansible-network/github_actions/.github/actions/checkout_dependency@main
         with:
           repository: ansible-collections/cloud.common
@@ -128,6 +129,7 @@ jobs:
           ref: main
 
       - name: install cloud.common collection
+        if: ${{ matrix.enable-turbo-mode == true }}
         uses: ansible-network/github_actions/.github/actions/build_install_collection@main
         with:
           install_python_dependencies: true


### PR DESCRIPTION
##### SUMMARY
The cloud.common collection is incompatible with ansible-core >= 2.19.0. With the current testing matrix using Python 3.12 and the ansible milestone (currently 2.22), this incompatibility causes integration tests to fail.

Instead of [completely removing turbo mode from the testing matrix](https://github.com/ansible-collections/kubernetes.core/pull/1108), this PR adds ansible-core 2.18 to the matrix and excludes the combination of the ansible milestone and turbo mode. The checkout and installation of the cloud.common collection are now conditionally executed only when turbo mode is enabled.

It keeps testing of turbo mode and also testing of milestone for the ensure compatiability with the upcoming version of ansible-core. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

`.github/workflows/integration-tests.yaml`

##### ADDITIONAL INFORMATION

Fixes the issue that led to failed CI in #1101. Alternative approach of #1108
