### PR TITLE
Update URL reference in `integration-test` CI file

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -55,7 +55,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ansible-version: ["2.18", "milestone"]
+        # Ref must match a branch/tag on github.com/ansible/ansible (e.g. stable-2.18, not 2.18).
+        ansible-version: ["stable-2.18", "milestone"]
         enable-turbo-mode: [true, false]
         exclude:
           - ansible-version: "milestone"


### PR DESCRIPTION
Even after the merge of https://github.com/ansible-collections/kubernetes.core/pull/1109 the integration tests in #1101 are still failing with:

```
Collecting https://github.com/ansible/ansible/archive/2.18.tar.gz
  ERROR: HTTP error 404 while getting https://github.com/ansible/ansible/archive/2.18.tar.gz
ERROR: Could not install requirement https://github.com/ansible/ansible/archive/2.18.tar.gz because of HTTP error 404 Client Error: Not Found for url: https://codeload.github.com/ansible/ansible/tar.gz/2.18 for URL https://github.com/ansible/ansible/archive/2.18.tar.gz
```

The `ansible/ansible` repo uses maintenance branches named [`stable-2.18`](https://github.com/ansible/ansible/tree/stable-2.18), not `2.18` — there's no `2.18` ref, so the archive returns 404. Updating the workflow matrix to reference `stable-2.18`.