### PR TITLE
Add meta/execution-environment.yml to fix EE builds on UBI images

### DIFF
--- a/changelogs/fragments/fix-openshift-clients-ee-dependency.yaml
+++ b/changelogs/fragments/fix-openshift-clients-ee-dependency.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ee - added ``meta/execution-environment.yml`` to decouple ansible-builder EE builds from the ``openshift-clients`` system dependency declared in ``bindep.txt``, which is not available in standard UBI repositories and caused builds to fail with ``No package matches 'openshift-clients'`` (https://github.com/ansible-collections/kubernetes.core/issues/1141).

--- a/meta/ee-bindep.txt
+++ b/meta/ee-bindep.txt
@@ -1,0 +1,1 @@
+kubernetes-client [platform:fedora]

--- a/meta/execution-environment.yml
+++ b/meta/execution-environment.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  python: requirements.txt
+  system: meta/ee-bindep.txt


### PR DESCRIPTION
## Summary

- Adds `meta/execution-environment.yml` that points ansible-builder to a minimal bindep file (`meta/ee-bindep.txt`) without the `openshift-clients` dependency
- The existing `bindep.txt` is **unchanged** — it continues to declare `openshift-clients` for direct bindep usage (e.g., RHEL CI builds)
- EE builds on standard UBI images will no longer fail with `No package matches 'openshift-clients'`

## Background

The `openshift-clients` RPM declared in `bindep.txt` for RHEL 8/9 is not available in standard UBI repositories — it requires an OpenShift subscription and additional repos. This causes `ansible-builder` to fail for anyone building an EE that includes `kubernetes.core`, even when they have no need for the `kubectl` connection plugin or `kustomize` lookup (the only two plugins that use the `kubectl` binary). The core modules all use the Python `kubernetes` client library.

This has been a pain point since 2022 (#537), with workarounds ranging from manually downloading RPMs to using `dependencies.exclude.system` in the EE definition.

## How it works

When `ansible-builder` introspects a collection, it checks for `meta/execution-environment.yml` first. If found, it uses the dependency files referenced there and **does not** fall back to the root `bindep.txt`. This is [documented collection metadata behavior](https://docs.ansible.com/projects/builder/en/latest/collection_metadata/) used by other collections (e.g., `azure`, `ibm_zos_sysauto`).

The new `meta/ee-bindep.txt` retains the `kubernetes-client [platform:fedora]` entry (available in standard Fedora repos) and omits `openshift-clients`. Users who need `kubectl` or `oc` for the kubectl connection plugin can install it via their EE definition's `additional_build_steps`.

Fixes #1141
Related: #537, #249, #438

## Test plan

- [ ] Build an EE on a UBI 9 base image with `kubernetes.core` in the galaxy requirements — should succeed without `openshift-clients` errors
- [ ] Verify `meta/execution-environment.yml` and `meta/ee-bindep.txt` are included in the built collection artifact (`ansible-galaxy collection build`)
- [ ] Verify existing CI tests still pass (no module functionality is affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)