### PR TITLE
ci: suppress SonarCloud python:S7498 for argument_spec dict() convention

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,3 +12,11 @@ sonar.python.version=3.12
 sonar.newCode.referenceBranch=main
 
 sonar.exclusions=tests/**,.tox/**
+
+# Ansible module argument_spec is conventionally defined with the dict(...)
+# constructor (not {...} literals) for readability and consistency across the
+# collection. Suppress python:S7498 ("prefer literal syntax"), which conflicts
+# with that convention and otherwise re-fires on every new module argument.
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=python:S7498
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/*.py


### PR DESCRIPTION
##### SUMMARY
Suppress SonarCloud rule `python:S7498` ("Literal syntax should be preferred when creating empty collections or dictionaries with keyword arguments") project-wide via `sonar-project.properties`.

Ansible modules in this collection (and across the Ansible ecosystem) intentionally define their `argument_spec` using the `dict(...)` constructor rather than `{...}` dict literals, for readability (no need to quote every key) and consistency. Sonar's `python:S7498` flags this established convention as an issue and re-fires on every newly added/changed module argument, producing recurring false-positive noise on PRs.

The rule is ignored via Sonar's standard `sonar.issue.ignore.multicriteria` mechanism scoped to `**/*.py`, so it stops surfacing in scans without requiring SonarCloud UI/admin access. No runtime code is changed.

Fixes #1151

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
sonar-project.properties (CI / SonarCloud configuration)

##### ADDITIONAL INFORMATION
Rule reference: [python:S7498 — Literal syntax should be preferred](https://next.sonarqube.com/sonarqube/coding_rules?open=python:S7498&rule_key=python:S7498)

Example of the convention being flagged (`plugins/modules/helm_plugin.py`), which is identical to every other argument in the same `argument_spec()`:

```python
keyring=dict(
    type="path",
    required=False,
)
```

Change applied to `sonar-project.properties`:

```paste below
sonar.issue.ignore.multicriteria=e1
sonar.issue.ignore.multicriteria.e1.ruleKey=python:S7498
sonar.issue.ignore.multicriteria.e1.resourceKey=**/*.py
```

Changelog fragment skipped as it is a CI-only change