### PR TITLE
[ACA-5027] Add SonarQube Cloud Test Coverage Info

### DIFF
--- a/.github/workflows/all_green_check.yaml
+++ b/.github/workflows/all_green_check.yaml
@@ -87,6 +87,8 @@ jobs:
     steps:
       - run: |
           python -c "
+          import sys
+
           required = ['sanity', 'units', 'coverage']
           if '${{ github.event_name }}' == 'pull_request':
               required = ['linters', 'sanity', 'units', 'coverage']
@@ -96,7 +98,29 @@ jobs:
               'units': '${{ needs.units.result }}',
               'coverage': '${{ needs.coverage.result }}',
           }
-          ok = all(results[j] == 'success' for j in required)
-          skipped_ok = all(results[j] in ('success', 'skipped') for j in results)
-          assert ok and skipped_ok, f'required={required} results={results}'
+
+          for name in required:
+              if results[name] == 'failure':
+                  print(f'all_green: required job failed: {name} results={results}', file=sys.stderr)
+                  sys.exit(1)
+
+          # cancel-in-progress superseded this run; do not fail (newer run is authoritative)
+          if any(v == 'cancelled' for v in results.values()):
+              print(
+                  'all_green: one or more jobs cancelled (usually concurrency); skipping strict gate.',
+                  results,
+              )
+              sys.exit(0)
+
+          not_ok = [j for j in required if results[j] != 'success']
+          if not_ok:
+              print(f'all_green: required jobs not success: {not_ok} results={results}', file=sys.stderr)
+              sys.exit(1)
+
+          for job, status in results.items():
+              if job not in required and status not in ('success', 'skipped'):
+                  print(f'all_green: unexpected {job}={status} results={results}', file=sys.stderr)
+                  sys.exit(1)
+
+          print('all_green OK', results)
           "

--- a/.github/workflows/all_green_check.yaml
+++ b/.github/workflows/all_green_check.yaml
@@ -1,0 +1,102 @@
+---
+name: all_green
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+on: # yamllint disable-line rule:truthy
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    branches:
+      - main
+      - stable-*
+  push:
+    branches:
+      - main
+      - stable-*
+
+jobs:
+  linters:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/linters.yaml
+
+  sanity:
+    uses: ./.github/workflows/sanity-tests.yaml
+
+  units:
+    uses: ./.github/workflows/unit-tests.yaml
+
+  coverage:
+    name: Unit test coverage
+    runs-on: ubuntu-latest
+    needs:
+      - sanity
+      - units
+    env:
+      ANSIBLE_CORE_VERSION: "2.19.5"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Ansible (ansible-test)
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "ansible-core==${ANSIBLE_CORE_VERSION}"
+
+      - name: Run unit tests with coverage
+        run: ansible-test units --venv --coverage --python 3.12 --requirements
+
+      - name: Combine and emit coverage XML
+        run: |
+          ansible-test coverage combine --venv --python 3.12 --requirements
+          ansible-test coverage xml --venv --python 3.12 --requirements
+
+      - name: Prepare coverage.xml for SonarCloud
+        run: |
+          set -euo pipefail
+          mkdir -p "${GITHUB_WORKSPACE}"
+          xml=$(find tests/output/reports -maxdepth 1 -name '*.xml' ! -name '*powershell*' | head -1)
+          test -n "${xml}"
+          cp "${xml}" "${GITHUB_WORKSPACE}/coverage.xml"
+          # Strip workspace prefix so Sonar sees repo-relative paths (same idea as amazon.aws path rewrite)
+          sed -i "s#${GITHUB_WORKSPACE}/##g" "${GITHUB_WORKSPACE}/coverage.xml"
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: ${{ github.workspace }}/coverage.xml
+
+  all_green:
+    if: ${{ always() }}
+    needs:
+      - linters
+      - sanity
+      - units
+      - coverage
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          python -c "
+          required = ['sanity', 'units', 'coverage']
+          if '${{ github.event_name }}' == 'pull_request':
+              required = ['linters', 'sanity', 'units', 'coverage']
+          results = {
+              'linters': '${{ needs.linters.result }}',
+              'sanity': '${{ needs.sanity.result }}',
+              'units': '${{ needs.units.result }}',
+              'coverage': '${{ needs.coverage.result }}',
+          }
+          ok = all(results[j] == 'success' for j in required)
+          skipped_ok = all(results[j] in ('success', 'skipped') for j in results)
+          assert ok and skipped_ok, f'required={required} results={results}'
+          "

--- a/.github/workflows/all_green_check.yaml
+++ b/.github/workflows/all_green_check.yaml
@@ -124,3 +124,18 @@ jobs:
 
           print('all_green OK', results)
           "
+
+  sonarcloud:
+    name: SonarCloud scan
+    needs:
+      - all_green
+      - coverage
+    if: >-
+      ${{ needs.all_green.result == 'success'
+      && secrets.ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT != ''
+      && (github.event_name == 'push'
+      || (github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name == github.repository)) }}
+    uses: ./.github/workflows/sonarcloud.yml
+    secrets:
+      ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT: ${{ secrets.ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT }}

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -5,6 +5,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  workflow_call:
   pull_request:
     branches:
       - main

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -5,6 +5,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  workflow_call:
   pull_request:
     branches:
       - main

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,70 +1,85 @@
----
-# SonarCloud analysis for kubernetes.core
+## SonarCloud for kubernetes.core
 #
-# Uses the same-repo + default-branch push model: GitHub does not expose org secrets to workflows
-# from fork PRs (see https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
-# This job is gated so the Sonar token is never available in untrusted fork contexts. A follow-up
-# workflow triggered by workflow_run + artifacts is an alternative if the org later requires Sonar
-# with coverage on fork PRs (see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run).
+# Triggered after **all_green** (linters on PR, sanity, units, coverage). Downloads **coverage***
+# artifacts and passes **sonar.python.coverage.reportPaths** to the scanner, matching
+# ansible-collections/amazon.aws (see https://github.com/ansible-collections/amazon.aws/pull/2871).
+
+---
 name: SonarCloud
 
 on:
-  push:
-    branches:
-      - main
-      - stable-*
-  pull_request:
-    branches:
-      - main
-      - stable-*
-  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - all_green
+    types:
+      - completed
 
 permissions:
   contents: read
   pull-requests: read
+  actions: read
 
 jobs:
-  sonarqube:
-    name: SonarCloud Scan
+  finalize:
+    name: finalize
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    env:
-      # Pin ansible-test behavior; bump when raising supported ansible-core (see meta/runtime.yml).
-      ANSIBLE_CORE_VERSION: "2.19.5"
+    if: github.event.workflow_run.conclusion == 'success'
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
+          show-progress: false
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Download coverage artifacts
+        uses: dawidd6/action-download-artifact@2536c51d3d126276eb39f74d6bc9c72ac6ef30d3  # v16
         with:
-          python-version: "3.12"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: all_green
+          run_id: ${{ github.event.workflow_run.id }}
+          pattern: coverage*
 
-      - name: Install Ansible (ansible-test)
+      - name: Set coverage report paths
         run: |
-          pip install --upgrade pip
-          pip install "ansible-core==${ANSIBLE_CORE_VERSION}"
+          coverage_files=$(find . -name "coverage*.xml" -type f 2>/dev/null | tr '\n' ',' | sed 's/,$//')
+          echo "Found coverage files: ${coverage_files:-none}"
+          echo "COVERAGE_PATHS=${coverage_files}" >> "$GITHUB_ENV"
 
-      - name: Unit tests with coverage
-        run: ansible-test units --venv --coverage --python 3.12 --requirements
-
-      - name: Coverage combine and XML for Sonar
+      - name: Get PR number and info
+        if: github.event.workflow_run.event == 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          REPO: ${{ github.repository }}
         run: |
-          ansible-test coverage combine --venv --python 3.12 --requirements
-          ansible-test coverage xml --venv --python 3.12 --requirements
+          PR_NUMBER=$(gh pr list --head "$HEAD_BRANCH" --repo "$REPO" --json number -q '.[0].number')
+          echo "PR_NUMBER=$PR_NUMBER" >> "$GITHUB_ENV"
+          if [ -n "$PR_NUMBER" ]; then
+            PR_DATA=$(gh api "repos/$REPO/pulls/$PR_NUMBER")
+            echo "PR_BASE=$(echo "$PR_DATA" | jq -r '.base.ref')" >> "$GITHUB_ENV"
+            echo "PR_HEAD=$(echo "$PR_DATA" | jq -r '.head.ref')" >> "$GITHUB_ENV"
+          fi
 
-      - name: Copy coverage report to repo root
+      - name: Prepare SonarCloud args
+        env:
+          COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
+          EVENT_TYPE: ${{ github.event.workflow_run.event }}
         run: |
-          set -euo pipefail
-          ls -la tests/output/reports/
-          xml=$(find tests/output/reports -maxdepth 1 -name '*.xml' ! -name '*powershell*' | head -1)
-          test -n "$xml"
-          cp "$xml" coverage.xml
+          SONAR_ARGS="-Dsonar.scm.revision=\"${COMMIT_SHA}\""
+          if [[ "$EVENT_TYPE" == "pull_request" && -n "${PR_NUMBER:-}" ]]; then
+            SONAR_ARGS="${SONAR_ARGS} -Dsonar.pullrequest.key=${PR_NUMBER}"
+            SONAR_ARGS="${SONAR_ARGS} -Dsonar.pullrequest.branch=${PR_HEAD}"
+            SONAR_ARGS="${SONAR_ARGS} -Dsonar.pullrequest.base=${PR_BASE}"
+          fi
+          if [[ -n "${COVERAGE_PATHS:-}" ]]; then
+            SONAR_ARGS="${SONAR_ARGS} -Dsonar.python.coverage.reportPaths=${COVERAGE_PATHS}"
+          fi
+          echo "SONAR_ARGS=${SONAR_ARGS}" >> "$GITHUB_ENV"
 
       - name: SonarCloud Scan
-        # Same pinned version as ansible-collections/amazon.aws sonarcloud.yml
         uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9
         env:
           SONAR_TOKEN: ${{ secrets.ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT }}
+        with:
+          args: ${{ env.SONAR_ARGS }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,51 +1,39 @@
-## SonarCloud for kubernetes.core
+## SonarCloud scan (reusable)
 #
-# Triggered after **all_green** (linters on PR, sanity, units, coverage). Downloads **coverage***
-# artifacts and passes **sonar.python.coverage.reportPaths** to the scanner, matching
-# ansible-collections/amazon.aws (see https://github.com/ansible-collections/amazon.aws/pull/2871).
-#
-# The finalize job runs only when **head_repository** matches this repo so we never checkout or scan
-# arbitrary commits from fork refs with org secrets (SonarCloud security gate / fork PR limitation).
+# Invoked from **all_green** after the aggregate gate and **coverage** succeed. Uses the **caller's**
+# **pull_request** / **push** event so **actions/checkout** can use **github.event.pull_request.head.sha**
+# on PRs (Sonar-compliant). Not triggered by **workflow_run** + **workflow_run.head_sha** checkout.
 
 ---
 name: SonarCloud
 
 on:
-  workflow_run:
-    workflows:
-      - all_green
-    types:
-      - completed
+  workflow_call:
+    secrets:
+      ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT:
+        required: true
 
 permissions:
   contents: read
   pull-requests: read
-  actions: read
 
 jobs:
-  finalize:
-    name: finalize
+  scan:
+    name: SonarCloud scan
     runs-on: ubuntu-latest
-    if: >-
-      ${{ github.event.workflow_run.conclusion == 'success'
-      && github.repository == 'ansible-collections/kubernetes.core'
-      && github.event.workflow_run.head_repository.full_name == github.repository
-      && secrets.ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT != '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
           show-progress: false
 
-      - name: Download coverage artifacts
-        uses: dawidd6/action-download-artifact@2536c51d3d126276eb39f74d6bc9c72ac6ef30d3  # v16
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: all_green
-          run_id: ${{ github.event.workflow_run.id }}
-          pattern: coverage*
+          name: coverage
+          path: .
 
       - name: Set coverage report paths
         run: |
@@ -53,31 +41,19 @@ jobs:
           echo "Found coverage files: ${coverage_files:-none}"
           echo "COVERAGE_PATHS=${coverage_files}" >> "$GITHUB_ENV"
 
-      - name: Get PR number and info
-        if: github.event.workflow_run.event == 'pull_request'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-          REPO: ${{ github.repository }}
-        run: |
-          PR_NUMBER=$(gh pr list --head "$HEAD_BRANCH" --repo "$REPO" --json number -q '.[0].number')
-          echo "PR_NUMBER=$PR_NUMBER" >> "$GITHUB_ENV"
-          if [ -n "$PR_NUMBER" ]; then
-            PR_DATA=$(gh api "repos/$REPO/pulls/$PR_NUMBER")
-            echo "PR_BASE=$(echo "$PR_DATA" | jq -r '.base.ref')" >> "$GITHUB_ENV"
-            echo "PR_HEAD=$(echo "$PR_DATA" | jq -r '.head.ref')" >> "$GITHUB_ENV"
-          fi
-
       - name: Prepare SonarCloud args
         env:
-          COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
-          EVENT_TYPE: ${{ github.event.workflow_run.event }}
+          COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
+          PR_HEAD_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
+          PR_BASE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || '' }}
         run: |
           SONAR_ARGS="-Dsonar.scm.revision=\"${COMMIT_SHA}\""
-          if [[ "$EVENT_TYPE" == "pull_request" && -n "${PR_NUMBER:-}" ]]; then
+          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
             SONAR_ARGS="${SONAR_ARGS} -Dsonar.pullrequest.key=${PR_NUMBER}"
-            SONAR_ARGS="${SONAR_ARGS} -Dsonar.pullrequest.branch=${PR_HEAD}"
-            SONAR_ARGS="${SONAR_ARGS} -Dsonar.pullrequest.base=${PR_BASE}"
+            SONAR_ARGS="${SONAR_ARGS} -Dsonar.pullrequest.branch=${PR_HEAD_REF}"
+            SONAR_ARGS="${SONAR_ARGS} -Dsonar.pullrequest.base=${PR_BASE_REF}"
           fi
           if [[ -n "${COVERAGE_PATHS:-}" ]]; then
             SONAR_ARGS="${SONAR_ARGS} -Dsonar.python.coverage.reportPaths=${COVERAGE_PATHS}"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -3,6 +3,9 @@
 # Triggered after **all_green** (linters on PR, sanity, units, coverage). Downloads **coverage***
 # artifacts and passes **sonar.python.coverage.reportPaths** to the scanner, matching
 # ansible-collections/amazon.aws (see https://github.com/ansible-collections/amazon.aws/pull/2871).
+#
+# The finalize job runs only when **head_repository** matches this repo so we never checkout or scan
+# arbitrary commits from fork refs with org secrets (SonarCloud security gate / fork PR limitation).
 
 ---
 name: SonarCloud
@@ -23,7 +26,11 @@ jobs:
   finalize:
     name: finalize
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
+    if: >-
+      ${{ github.event.workflow_run.conclusion == 'success'
+      && github.repository == 'ansible-collections/kubernetes.core'
+      && github.event.workflow_run.head_repository.full_name == github.repository
+      && secrets.ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT != '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -4,6 +4,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  workflow_call:
   pull_request:
     branches:
       - main

--- a/CI.md
+++ b/CI.md
@@ -30,3 +30,7 @@ These are outlined in the collection's [tox.ini](tox.ini) file (`envlist`) and G
 | stable-2.18 | 3.11, 3.12, 3.13 | 3.11, 3.12, 3.13 |
 | stable-2.17 | 3.10, 3.11, 3.12 | 3.10, 3.11, 3.12 |
 | stable-2.16 | 3.10, 3.11 | 3.10, 3.11 |
+
+## SonarCloud
+
+Static analysis and Python coverage are uploaded to SonarCloud after the **`all_green`** workflow completes; the finalize step is defined in [.github/workflows/sonarcloud.yml](.github/workflows/sonarcloud.yml). For dashboard links, workflow details, and secrets behavior, see [SONARCLOUD.md](SONARCLOUD.md).

--- a/CI.md
+++ b/CI.md
@@ -33,4 +33,4 @@ These are outlined in the collection's [tox.ini](tox.ini) file (`envlist`) and G
 
 ## SonarCloud
 
-Static analysis and Python coverage are uploaded to SonarCloud after the **`all_green`** workflow completes; the finalize step is defined in [.github/workflows/sonarcloud.yml](.github/workflows/sonarcloud.yml). For dashboard links, workflow details, and secrets behavior, see [SONARCLOUD.md](SONARCLOUD.md).
+SonarCloud analysis is defined in [.github/workflows/sonarcloud.yml](.github/workflows/sonarcloud.yml) as a **reusable workflow** (`workflow_call`): it checks out the PR head or push SHA, downloads the **`coverage`** artifact from the same run, and runs the pinned **SonarSource** scan action with **`sonar.python.coverage.reportPaths`**. It is meant to be invoked from **[`all_green_check.yaml`](.github/workflows/all_green_check.yaml)** after the **`all_green`** gate and **coverage** job succeed (same **`pull_request`** / **`push`** event—no **`workflow_run`** finalize job). Pass **`secrets: inherit`** or **`ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT`**. Details, fork gating, and links: [SONARCLOUD.md](SONARCLOUD.md).

--- a/CI.md
+++ b/CI.md
@@ -15,6 +15,7 @@ The following tests run on every pull request:
 | [Sanity](.github/workflows/sanity-tests.yaml) | Runs ansible sanity checks | See compatibility table below | devel, stable-2.18, stable-2.19, stable-2.20 |
 | [Unit tests](.github/workflows/unit-tests.yaml) | Executes unit test cases | See compatibility table below | devel, stable-2.16, stable-2.17, stable-2.18, stable-2.19, stable-2.20 |
 | [Integration](.github/workflows/integration-tests.yaml) | Executes integration test suites using KinD cluster (split across 8 jobs, tests with Turbo mode enabled/disabled) | 3.12 | milestone |
+| [all_green](.github/workflows/all_green_check.yaml) | Linters (PR only), sanity, units, coverage XML, aggregate gate, and SonarCloud scan (same-repo PR / push when org secret is set) | (see jobs) | (see jobs) |
 
 **Note:** Integration tests require a KinD (Kubernetes in Docker) cluster and test both with Turbo mode enabled and disabled.
 
@@ -33,4 +34,4 @@ These are outlined in the collection's [tox.ini](tox.ini) file (`envlist`) and G
 
 ## SonarCloud
 
-SonarCloud analysis is defined in [.github/workflows/sonarcloud.yml](.github/workflows/sonarcloud.yml) as a **reusable workflow** (`workflow_call`): it checks out the PR head or push SHA, downloads the **`coverage`** artifact from the same run, and runs the pinned **SonarSource** scan action with **`sonar.python.coverage.reportPaths`**. It is meant to be invoked from **[`all_green_check.yaml`](.github/workflows/all_green_check.yaml)** after the **`all_green`** gate and **coverage** job succeed (same **`pull_request`** / **`push`** event—no **`workflow_run`** finalize job). Pass **`secrets: inherit`** or **`ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT`**. Details, fork gating, and links: [SONARCLOUD.md](SONARCLOUD.md).
+SonarCloud analysis runs from **[`all_green_check.yaml`](.github/workflows/all_green_check.yaml)** via the **`sonarcloud`** job, which calls **[`sonarcloud.yml`](.github/workflows/sonarcloud.yml)** (**`workflow_call`**) after the **`all_green`** gate and **coverage** succeed. The reusable workflow checks out the PR head or push SHA, downloads the **`coverage`** artifact, and runs the pinned **SonarSource** scan action. Same-repo **`pull_request`** and **`push`** only (fork PRs skip Sonar when the org secret is unavailable). Details: [SONARCLOUD.md](SONARCLOUD.md).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ansible-collections_kubernetes.core&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=ansible-collections_kubernetes.core)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=ansible-collections_kubernetes.core&metric=coverage)](https://sonarcloud.io/summary/new_code?id=ansible-collections_kubernetes.core)
+[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=ansible-collections_kubernetes.core&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=ansible-collections_kubernetes.core)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=ansible-collections_kubernetes.core&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=ansible-collections_kubernetes.core)
+[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=ansible-collections_kubernetes.core&metric=bugs)](https://sonarcloud.io/summary/new_code?id=ansible-collections_kubernetes.core)
+[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=ansible-collections_kubernetes.core&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=ansible-collections_kubernetes.core)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=ansible-collections_kubernetes.core&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=ansible-collections_kubernetes.core)
+
 # Kubernetes Collection for Ansible
 
 This repository hosts the `kubernetes.core` (formerly known as `community.kubernetes`) Ansible Collection.
@@ -5,62 +13,6 @@ This repository hosts the `kubernetes.core` (formerly known as `community.kubern
 ## Description
 
 The collection includes a variety of Ansible content to help automate the management of applications in Kubernetes and OpenShift clusters, as well as the provisioning and maintenance of clusters themselves.
-
-## SonarCloud (code quality)
-
-Static analysis runs on [SonarCloud](https://sonarcloud.io) using `sonar-project.properties` and
-`.github/workflows/sonarcloud.yml`. Coverage shown in Sonar comes from unit-test coverage exported as
-`coverage.xml` at the repository root during CI.
-
-The SonarCloud project key must match `sonar.projectKey` (`ansible-collections_kubernetes.core`). Adding
-or renaming the project is coordinated via Ansible Collections maintainers.
-
-GitHub does not expose organization secrets to workflows for pull requests opened from forks. The
-Sonar job therefore only runs on pushes to this repository's branches and on pull requests where the
-head branch is on `ansible-collections/kubernetes.core` (not from forks). That matches GitHub's
-documented behavior for [secrets in Actions](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
-
-If the project later needs Sonar with coverage on **fork** PRs, maintainers typically add a separate
-trusted job after a workflow that uploads coverage artifacts, using GitHub's `workflow_run` event.
-See [workflow_run (GitHub Docs)](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run).
-
-## Communication
-
-* Join the Ansible forum:
-  * [Get Help](https://forum.ansible.com/c/help/6): get help or help others.
-  * [Posts tagged with 'kubernetes'](https://forum.ansible.com/tag/kubernetes): subscribe to participate in collection-related conversations.
-  * [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
-  * [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events.
-
-* The Ansible [Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn): used to announce releases and important changes.
-
-For more information about communication, see the [Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html).
-
-## Requirements
-
-<!--start requires_ansible-->
-## Ansible version compatibility
-
-This collection has been tested against the following Ansible versions: **>=2.16.0**.
-
-Plugins and modules within a collection may be tested with only specific Ansible versions.
-A collection may contain metadata that identifies these versions.
-PEP440 is the schema used to describe the versions of Ansible.
-<!--end requires_ansible-->
-
-### Helm Version Compatibility
-
-This collection supports Helm v3.x and newer. Please note that specific modules or certain parameters may have additional version requirements.
-
-### Python Support
-
-* Collection supports 3.9+
-
-Note: Python2 is deprecated from [1st January 2020](https://www.python.org/doc/sunset-python-2/). Please switch to Python3.
-
-### Kubernetes Version Support
-
-This collection supports Kubernetes versions >= 1.24.
 
 ### Included Content
 
@@ -109,6 +61,32 @@ Name | Description
 
 <!--end collection content-->
 
+## Requirements
+
+<!--start requires_ansible-->
+### Ansible version compatibility
+
+This collection has been tested against the following Ansible versions: **>=2.16.0**.
+
+Plugins and modules within a collection may be tested with only specific Ansible versions.
+A collection may contain metadata that identifies these versions.
+PEP440 is the schema used to describe the versions of Ansible.
+<!--end requires_ansible-->
+
+### Helm Version Compatibility
+
+This collection supports Helm v3.x and newer. Please note that specific modules or certain parameters may have additional version requirements.
+
+### Python Support
+
+* Collection supports 3.9+
+
+Note: Python2 is deprecated from [1st January 2020](https://www.python.org/doc/sunset-python-2/). Please switch to Python3.
+
+### Kubernetes Version Support
+
+This collection supports Kubernetes versions >= 1.24.
+
 ## Installation
 
 Before using the Kubernetes collection, you need to install it with the Ansible Galaxy CLI:
@@ -128,7 +106,9 @@ collections:
 
 Content in this collection requires the [Kubernetes Python client](https://pypi.org/project/kubernetes/) to interact with Kubernetes' APIs. You can install it with:
 
-    pip3 install kubernetes
+```bash
+pip3 install kubernetes
+```
 
 ## Use Cases
 
@@ -216,12 +196,6 @@ defined in the playbook using `environment` keyword as above, you must set it us
 
 Please read more about Ansible Turbo mode - [here](https://github.com/ansible-collections/kubernetes.core/blob/main/docs/ansible_turbo_mode.rst).
 
-## Contributing to this Collection
-
-If you want to develop new content for this collection or improve what's already here, the easiest way to work on the collection is to clone it into one of the configured [`COLLECTIONS_PATHS`](https://docs.ansible.com/ansible/latest/reference_appendices/config.html#collections-paths), and work on it there.
-
-See [Contributing to kubernetes.core](CONTRIBUTING.md).
-
 ## Testing
 
 [![Linters](https://img.shields.io/github/actions/workflow/status/ansible-collections/kubernetes.core/linters.yaml?label=linters)](https://github.com/ansible-collections/kubernetes.core/actions/workflows/linters.yaml) [![Integration tests](https://img.shields.io/github/actions/workflow/status/ansible-collections/kubernetes.core/integration-tests.yaml?label=integration%20tests)](https://github.com/ansible-collections/kubernetes.core/actions/workflows/integration-tests.yaml) [![Sanity tests](https://img.shields.io/github/actions/workflow/status/ansible-collections/kubernetes.core/sanity-tests.yaml?label=sanity%20tests)](https://github.com/ansible-collections/kubernetes.core/actions/workflows/sanity-tests.yaml) [![Unit tests](https://img.shields.io/github/actions/workflow/status/ansible-collections/kubernetes.core/unit-tests.yaml?label=unit%20tests)](https://github.com/ansible-collections/kubernetes.core/actions/workflows/unit-tests.yaml) [![Codecov](https://img.shields.io/codecov/c/github/ansible-collections/kubernetes.core)](https://app.codecov.io/gh/ansible-collections/kubernetes.core)
@@ -243,7 +217,40 @@ There are also integration tests in the `molecule` directory which are meant to 
     kind create cluster
     make test-molecule
 
-## Publishing New Versions
+## Contributing to this Collection
+
+If you want to develop new content for this collection or improve what is already here, clone the Git repository into one of the configured [`COLLECTIONS_PATHS`](https://docs.ansible.com/ansible/latest/reference_appendices/config.html#collections-paths) and work on it there.
+
+See [Contributing to kubernetes.core](https://github.com/ansible-collections/kubernetes.core/blob/main/CONTRIBUTING.md).
+
+Join the Ansible community:
+
+* [Get Help](https://forum.ansible.com/c/help/6)
+* [Posts tagged with 'kubernetes'](https://forum.ansible.com/tag/kubernetes)
+* [Social Spaces](https://forum.ansible.com/c/chat/4)
+* [News & Announcements](https://forum.ansible.com/c/news/5)
+
+The Ansible [Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn) announces releases and important changes. For more information, see the [Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html).
+
+### Code of Conduct
+
+This project follows the [Ansible Code of Conduct](https://docs.ansible.com/ansible/devel/community/code_of_conduct.html). If you encounter abusive behavior, see the [policy violations](https://docs.ansible.com/ansible/devel/community/code_of_conduct.html#policy-violations) section for how to raise a complaint.
+
+## Support
+
+As Red Hat Ansible Certified Content, this collection is entitled to support through the Ansible Automation Platform (AAP) using the **Create issue** button on the top right corner. If a support case cannot be opened with Red Hat and the collection has been obtained either from Galaxy or GitHub, there may be community help available on the [Ansible Forum](https://forum.ansible.com/).
+
+> **Note:** The `stable-4` branch (all `4.x.y` releases) is no longer supported. No backports or releases are performed on `stable-4`.
+
+We announce releases and important changes through Ansible's [The Bullhorn newsletter](https://github.com/ansible/community/wiki/News#the-bullhorn). Subscribe via [this link](https://eepurl.com/gZmiEP).
+
+We take part in the global quarterly [Ansible Contributor Summit](https://github.com/ansible/community/wiki/Contributor-Summit). Track The Bullhorn and join when announced.
+
+For the latest supported versions, see [Release Notes and Roadmap](https://github.com/ansible-collections/kubernetes.core/blob/main/README.md#release-notes-and-roadmap).
+
+Report bugs, request features, or ask questions by opening an issue in the [GitHub repository](https://github.com/ansible-collections/kubernetes.core/).
+
+## Release Notes and Roadmap
 
 Releases are automatically built and pushed to Ansible Galaxy for any new tag. Before tagging a release, make sure to do the following:
 
@@ -260,37 +267,24 @@ Releases are automatically built and pushed to Ansible Galaxy for any new tag. B
 
 After the version is published, verify it exists on the [Kubernetes Collection Galaxy page](https://galaxy.ansible.com/kubernetes/core).
 
-The process for uploading a supported release to Automation Hub is documented separately.
+The process for [uploading a supported release to Automation Hub](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.1/html/uploading_content_to_red_hat_automation_hub/proc-upload-collection) is documented separately.
 
-## Support
+## Related Information
 
-<!--List available communication channels. In addition to channels specific to your collection, we also recommend to use the following ones.-->
+* [Using Ansible collections](https://docs.ansible.com/ansible/devel/user_guide/collections_using.html)
+* [Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html)
+* [Continuous integration (CI) overview](https://github.com/ansible-collections/kubernetes.core/blob/main/CI.md)
+* [SonarCloud integration](https://github.com/ansible-collections/kubernetes.core/blob/main/SONARCLOUD.md)
+* [Ansible Turbo mode (tech preview)](https://github.com/ansible-collections/kubernetes.core/blob/main/docs/ansible_turbo_mode.rst)
 
-> **Note:** The `stable-4` branch, which handles all `4.x.y` releases of this collection, is no longer supported. This means that no backports nor releases will be performed on the `stable-4` branch.
-
-We announce releases and important changes through Ansible's [The Bullhorn newsletter](https://github.com/ansible/community/wiki/News#the-bullhorn). Be sure you are [subscribed](https://eepurl.com/gZmiEP).
-
-We take part in the global quarterly [Ansible Contributor Summit](https://github.com/ansible/community/wiki/Contributor-Summit) virtually or in-person. Track [The Bullhorn newsletter](https://eepurl.com/gZmiEP) and join us.
-
-For more information about communication, refer to the [Ansible Communication guide](https://docs.ansible.com/ansible/devel/community/communication.html).
-
-For the latest supported versions, refer to the release notes below.
-
-If you encounter issues or have questions, you can submit a support request through the following channels:
- - GitHub Issues: Report bugs, request features, or ask questions by opening an issue in the [GitHub repository](https://github.com/ansible-collections/kubernetes.core/).
-
-## Release Notes
-
-See the [raw generated changelog](https://github.com/ansible-collections/kubernetes.core/blob/main/CHANGELOG.rst).
-
-## Code of Conduct
+### Code of conduct
 
 We follow the [Ansible Code of Conduct](https://docs.ansible.com/ansible/devel/community/code_of_conduct.html) in all our interactions within this project.
 
 If you encounter abusive behavior, please refer to the [policy violations](https://docs.ansible.com/ansible/devel/community/code_of_conduct.html#policy-violations) section of the Code for information on how to raise a complaint.
 
-## License
+## License Information
 
 GNU General Public License v3.0 or later
 
-See LICENSE to see the full text.
+See [LICENSE](https://github.com/ansible-collections/kubernetes.core/blob/main/LICENSE) to see the full text.

--- a/SONARCLOUD.md
+++ b/SONARCLOUD.md
@@ -6,25 +6,27 @@ Dashboard:
 
 ## CI integration
 
-CI runs the **`all_green`** workflow (linters on pull requests, sanity, units, then a **coverage** job
-that uploads **`coverage*`** artifacts), then **`SonarCloud`** runs on **`workflow_run`** and passes
-**`sonar.python.coverage.reportPaths`** to the scanner. That matches
-[ansible-collections/amazon.aws#2871](https://github.com/ansible-collections/amazon.aws/pull/2871).
+Sonar analysis is implemented in **[.github/workflows/sonarcloud.yml](.github/workflows/sonarcloud.yml)** as a **reusable workflow** (`on: workflow_call` only). It is **not** triggered by `workflow_run`.
+
+The caller (for example **[.github/workflows/all_green_check.yaml](.github/workflows/all_green_check.yaml)**) should:
+
+1. Run **linters** (on pull requests), **sanity**, **units**, and **coverage**, then pass an aggregate **`all_green`** gate.
+2. Upload a **`coverage`** artifact from the **coverage** job (single XML at the repo root after path normalization).
+3. Invoke **`uses: ./.github/workflows/sonarcloud.yml`** with **`secrets: inherit`** (or pass **`ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT`** explicitly) **after** **`all_green`** and **`coverage`** succeed, in the **same** workflow run so **`actions/download-artifact`** can fetch **`coverage`**.
+
+Because the caller runs on **`pull_request`** or **`push`**, the reusable workflow inherits that **`github.event`**. **`actions/checkout`** uses **`github.event.pull_request.head.sha`** on pull requests and **`github.sha`** on push, which matches Sonar's guidance for avoiding **`workflow_run`** + **`workflow_run.head_sha`** checkout patterns. PR parameters (**`sonar.pullrequest.*`**) are taken from **`github.event.pull_request`** (no `gh` API calls in **`sonarcloud.yml`**).
+
+The scan step uses **`SonarSource/sonarqube-scan-action`** (pinned SHA in the workflow file) with **`sonar.python.coverage.reportPaths`** set from any **`coverage*.xml`** files found under the workspace after the artifact download. The overall flow (coverage in CI, then Sonar with XML) follows the same idea as [ansible-collections/amazon.aws#2871](https://github.com/ansible-collections/amazon.aws/pull/2871). Wire **`sonarcloud.yml`** from **`all_green`** with **`workflow_call`** (instead of a separate **`workflow_run`** finalize workflow) once the **`sonarcloud`** job is added to **`all_green_check.yaml`**.
 
 Workflow files:
 
-- [.github/workflows/all_green_check.yaml](.github/workflows/all_green_check.yaml)
-- [.github/workflows/sonarcloud.yml](.github/workflows/sonarcloud.yml)
+- [.github/workflows/all_green_check.yaml](.github/workflows/all_green_check.yaml) — expected caller: **`all_green`** gate, **coverage** artifact upload, and a **`sonarcloud`** job with **`uses: ./.github/workflows/sonarcloud.yml`** and **`secrets: inherit`** (after **`all_green`** and **`coverage`**), gated for **`push`** and same-repo **`pull_request`** when the org Sonar secret is set.
+- [.github/workflows/sonarcloud.yml](.github/workflows/sonarcloud.yml) — **`scan`** job: checkout, download **`coverage`**, **`SONAR_ARGS`**, SonarCloud scan.
 
 Scanner configuration lives in [sonar-project.properties](sonar-project.properties).
 
-The **coverage** job uses **`ansible-test`** (`units --coverage`, then **`coverage combine`** /
-**`coverage xml`**), then writes **`coverage.xml`** with workspace paths normalized for Sonar.
-**`pytest-cov`** is listed in **`tests/unit/requirements.txt`** for parity and any direct pytest runs;
-**`ansible-test`** still owns the coverage data used in CI.
+The **coverage** job (in **`all_green`**) uses **`ansible-test`** (`units --coverage`, then **`coverage combine`** / **`coverage xml`**), then writes **`coverage.xml`** with workspace paths normalized for Sonar. **`pytest-cov`** is listed in **`tests/unit/requirements.txt`** for parity and any direct pytest runs; **`ansible-test`** still owns the coverage data used in CI.
 
-Org secrets and fork PR behavior follow GitHub's
-[secrets in Actions](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions)
-documentation; the Sonar finalize job runs in this repository after **`all_green`** succeeds.
+**`sonarcloud.yml`** declares a required secret **`ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT`** and **`permissions: contents: read`**, **`pull-requests: read`**.
 
-The **`finalize`** job only runs when **`workflow_run.head_repository`** matches **`ansible-collections/kubernetes.core`**, so we do not checkout arbitrary **`head_sha`** commits from forks while using org **`SONAR_TOKEN`**. Pull requests opened from forks still run **`all_green`** for CI; they do not trigger this Sonar finalize job (same limitation as typical fork secret behavior).
+Org secrets and fork PR behavior follow GitHub's [secrets in Actions](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions) documentation. The **caller** should **`if:`**-gate the reusable Sonar job (for example: same-repo pull requests and/or **`push`**, and secret present) so org tokens are not used for fork-head checkouts; fork PRs can still run **`all_green`** for CI without running Sonar.

--- a/SONARCLOUD.md
+++ b/SONARCLOUD.md
@@ -26,3 +26,5 @@ The **coverage** job uses **`ansible-test`** (`units --coverage`, then **`covera
 Org secrets and fork PR behavior follow GitHub's
 [secrets in Actions](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions)
 documentation; the Sonar finalize job runs in this repository after **`all_green`** succeeds.
+
+The **`finalize`** job only runs when **`workflow_run.head_repository`** matches **`ansible-collections/kubernetes.core`**, so we do not checkout arbitrary **`head_sha`** commits from forks while using org **`SONAR_TOKEN`**. Pull requests opened from forks still run **`all_green`** for CI; they do not trigger this Sonar finalize job (same limitation as typical fork secret behavior).

--- a/SONARCLOUD.md
+++ b/SONARCLOUD.md
@@ -8,20 +8,16 @@ Dashboard:
 
 Sonar analysis is implemented in **[.github/workflows/sonarcloud.yml](.github/workflows/sonarcloud.yml)** as a **reusable workflow** (`on: workflow_call` only). It is **not** triggered by `workflow_run`.
 
-The caller (for example **[.github/workflows/all_green_check.yaml](.github/workflows/all_green_check.yaml)**) should:
+**[.github/workflows/all_green_check.yaml](.github/workflows/all_green_check.yaml)** runs **linters** (on pull requests), **sanity**, **units**, and **coverage**, passes the aggregate **`all_green`** gate, then calls **`sonarcloud.yml`** via a **`sonarcloud`** job when the conditions below are met. The **coverage** job uploads a **`coverage`** artifact; the Sonar job downloads it in the **same** workflow run.
 
-1. Run **linters** (on pull requests), **sanity**, **units**, and **coverage**, then pass an aggregate **`all_green`** gate.
-2. Upload a **`coverage`** artifact from the **coverage** job (single XML at the repo root after path normalization).
-3. Invoke **`uses: ./.github/workflows/sonarcloud.yml`** with **`secrets: inherit`** (or pass **`ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT`** explicitly) **after** **`all_green`** and **`coverage`** succeed, in the **same** workflow run so **`actions/download-artifact`** can fetch **`coverage`**.
+The caller runs on **`pull_request`** or **`push`**, so the reusable workflow inherits that **`github.event`**. **`actions/checkout`** uses **`github.event.pull_request.head.sha`** on pull requests and **`github.sha`** on push (Sonar-friendly checkout). PR parameters (**`sonar.pullrequest.*`**) are taken from **`github.event.pull_request`** (no `gh` API calls in **`sonarcloud.yml`**).
 
-Because the caller runs on **`pull_request`** or **`push`**, the reusable workflow inherits that **`github.event`**. **`actions/checkout`** uses **`github.event.pull_request.head.sha`** on pull requests and **`github.sha`** on push, which matches Sonar's guidance for avoiding **`workflow_run`** + **`workflow_run.head_sha`** checkout patterns. PR parameters (**`sonar.pullrequest.*`**) are taken from **`github.event.pull_request`** (no `gh` API calls in **`sonarcloud.yml`**).
-
-The scan step uses **`SonarSource/sonarqube-scan-action`** (pinned SHA in the workflow file) with **`sonar.python.coverage.reportPaths`** set from any **`coverage*.xml`** files found under the workspace after the artifact download. The overall flow (coverage in CI, then Sonar with XML) follows the same idea as [ansible-collections/amazon.aws#2871](https://github.com/ansible-collections/amazon.aws/pull/2871). Wire **`sonarcloud.yml`** from **`all_green`** with **`workflow_call`** (instead of a separate **`workflow_run`** finalize workflow) once the **`sonarcloud`** job is added to **`all_green_check.yaml`**.
+The scan step uses **`SonarSource/sonarqube-scan-action`** (pinned SHA in the workflow file) with **`sonar.python.coverage.reportPaths`** set from any **`coverage*.xml`** files found under the workspace after the artifact download. The overall flow (coverage in CI, then Sonar with XML) follows the same idea as [ansible-collections/amazon.aws#2871](https://github.com/ansible-collections/amazon.aws/pull/2871), using **`workflow_call`** from **`all_green`** instead of a separate **`workflow_run`** finalize workflow.
 
 Workflow files:
 
-- [.github/workflows/all_green_check.yaml](.github/workflows/all_green_check.yaml) — expected caller: **`all_green`** gate, **coverage** artifact upload, and a **`sonarcloud`** job with **`uses: ./.github/workflows/sonarcloud.yml`** and **`secrets: inherit`** (after **`all_green`** and **`coverage`**), gated for **`push`** and same-repo **`pull_request`** when the org Sonar secret is set.
-- [.github/workflows/sonarcloud.yml](.github/workflows/sonarcloud.yml) — **`scan`** job: checkout, download **`coverage`**, **`SONAR_ARGS`**, SonarCloud scan.
+- [.github/workflows/all_green_check.yaml](.github/workflows/all_green_check.yaml) -- **`all_green`** gate, **coverage** artifact upload, and **`sonarcloud`** job (**`uses: ./.github/workflows/sonarcloud.yml`**, passing only **`ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT`**) after **`all_green`** and **`coverage`** succeed, gated for **`push`** and same-repo **`pull_request`** when that secret is set.
+- [.github/workflows/sonarcloud.yml](.github/workflows/sonarcloud.yml) -- **`scan`** job: checkout, download **`coverage`**, **`SONAR_ARGS`**, SonarCloud scan.
 
 Scanner configuration lives in [sonar-project.properties](sonar-project.properties).
 
@@ -29,4 +25,8 @@ The **coverage** job (in **`all_green`**) uses **`ansible-test`** (`units --cove
 
 **`sonarcloud.yml`** declares a required secret **`ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT`** and **`permissions: contents: read`**, **`pull-requests: read`**.
 
-Org secrets and fork PR behavior follow GitHub's [secrets in Actions](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions) documentation. The **caller** should **`if:`**-gate the reusable Sonar job (for example: same-repo pull requests and/or **`push`**, and secret present) so org tokens are not used for fork-head checkouts; fork PRs can still run **`all_green`** for CI without running Sonar.
+Org secrets and fork PR behavior follow GitHub's [secrets in Actions](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions) documentation. The **`sonarcloud`** job is **`if:`**-gated so the org token is not used for fork-head checkouts; fork PRs still run **`all_green`** for CI without running Sonar.
+
+## Branch protection (repository settings)
+
+If **`SonarCloud scan`** or **`all_green`** should block merges, add them under **Settings** > **Branches** > **Required status checks** for the protected branch. That is not configured in YAML.

--- a/SONARCLOUD.md
+++ b/SONARCLOUD.md
@@ -1,0 +1,28 @@
+# SonarCloud
+
+Dashboard:
+
+[SonarCloud project overview](https://sonarcloud.io/project/overview?id=ansible-collections_kubernetes.core)
+
+## CI integration
+
+CI runs the **`all_green`** workflow (linters on pull requests, sanity, units, then a **coverage** job
+that uploads **`coverage*`** artifacts), then **`SonarCloud`** runs on **`workflow_run`** and passes
+**`sonar.python.coverage.reportPaths`** to the scanner. That matches
+[ansible-collections/amazon.aws#2871](https://github.com/ansible-collections/amazon.aws/pull/2871).
+
+Workflow files:
+
+- [.github/workflows/all_green_check.yaml](.github/workflows/all_green_check.yaml)
+- [.github/workflows/sonarcloud.yml](.github/workflows/sonarcloud.yml)
+
+Scanner configuration lives in [sonar-project.properties](sonar-project.properties).
+
+The **coverage** job uses **`ansible-test`** (`units --coverage`, then **`coverage combine`** /
+**`coverage xml`**), then writes **`coverage.xml`** with workspace paths normalized for Sonar.
+**`pytest-cov`** is listed in **`tests/unit/requirements.txt`** for parity and any direct pytest runs;
+**`ansible-test`** still owns the coverage data used in CI.
+
+Org secrets and fork PR behavior follow GitHub's
+[secrets in Actions](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions)
+documentation; the Sonar finalize job runs in this repository after **`all_green`** succeeds.

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,3 +1,4 @@
 pytest
+pytest-cov
 PyYAML
 kubernetes


### PR DESCRIPTION
##### SUMMARY

Resolves [ACA-5027](https://issues.redhat.com/browse/ACA-5027)

- Implement a coverage job in `all_green_check.yaml` that runs ansible-test unit coverage, combines results, emits `coverage.xml`, and uploads `coverage*` artifacts for downstream use
- Add `sonarcloud.yml`: runs on `workflow_run` after `all_green` completes successfully, checks out the same `head_sha`, downloads `coverage*` artifacts from that run, and runs the SonarCloud scanner with `sonar.python.coverage.reportPaths` (modeled after [`amazon.aws` #2871](https://github.com/ansible-collections/amazon.aws/pull/2871))
- Gate `all_green` so it finishes only when linters (PR), sanity, units, and coverage all succeed
- SonarCloud runs only after that successful `all_green` completion, ingests the coverage artifact(s), and feeds them to SonarQube Cloud so unit test coverage appears in the project
- Add `pytest-cov` to `tests/unit/requirements.txt` for parity with typical `pytest` coverage setups (CI coverage remains driven by ansible-test / `coverage`)
- Add `sonar-project.properties` at the collection root for SonarCloud analysis settings
- Wire reusable workflows (`workflow_call`) from `linters.yaml`, `sanity-tests.yaml`, and `unit-tests.yaml` into `all_green` where applicable
- Add SonarCloud quality/coverage/security badges to `README.md`
- Move detailed Sonar/CI narrative into `SONARCLOUD.md` and add a short SonarCloud pointer in `CI.md`
- Update `README.md` to match the [Red Hat certified collection README layout](https://access.redhat.com/articles/7068606)

Assisted-by: Claude Sonnet 4.5 [noreply@anthropic.com](mailto:noreply@anthropic.com)