### PR TITLE
Support wait_for_jobs flag for helm release upgrade/install

### DIFF
--- a/changelogs/fragments/20260807-helm-wait-for-jobs.yaml
+++ b/changelogs/fragments/20260807-helm-wait-for-jobs.yaml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - "helm - Add ``wait_for_jobs`` option to wait for all Jobs to complete before
+    marking a Helm release as successful. Requires Helm >= 3.5.0
+    (https://github.com/ansible-collections/kubernetes.core/pull/1140)."

--- a/plugins/modules/helm.py
+++ b/plugins/modules/helm.py
@@ -187,6 +187,12 @@ options:
         It will wait for as long as I(wait_timeout). This feature requires helm>=3.7.0. Added in version 2.3.0.
     default: False
     type: bool
+  wait_for_jobs:
+    description:
+      - When I(release_state) is set to C(present), and I(wait) is set to C(True), wait until all jobs are in a
+        completed state before marking the release as successful. Added in version 6.5.0.
+    default: False
+    type: bool
   wait_timeout:
     description:
       - Timeout when wait option is enabled (helm2 is a number of seconds, helm3 is a duration).
@@ -385,6 +391,7 @@ EXAMPLES = r"""
     release_namespace: default
     force: True
     wait: True
+    wait_for_jobs: True
     replace: True
     update_repo_cache: True
     disable_hook: True
@@ -601,6 +608,7 @@ def deploy(
     release_values,
     chart_name,
     wait,
+    wait_for_jobs,
     wait_timeout,
     disable_hook,
     force,
@@ -655,6 +663,8 @@ def deploy(
 
     if wait:
         deploy_command += " --wait"
+        if wait_for_jobs:
+            deploy_command += " --wait-for-jobs"
         if wait_timeout is not None:
             deploy_command += " --timeout " + wait_timeout
 
@@ -959,6 +969,7 @@ def argument_spec():
             force=dict(type="bool", default=False),
             purge=dict(type="bool", default=True),
             wait=dict(type="bool", default=False),
+            wait_for_jobs=dict(type="bool", default=False),
             wait_timeout=dict(type="str"),
             timeout=dict(type="str"),
             atomic=dict(type="bool", default=False),
@@ -1025,6 +1036,7 @@ def main():
     force = module.params.get("force")
     purge = module.params.get("purge")
     wait = module.params.get("wait")
+    wait_for_jobs = module.params.get("wait_for_jobs")
     wait_timeout = module.params.get("wait_timeout")
     atomic = module.params.get("atomic")
     server_side = module.params.get("server_side")
@@ -1152,6 +1164,7 @@ def main():
                 release_values,
                 chart_ref,
                 wait,
+                wait_for_jobs,
                 wait_timeout,
                 disable_hook,
                 False,
@@ -1238,6 +1251,7 @@ def main():
                     release_values,
                     chart_ref,
                     wait,
+                    wait_for_jobs,
                     wait_timeout,
                     disable_hook,
                     force,

--- a/plugins/modules/helm.py
+++ b/plugins/modules/helm.py
@@ -193,7 +193,7 @@ options:
         completed state before marking the release as successful.
       - Ignored when used without O(wait).
       - Requires Helm >= 3.5.0
-   version_added: 6.6.0
+    version_added: 6.6.0
     default: False
     type: bool
   wait_timeout:
@@ -667,15 +667,15 @@ def deploy(
     if wait:
         deploy_command += " --wait"
         if wait_for_jobs:
-            deploy_command += " --wait-for-jobs"
+            helm_version = module.get_helm_version()
             if LooseVersion(helm_version) < LooseVersion("3.5.0"):
                 module.fail_json(
                     msg="wait_for_jobs requires helm >= 3.5.0, current version is {0}".format(
-                    helm_version
+                        helm_version
                     )
                 )
             else:
-                deploy_command += "  --wait-for-jobs"
+                deploy_command += " --wait-for-jobs"
         if wait_timeout is not None:
             deploy_command += " --timeout " + wait_timeout
 

--- a/plugins/modules/helm.py
+++ b/plugins/modules/helm.py
@@ -665,6 +665,14 @@ def deploy(
         deploy_command += " --wait"
         if wait_for_jobs:
             deploy_command += " --wait-for-jobs"
+            if LooseVersion(helm_version) < LooseVersion("3.5.0"):
+                module.fail_json(
+                    msg="wait_for_jobs requires helm >= 3.5.0, current version is {0}".format(
+                    helm_version
+                    )
+                )
+            else:
+                deploy_command += "  --wait-for-jobs"
         if wait_timeout is not None:
             deploy_command += " --timeout " + wait_timeout
 

--- a/plugins/modules/helm.py
+++ b/plugins/modules/helm.py
@@ -963,45 +963,49 @@ def default_check(release_status, chart_info, values=None, values_files=None):
 def argument_spec():
     arg_spec = copy.deepcopy(HELM_AUTH_ARG_SPEC)
     arg_spec.update(
-        dict(
-            chart_ref=dict(type="path"),
-            chart_repo_url=dict(type="str"),
-            chart_version=dict(type="str"),
-            dependency_update=dict(type="bool", default=False, aliases=["dep_up"]),
-            release_name=dict(type="str", required=True, aliases=["name"]),
-            release_namespace=dict(type="str", required=True, aliases=["namespace"]),
-            release_state=dict(
-                default="present", choices=["present", "absent"], aliases=["state"]
-            ),
-            release_values=dict(type="dict", default={}, aliases=["values"]),
-            values_files=dict(type="list", default=[], elements="str"),
-            update_repo_cache=dict(type="bool", default=False),
-            disable_hook=dict(type="bool", default=False),
-            force=dict(type="bool", default=False),
-            purge=dict(type="bool", default=True),
-            wait=dict(type="bool", default=False),
-            wait_for_jobs=dict(type="bool", default=False),
-            wait_timeout=dict(type="str"),
-            timeout=dict(type="str"),
-            atomic=dict(type="bool", default=False),
-            server_side=dict(type="str", choices=["auto", "true", "false"]),
-            force_conflicts=dict(type="bool", default=False),
-            create_namespace=dict(type="bool", default=False),
-            post_renderer=dict(type="str"),
-            replace=dict(type="bool", default=False),
-            skip_crds=dict(type="bool", default=False),
-            history_max=dict(type="int"),
-            set_values=dict(type="list", elements="dict"),
-            reuse_values=dict(type="bool"),
-            reset_values=dict(type="bool", default=True),
-            reset_then_reuse_values=dict(type="bool", default=False),
-            insecure_skip_tls_verify=dict(
-                type="bool", default=False, aliases=["skip_tls_certs_check"]
-            ),
-            plain_http=dict(type="bool", default=False),
-            take_ownership=dict(type="bool", default=False),
-            skip_schema_validation=dict(type="bool", default=False),
-        )
+        {
+            "chart_ref": {"type": "path"},
+            "chart_repo_url": {"type": "str"},
+            "chart_version": {"type": "str"},
+            "dependency_update": {"type": "bool", "default": False, "aliases": ["dep_up"]},
+            "release_name": {"type": "str", "required": True, "aliases": ["name"]},
+            "release_namespace": {"type": "str", "required": True, "aliases": ["namespace"]},
+            "release_state": {
+                "default": "present",
+                "choices": ["present", "absent"],
+                "aliases": ["state"],
+            },
+            "release_values": {"type": "dict", "default": {}, "aliases": ["values"]},
+            "values_files": {"type": "list", "default": [], "elements": "str"},
+            "update_repo_cache": {"type": "bool", "default": False},
+            "disable_hook": {"type": "bool", "default": False},
+            "force": {"type": "bool", "default": False},
+            "purge": {"type": "bool", "default": True},
+            "wait": {"type": "bool", "default": False},
+            "wait_for_jobs": {"type": "bool", "default": False},
+            "wait_timeout": {"type": "str"},
+            "timeout": {"type": "str"},
+            "atomic": {"type": "bool", "default": False},
+            "server_side": {"type": "str", "choices": ["auto", "true", "false"]},
+            "force_conflicts": {"type": "bool", "default": False},
+            "create_namespace": {"type": "bool", "default": False},
+            "post_renderer": {"type": "str"},
+            "replace": {"type": "bool", "default": False},
+            "skip_crds": {"type": "bool", "default": False},
+            "history_max": {"type": "int"},
+            "set_values": {"type": "list", "elements": "dict"},
+            "reuse_values": {"type": "bool"},
+            "reset_values": {"type": "bool", "default": True},
+            "reset_then_reuse_values": {"type": "bool", "default": False},
+            "insecure_skip_tls_verify": {
+                "type": "bool",
+                "default": False,
+                "aliases": ["skip_tls_certs_check"],
+            },
+            "plain_http": {"type": "bool", "default": False},
+            "take_ownership": {"type": "bool", "default": False},
+            "skip_schema_validation": {"type": "bool", "default": False},
+        }
     )
     return arg_spec
 

--- a/plugins/modules/helm.py
+++ b/plugins/modules/helm.py
@@ -967,9 +967,17 @@ def argument_spec():
             "chart_ref": {"type": "path"},
             "chart_repo_url": {"type": "str"},
             "chart_version": {"type": "str"},
-            "dependency_update": {"type": "bool", "default": False, "aliases": ["dep_up"]},
+            "dependency_update": {
+                "type": "bool",
+                "default": False,
+                "aliases": ["dep_up"],
+            },
             "release_name": {"type": "str", "required": True, "aliases": ["name"]},
-            "release_namespace": {"type": "str", "required": True, "aliases": ["namespace"]},
+            "release_namespace": {
+                "type": "str",
+                "required": True,
+                "aliases": ["namespace"],
+            },
             "release_state": {
                 "default": "present",
                 "choices": ["present", "absent"],

--- a/plugins/modules/helm.py
+++ b/plugins/modules/helm.py
@@ -190,7 +190,10 @@ options:
   wait_for_jobs:
     description:
       - When I(release_state) is set to C(present), and I(wait) is set to C(True), wait until all jobs are in a
-        completed state before marking the release as successful. Added in version 6.5.0.
+        completed state before marking the release as successful.
+      - Ignored when used without O(wait).
+      - Requires Helm >= 3.5.0
+   version_added: 6.6.0
     default: False
     type: bool
   wait_timeout:

--- a/tests/integration/targets/helm/defaults/main.yml
+++ b/tests/integration/targets/helm/defaults/main.yml
@@ -31,3 +31,4 @@ test_namespace:
   - "helm-insecure-{{ helm_version | replace('.', '-') }}"
   - "helm-test-take-ownership-{{ helm_version | replace('.', '-') }}"
   - "helm-skip-schema-validation-{{ helm_version | replace('.', '-') }}"
+  - "helm-wait-for-jobs-{{ helm_version | replace('.', '-') }}"

--- a/tests/integration/targets/helm/files/test-chart-job/Chart.yaml
+++ b/tests/integration/targets/helm/files/test-chart-job/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: test-chart-job
+description: A chart with a Job for testing wait_for_jobs
+type: application
+version: 0.1.0
+appVersion: "default"

--- a/tests/integration/targets/helm/files/test-chart-job/templates/job.yaml
+++ b/tests/integration/targets/helm/files/test-chart-job/templates/job.yaml
@@ -1,0 +1,13 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-job
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: test
+          image: "busybox"
+          command: ["sh", "-c", "echo done"]

--- a/tests/integration/targets/helm/files/test-chart-job/templates/job.yaml
+++ b/tests/integration/targets/helm/files/test-chart-job/templates/job.yaml
@@ -10,8 +10,12 @@ spec:
       restartPolicy: Never
       containers:
         - name: test
-          image: "busybox"
+          image: "busybox:1.37"
           command: ["sh", "-c", "echo done"]
           resources:
+            requests:
+              cpu: "50m"
+              memory: "32Mi"
+              ephemeral-storage: "16Mi"
             limits:
               memory: "64Mi"

--- a/tests/integration/targets/helm/files/test-chart-job/templates/job.yaml
+++ b/tests/integration/targets/helm/files/test-chart-job/templates/job.yaml
@@ -6,8 +6,12 @@ spec:
   backoffLimit: 0
   template:
     spec:
+      automountServiceAccountToken: false
       restartPolicy: Never
       containers:
         - name: test
           image: "busybox"
           command: ["sh", "-c", "echo done"]
+          resources:
+            limits:
+              memory: "64Mi"

--- a/tests/integration/targets/helm/files/test-chart-job/templates/job.yaml
+++ b/tests/integration/targets/helm/files/test-chart-job/templates/job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-job
+  name: "{{ .Release.Name }}-job"
 spec:
   backoffLimit: 0
   template:

--- a/tests/integration/targets/helm/tasks/run_test.yml
+++ b/tests/integration/targets/helm/tasks/run_test.yml
@@ -49,6 +49,9 @@
     - name: Test helm skip_schema_validation
       include_tasks: test_skip_schema_validation.yml
 
+    - name: Test helm wait_for_jobs
+      include_tasks: test_helm_wait_for_jobs.yml
+
   always:
     - name: Remove helm-diff plugin
       helm_plugin:

--- a/tests/integration/targets/helm/tasks/test_helm_wait_for_jobs.yml
+++ b/tests/integration/targets/helm/tasks/test_helm_wait_for_jobs.yml
@@ -1,0 +1,59 @@
+---
+- name: Test helm wait_for_jobs
+  vars:
+    helm_namespace: "{{ test_namespace[15] }}"
+    chart_local: "{{ role_path }}/files/test-chart-job"
+  block:
+
+    - name: Install chart with wait and wait_for_jobs
+      helm:
+        binary_path: "{{ helm_binary }}"
+        chart_ref: "{{ chart_local }}"
+        release_name: test-wait-for-jobs
+        release_namespace: "{{ helm_namespace }}"
+        create_namespace: true
+        wait: true
+        wait_for_jobs: true
+        wait_timeout: "120s"
+      register: install
+      ignore_errors: true
+
+    - name: Validate wait_for_jobs with helm >= 3.5.0 works
+      assert:
+        that:
+          - install is changed
+          - "'--wait' in install.command"
+          - "'--wait-for-jobs' in install.command"
+      when: "helm_version is ansible.builtin.version('v3.5.0', '>=')"
+
+    - name: Validate wait_for_jobs with helm < 3.5.0 fails
+      assert:
+        that:
+          - install is failed
+          - "'wait_for_jobs requires helm >= 3.5.0' in install.msg"
+      when: "helm_version is ansible.builtin.version('v3.5.0', '<')"
+
+    - name: Install chart with wait_for_jobs but without wait
+      helm:
+        binary_path: "{{ helm_binary }}"
+        chart_ref: "{{ chart_local }}"
+        release_name: test-wait-for-jobs-no-wait
+        release_namespace: "{{ helm_namespace }}"
+        create_namespace: true
+        wait_for_jobs: true
+      register: install_no_wait
+
+    - name: Validate wait_for_jobs is ignored without wait
+      assert:
+        that:
+          - install_no_wait is changed
+          - "'--wait-for-jobs' not in install_no_wait.command"
+          - "'--wait' not in install_no_wait.command"
+
+  always:
+    - name: Remove helm namespace
+      k8s:
+        api_version: v1
+        kind: Namespace
+        name: "{{ helm_namespace }}"
+        state: absent

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -21,6 +21,7 @@ tests/integration/targets/k8s_delete/files/deployments.yaml yamllint!skip
 tests/unit/module_utils/fixtures/pods.yml yamllint!skip
 tests/integration/targets/helm/files/appversionless-chart-v2/templates/configmap.yaml yamllint!skip
 tests/integration/targets/helm/files/appversionless-chart/templates/configmap.yaml yamllint!skip
+tests/integration/targets/helm/files/test-chart-job/Chart.yaml yamllint!skip
 tests/integration/targets/helm/files/test-chart-v2/templates/configmap.yaml yamllint!skip
 tests/integration/targets/helm/files/test-chart/templates/configmap.yaml yamllint!skip
 tests/integration/targets/helm_diff/files/test-chart/templates/configmap.yaml yamllint!skip

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -21,6 +21,7 @@ tests/integration/targets/k8s_delete/files/deployments.yaml yamllint!skip
 tests/unit/module_utils/fixtures/pods.yml yamllint!skip
 tests/integration/targets/helm/files/appversionless-chart-v2/templates/configmap.yaml yamllint!skip
 tests/integration/targets/helm/files/appversionless-chart/templates/configmap.yaml yamllint!skip
+tests/integration/targets/helm/files/test-chart-job/Chart.yaml yamllint!skip
 tests/integration/targets/helm/files/test-chart-v2/templates/configmap.yaml yamllint!skip
 tests/integration/targets/helm/files/test-chart/templates/configmap.yaml yamllint!skip
 tests/integration/targets/helm_diff/files/test-chart/templates/configmap.yaml yamllint!skip

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -18,6 +18,7 @@ tests/integration/targets/k8s_delete/files/deployments.yaml yamllint!skip
 tests/unit/module_utils/fixtures/pods.yml yamllint!skip
 tests/integration/targets/helm/files/appversionless-chart-v2/templates/configmap.yaml yamllint!skip
 tests/integration/targets/helm/files/appversionless-chart/templates/configmap.yaml yamllint!skip
+tests/integration/targets/helm/files/test-chart-job/Chart.yaml yamllint!skip
 tests/integration/targets/helm/files/test-chart-v2/templates/configmap.yaml yamllint!skip
 tests/integration/targets/helm/files/test-chart/templates/configmap.yaml yamllint!skip
 tests/integration/targets/helm_diff/files/test-chart/templates/configmap.yaml yamllint!skip

--- a/tests/sanity/ignore-2.19.txt
+++ b/tests/sanity/ignore-2.19.txt
@@ -18,6 +18,7 @@ tests/integration/targets/k8s_delete/files/deployments.yaml yamllint!skip
 tests/unit/module_utils/fixtures/pods.yml yamllint!skip
 tests/integration/targets/helm/files/appversionless-chart-v2/templates/configmap.yaml yamllint!skip
 tests/integration/targets/helm/files/appversionless-chart/templates/configmap.yaml yamllint!skip
+tests/integration/targets/helm/files/test-chart-job/Chart.yaml yamllint!skip
 tests/integration/targets/helm/files/test-chart-v2/templates/configmap.yaml yamllint!skip
 tests/integration/targets/helm/files/test-chart/templates/configmap.yaml yamllint!skip
 tests/integration/targets/helm_diff/files/test-chart/templates/configmap.yaml yamllint!skip

--- a/tests/sanity/ignore-2.20.txt
+++ b/tests/sanity/ignore-2.20.txt
@@ -21,6 +21,7 @@ tests/integration/targets/k8s_delete/files/deployments.yaml yamllint!skip
 tests/unit/module_utils/fixtures/pods.yml yamllint!skip
 tests/integration/targets/helm/files/appversionless-chart-v2/templates/configmap.yaml yamllint!skip
 tests/integration/targets/helm/files/appversionless-chart/templates/configmap.yaml yamllint!skip
+tests/integration/targets/helm/files/test-chart-job/Chart.yaml yamllint!skip
 tests/integration/targets/helm/files/test-chart-v2/templates/configmap.yaml yamllint!skip
 tests/integration/targets/helm/files/test-chart/templates/configmap.yaml yamllint!skip
 tests/integration/targets/helm_diff/files/test-chart/templates/configmap.yaml yamllint!skip

--- a/tests/sanity/ignore-2.21.txt
+++ b/tests/sanity/ignore-2.21.txt
@@ -21,6 +21,7 @@ tests/integration/targets/k8s_delete/files/deployments.yaml yamllint!skip
 tests/unit/module_utils/fixtures/pods.yml yamllint!skip
 tests/integration/targets/helm/files/appversionless-chart-v2/templates/configmap.yaml yamllint!skip
 tests/integration/targets/helm/files/appversionless-chart/templates/configmap.yaml yamllint!skip
+tests/integration/targets/helm/files/test-chart-job/Chart.yaml yamllint!skip
 tests/integration/targets/helm/files/test-chart-v2/templates/configmap.yaml yamllint!skip
 tests/integration/targets/helm/files/test-chart/templates/configmap.yaml yamllint!skip
 tests/integration/targets/helm_diff/files/test-chart/templates/configmap.yaml yamllint!skip

--- a/tests/sanity/ignore-2.22.txt
+++ b/tests/sanity/ignore-2.22.txt
@@ -21,6 +21,7 @@ tests/integration/targets/k8s_delete/files/deployments.yaml yamllint!skip
 tests/unit/module_utils/fixtures/pods.yml yamllint!skip
 tests/integration/targets/helm/files/appversionless-chart-v2/templates/configmap.yaml yamllint!skip
 tests/integration/targets/helm/files/appversionless-chart/templates/configmap.yaml yamllint!skip
+tests/integration/targets/helm/files/test-chart-job/Chart.yaml yamllint!skip
 tests/integration/targets/helm/files/test-chart-v2/templates/configmap.yaml yamllint!skip
 tests/integration/targets/helm/files/test-chart/templates/configmap.yaml yamllint!skip
 tests/integration/targets/helm_diff/files/test-chart/templates/configmap.yaml yamllint!skip


### PR DESCRIPTION
##### SUMMARY

The `helm` module missing the option to specify `--wait-for-jobs` flag in addition to the already supported `--wait`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
helm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

The helm cli supports the `--wait-for-jobs` flag that waits for all jobs to complete before marking the release as successful. We have a use-case where we perform database migrations and database seeding using a job during release deployment. We need to wait for the job to finish successfully or roll back the deployment (i.e. we need `--atomic` along with `--wait-for-jobs`). This flag was not supported by the `helm` module.

<!--- Paste verbatim command output below, e.g. before and after your change -->
