### PR TITLE
fix(helm_repository): strip trailing slashes from repo_url

### DIFF
--- a/changelogs/fragments/20260506-improve_idempotency_for_helm_repository.yaml
+++ b/changelogs/fragments/20260506-improve_idempotency_for_helm_repository.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - helm_repository - correct handling of repository URLs with trailing slashes (https://github.com/ansible-collections/kubernetes.core/pull/1121).

--- a/plugins/modules/helm_repository.py
+++ b/plugins/modules/helm_repository.py
@@ -302,6 +302,8 @@ def main():
 
     repo_name = module.params.get("repo_name")
     repo_url = module.params.get("repo_url")
+    if repo_url:
+        repo_url = repo_url.rstrip("/")
     repo_username = module.params.get("repo_username")
     repo_password = module.params.get("repo_password")
     repo_state = module.params.get("repo_state")


### PR DESCRIPTION
##### SUMMARY
Helm normalizes repository URLs internally, so a URL supplied with a trailing slash and the same URL without one are treated as different entries. This causes the module to fail every run when the user provides a trailing slash, even though the repository is already correctly registered.

Strip the trailing slash from repo_url before comparing against the existing repository list so repeated runs with the same input are idempotent.

Fixes #480

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION

Step to reproduce:
```
- hosts: localhost
  gather_facts: no
  tasks:
    - kubernetes.core.helm_repository:
        repo_url: https://charts.bitnami.com/bitnami
        name: bitnami

    - kubernetes.core.helm_repository:
        repo_url: https://charts.bitnami.com/bitnami/ # note the trailing "/"
        name: bitnami
```

Before change:
```
PLAY [localhost] *******************************************************************************************************

TASK [kubernetes.core.helm_repository] *********************************************************************************
changed: [localhost]

TASK [kubernetes.core.helm_repository] *********************************************************************************
[ERROR]: Task failed: Module failed: Repository already have a repository named bitnami
Origin: /test.yaml:8:7

6         name: bitnami
7
8     - kubernetes.core.helm_repository:
        ^ column 7

fatal: [localhost]: FAILED! => {"changed": false, "msg": "Repository already have a repository named bitnami"}

PLAY RECAP *************************************************************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```

After the change:
```
PLAY [localhost] *******************************************************************************************************

TASK [kubernetes.core.helm_repository] *********************************************************************************
changed: [localhost]

TASK [kubernetes.core.helm_repository] *********************************************************************************
ok: [localhost]

PLAY RECAP *************************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

