### PR TITLE
Fix all-green CI workflow

### DIFF
--- a/.github/workflows/all_green_check.yaml
+++ b/.github/workflows/all_green_check.yaml
@@ -132,7 +132,6 @@ jobs:
       - coverage
     if: >-
       ${{ needs.all_green.result == 'success'
-      && secrets.ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT != ''
       && (github.event_name == 'push'
       || (github.event_name == 'pull_request'
       && github.event.pull_request.head.repo.full_name == github.repository)) }}

--- a/CI.md
+++ b/CI.md
@@ -15,7 +15,7 @@ The following tests run on every pull request:
 | [Sanity](.github/workflows/sanity-tests.yaml) | Runs ansible sanity checks | See compatibility table below | devel, stable-2.18, stable-2.19, stable-2.20 |
 | [Unit tests](.github/workflows/unit-tests.yaml) | Executes unit test cases | See compatibility table below | devel, stable-2.16, stable-2.17, stable-2.18, stable-2.19, stable-2.20 |
 | [Integration](.github/workflows/integration-tests.yaml) | Executes integration test suites using KinD cluster (split across 8 jobs, tests with Turbo mode enabled/disabled) | 3.12 | milestone |
-| [all_green](.github/workflows/all_green_check.yaml) | Linters (PR only), sanity, units, coverage XML, aggregate gate, and SonarCloud scan (same-repo PR / push when org secret is set) | (see jobs) | (see jobs) |
+| [all_green](.github/workflows/all_green_check.yaml) | Linters (PR only), sanity, units, coverage XML, aggregate gate, and SonarCloud scan (same-repo PR / push only) | (see jobs) | (see jobs) |
 
 **Note:** Integration tests require a KinD (Kubernetes in Docker) cluster and test both with Turbo mode enabled and disabled.
 
@@ -34,4 +34,4 @@ These are outlined in the collection's [tox.ini](tox.ini) file (`envlist`) and G
 
 ## SonarCloud
 
-SonarCloud analysis runs from **[`all_green_check.yaml`](.github/workflows/all_green_check.yaml)** via the **`sonarcloud`** job, which calls **[`sonarcloud.yml`](.github/workflows/sonarcloud.yml)** (**`workflow_call`**) after the **`all_green`** gate and **coverage** succeed. The reusable workflow checks out the PR head or push SHA, downloads the **`coverage`** artifact, and runs the pinned **SonarSource** scan action. Same-repo **`pull_request`** and **`push`** only (fork PRs skip Sonar when the org secret is unavailable). Details: [SONARCLOUD.md](SONARCLOUD.md).
+SonarCloud analysis runs from **[`all_green_check.yaml`](.github/workflows/all_green_check.yaml)** via the **`sonarcloud`** job, which calls **[`sonarcloud.yml`](.github/workflows/sonarcloud.yml)** (**`workflow_call`**) after the **`all_green`** gate and **coverage** succeed. The reusable workflow checks out the PR head or push SHA, downloads the **`coverage`** artifact, and runs the pinned **SonarSource** scan action. Same-repo **`pull_request`** and **`push`** only (fork PRs are excluded by the job **`if:`** gate). Details: [SONARCLOUD.md](SONARCLOUD.md).

--- a/SONARCLOUD.md
+++ b/SONARCLOUD.md
@@ -16,7 +16,7 @@ The scan step uses **`SonarSource/sonarqube-scan-action`** (pinned SHA in the wo
 
 Workflow files:
 
-- [.github/workflows/all_green_check.yaml](.github/workflows/all_green_check.yaml) -- **`all_green`** gate, **coverage** artifact upload, and **`sonarcloud`** job (**`uses: ./.github/workflows/sonarcloud.yml`**, passing only **`ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT`**) after **`all_green`** and **`coverage`** succeed, gated for **`push`** and same-repo **`pull_request`** when that secret is set.
+- [.github/workflows/all_green_check.yaml](.github/workflows/all_green_check.yaml) -- **`all_green`** gate, **coverage** artifact upload, and **`sonarcloud`** job (**`uses: ./.github/workflows/sonarcloud.yml`**, passing only **`ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT`**) after **`all_green`** and **`coverage`** succeed, gated for **`push`** and same-repo **`pull_request`** only.
 - [.github/workflows/sonarcloud.yml](.github/workflows/sonarcloud.yml) -- **`scan`** job: checkout, download **`coverage`**, **`SONAR_ARGS`**, SonarCloud scan.
 
 Scanner configuration lives in [sonar-project.properties](sonar-project.properties).


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Resolves #1148 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

The `all_green` workflow fails at workflow validation before any job runs because GitHub does not allow the secrets context in a job-level `if:`. Removing the line with the org secret in that workflow file.