### PR TITLE
ci: suppress SonarCloud python:S5443 for test code

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -17,6 +17,14 @@ sonar.exclusions=tests/**,.tox/**
 # constructor (not {...} literals) for readability and consistency across the
 # collection. Suppress python:S7498 ("prefer literal syntax"), which conflicts
 # with that convention and otherwise re-fires on every new module argument.
-sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria=e1,e2
 sonar.issue.ignore.multicriteria.e1.ruleKey=python:S7498
 sonar.issue.ignore.multicriteria.e1.resourceKey=**/*.py
+
+# Unit tests pass hardcoded '/tmp/...' strings as fake module arguments (e.g.
+# chart_ref) to fully mocked commands; no file is ever created there. Suppress
+# python:S5443 ("temporary files in publicly writable directories") for test
+# code only. Production code creates temp files via tempfile.mkstemp /
+# NamedTemporaryFile and stays covered by the rule.
+sonar.issue.ignore.multicriteria.e2.ruleKey=python:S5443
+sonar.issue.ignore.multicriteria.e2.resourceKey=tests/**/*.py


### PR DESCRIPTION
##### SUMMARY

Scope a SonarCloud rule suppression to test code only.

SonarCloud's `python:S5443` ("Temporary files should not be created in publicly writable directories") raises a security *hotspot* on every hardcoded `/tmp/...` string literal. In the unit tests these literals are passed as fake module arguments (for example `chart_ref: /tmp/path`) into fully mocked helm commands — no file is ever created and there is no real exposure. Because SonarCloud scores only *new code* on a pull request, any PR that adds such a test line gets its security rating dropped (to D) and fails the quality gate, even though the identical pattern already pervades the existing test suite.

This change ignores `python:S5443` for `tests/**` only, mirroring the existing `python:S7498` suppression (#1152). Production code is intentionally left covered: it creates temporary files via `tempfile.mkstemp` / `NamedTemporaryFile`, where the rule carries real value.

This surfaced on the SonarCloud review of #1164 (six identical hotspots, all on `tests/unit/modules/test_module_helm.py`).

##### ISSUE TYPE

- CI / Infrastructure change (SonarCloud configuration)

##### COMPONENT NAME

sonar-project.properties (CI / SonarCloud static-analysis configuration)

##### ADDITIONAL INFORMATION

The suppression is scoped to test files, so the rule keeps flagging any genuinely risky temp-file handling in `plugins/`. An audit confirms production code already uses the secure temp-file APIs (`tempfile.mkstemp`, `NamedTemporaryFile`, `tempfile.gettempdir`); the only `/tmp` strings under `plugins/` are in `EXAMPLES`/doc comments.