### PR TITLE
helm_registry_auth: document/test stdout for registry success messages (Helm 4.2.1)

### DIFF
--- a/changelogs/fragments/20260612-helm-registry-output-stream.yml
+++ b/changelogs/fragments/20260612-helm-registry-output-stream.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - helm_registry_auth - document that, as of Helm 4.2.1, registry success messages such as ``Login Succeeded`` are printed to stdout instead of stderr (https://github.com/ansible-collections/kubernetes.core/pull/1147).

--- a/plugins/modules/helm_registry_auth.py
+++ b/plugins/modules/helm_registry_auth.py
@@ -106,17 +106,23 @@ EXAMPLES = r"""
 RETURN = r"""
 stdout:
   type: str
-  description: Full C(helm) command stdout, in case you want to display it or examine the event log
+  description:
+    - Full C(helm) command stdout, in case you want to display it or examine the event log.
+    - As of Helm 4.2.1 success messages such as C(Login Succeeded) are printed to stdout
+      (see U(https://github.com/helm/helm/pull/32056)). On earlier versions they are printed to stderr.
   returned: always
-stout_lines:
+  sample: 'Login Succeeded\n'
+stdout_lines:
   type: list
   description: Full C(helm) command stdout, in case you want to display it or examine the event log
   returned: always
 stderr:
   type: str
-  description: >-
-    Full C(helm) command stderr, in case you want to display it or examine the event log.
-    Please be note that helm binnary may print messages to stderr even if the command is successful.
+  description:
+    - Full C(helm) command stderr, in case you want to display it or examine the event log.
+    - Please note that the helm binary may print messages to stderr even if the command is successful.
+    - On Helm versions earlier than 4.2.1, success messages such as C(Login Succeeded) are printed
+      here; as of Helm 4.2.1 they are printed to stdout (see U(https://github.com/helm/helm/pull/32056)).
   returned: always
   sample: 'Login Succeeded\n'
 stderr_lines:

--- a/tests/integration/targets/helm_registry_auth/tasks/run_tests.yml
+++ b/tests/integration/targets/helm_registry_auth/tasks/run_tests.yml
@@ -28,7 +28,9 @@
       register: _helm_registry_auth_correct
 
     - name: Assert that the registry is logged in
-      # Helm binary prints the message to stderr, refence: https://github.com/helm/helm/issues/13464
+      # Helm < 4.2.1 prints success messages to stderr (https://github.com/helm/helm/issues/13464),
+      # Helm >= 4.2.1 moves them to stdout (https://github.com/helm/helm/pull/32056).
+      # Check both streams to stay version-agnostic.
       assert:
         that:
           - "'Login Succeeded' in _helm_registry_auth_correct.stdout_lines + _helm_registry_auth_correct.stderr_lines"
@@ -43,9 +45,11 @@
       failed_when: _save_chart.rc != 0
 
     - name: Assert that the chart is saved
-      # Helm binary prints the message to stderr, refence: https://github.com/helm/helm/issues/13464
+      # Helm < 4.2.1 prints success messages to stderr (https://github.com/helm/helm/issues/13464),
+      # Helm >= 4.2.1 moves them to stdout (https://github.com/helm/helm/pull/32056).
+      # Check both streams to stay version-agnostic.
       assert:
-        that: "'Pushed: localhost:' + registry_port | string + '/test/k8s-monitoring' in _save_chart.stderr"
+        that: "'Pushed: localhost:' + registry_port | string + '/test/k8s-monitoring' in _save_chart.stdout + _save_chart.stderr"
 
     - name: Test logout
       helm_registry_auth:
@@ -55,9 +59,11 @@
       register: _helm_registry_auth_logout
 
     - name: Assert logout
-      # Helm binary prints the message to stderr
+      # Helm < 4.2.1 prints success messages to stderr (https://github.com/helm/helm/issues/13464),
+      # Helm >= 4.2.1 moves them to stdout (https://github.com/helm/helm/pull/32056).
+      # Check both streams to stay version-agnostic.
       assert:
-        that: "'Removing login credentials' in _helm_registry_auth_logout.stderr"
+        that: "'Removing login credentials' in _helm_registry_auth_logout.stdout + _helm_registry_auth_logout.stderr"
 
     - name: Ensure that not able to push to the registry
       ansible.builtin.shell: >-


### PR DESCRIPTION
##### SUMMARY

Helm versions before 4.2.1 print OCI registry success messages (`Login Succeeded`, `Pushed:`, `Pulled:`, `Digest:`) to **stderr** (helm/helm#13464). Helm 4.2.1 moves them to **stdout** (helm/helm#32056).

The `helm_registry_auth` module already keys success/failure on the return code, so there is **no functional change** — but its `RETURN` documentation and the integration assertions assumed the messages land on stderr. This PR makes the docs version-accurate and the tests stream-agnostic so they keep passing across Helm 3.x, pre-4.2.1, and >= 4.2.1.

##### ISSUE TYPE
- Docs Pull Request
- Testing/CI Pull Request

##### COMPONENT NAME
helm_registry_auth

##### CHANGES

- `helm_registry_auth` `RETURN` docs: note that, as of Helm 4.2.1, success messages such as `Login Succeeded` are printed to stdout (stderr on earlier versions), with links to the upstream issue/PR.
- `helm_registry_auth` integration tests (`run_tests.yml`): assert the `Pushed:` and `Removing login credentials` success messages against the `stdout + stderr` union instead of `stderr` only (the `Login Succeeded` assertion already used the union). Error-message assertions are unchanged, since error output stays on stderr.

##### ADDITIONAL INFORMATION

No module logic changes — `helm_registry_auth` determines success from the return code, and the only stderr string it inspects (`Error: not logged in`) is an error message that remains on stderr. This is forward-compatibility hardening: current CI (Helm 3.x / 4.0–4.2.0) stays green, and the integration tests will keep passing once runners pick up Helm >= 4.2.1.

References:
- Helm behavior (success → stderr): helm/helm#13464
- Helm fix (success → stdout, milestone 4.2.1): helm/helm#32056

Fixes #1146