### PR TITLE
Fix workflow concurrency issue

### DIFF
--- a/.github/workflows/all_green_check.yaml
+++ b/.github/workflows/all_green_check.yaml
@@ -2,7 +2,7 @@
 name: all_green
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 on: # yamllint disable-line rule:truthy


### PR DESCRIPTION
##### SUMMARY

Fixes a concurrency deadlock in the `all_green` workflow that caused runs to fail immediately after [#1153](https://github.com/ansible-collections/kubernetes.core/pull/1153) fixed the workflow validation issue ([#1148](https://github.com/ansible-collections/kubernetes.core/issues/1148)).

When `all_green_check.yaml` calls reusable workflows (`sanity-tests.yaml`, `unit-tests.yaml`, `linters.yaml`), GitHub sets `github.workflow` in the callee to the caller's name (`all_green`). Both the parent and children used `${{ github.workflow }}` in their concurrency groups, so they resolved to the same group (e.g. `all_green-refs/heads/main`). Because of this, GitHub detects a deadlock and cancels the run.

Removing the `${{ github.workflow }}-` prefix from the parent concurrency group so that it uses `${{ github.head_ref || github.ref }}` only, which is the same pattern as [amazon.aws](https://github.com/ansible-collections/amazon.aws/blob/main/.github/workflows/all_green_check.yml). The parent and reusable workflows no longer share a concurrency group.
