### PR TITLE
Point to Python 3.13 for ansible-core devel

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -58,11 +58,15 @@ jobs:
         # Ref must match a branch/tag on github.com/ansible/ansible (e.g. stable-2.18, not 2.18).
         ansible-version: ["stable-2.18", "milestone"]
         enable-turbo-mode: [true, false]
+        python-version: ["3.12", "3.13"]
         exclude:
           - ansible-version: "milestone"
             enable-turbo-mode: true
-        python-version:
-          - "3.12"
+          # stable-2.18 supports 3.12; milestone (devel) requires >=3.13
+          - ansible-version: "stable-2.18"
+            python-version: "3.13"
+          - ansible-version: "milestone"
+            python-version: "3.12"
         workflow-id: ${{ fromJson(needs.splitter.outputs.test_jobs) }}
     name: Integration tests
     steps:

--- a/CI.md
+++ b/CI.md
@@ -14,7 +14,7 @@ The following tests run on every pull request:
 | [Linters](.github/workflows/linters.yaml) | Runs `black`, `flake8`, `isort`, `yamllint`, and `ansible-lint` on plugins and tests | 3.10 | devel |
 | [Sanity](.github/workflows/sanity-tests.yaml) | Runs ansible sanity checks | See compatibility table below | devel, stable-2.18, stable-2.19, stable-2.20 |
 | [Unit tests](.github/workflows/unit-tests.yaml) | Executes unit test cases | See compatibility table below | devel, stable-2.16, stable-2.17, stable-2.18, stable-2.19, stable-2.20 |
-| [Integration](.github/workflows/integration-tests.yaml) | Executes integration test suites using KinD cluster (split across 8 jobs, tests with Turbo mode enabled/disabled) | 3.12 | milestone |
+| [Integration](.github/workflows/integration-tests.yaml) | Executes integration test suites using KinD cluster (split across 8 jobs, tests with Turbo mode enabled/disabled) | 3.12 (stable-2.18), 3.13 (milestone) | stable-2.18, milestone |
 | [all_green](.github/workflows/all_green_check.yaml) | Linters (PR only), sanity, units, coverage XML, aggregate gate, and SonarCloud scan (same-repo PR / push only) | (see jobs) | (see jobs) |
 
 **Note:** Integration tests require a KinD (Kubernetes in Docker) cluster and test both with Turbo mode enabled and disabled.
@@ -23,14 +23,14 @@ The following tests run on every pull request:
 
 These are outlined in the collection's [tox.ini](tox.ini) file (`envlist`) and GitHub Actions workflow exclusions.
 
-| ansible-core Version | Sanity Tests | Unit Tests |
-| -------------------- | ------------ | ---------- |
-| devel | 3.12, 3.13, 3.14 | 3.12, 3.13 |
-| stable-2.20 | 3.12, 3.13, 3.14 | 3.12, 3.13, 3.14 |
-| stable-2.19 | 3.11, 3.12, 3.13 | 3.11, 3.12, 3.13 |
-| stable-2.18 | 3.11, 3.12, 3.13 | 3.11, 3.12, 3.13 |
-| stable-2.17 | 3.10, 3.11, 3.12 | 3.10, 3.11, 3.12 |
-| stable-2.16 | 3.10, 3.11 | 3.10, 3.11 |
+| ansible-core Version | Sanity Tests | Unit Tests | Integration Tests |
+| -------------------- | ------------ | ---------- | ----------------- |
+| devel | 3.12, 3.13, 3.14 | 3.13 | 3.13 (milestone) |
+| stable-2.20 | 3.12, 3.13, 3.14 | 3.12, 3.13, 3.14 | — |
+| stable-2.19 | 3.11, 3.12, 3.13 | 3.11, 3.12, 3.13 | — |
+| stable-2.18 | 3.11, 3.12, 3.13 | 3.11, 3.12, 3.13 | 3.12 |
+| stable-2.17 | 3.10, 3.11, 3.12 | 3.10, 3.11, 3.12 | — |
+| stable-2.16 | 3.10, 3.11 | 3.10, 3.11 | — |
 
 ## SonarCloud
 


### PR DESCRIPTION
##### SUMMARY
`milestone` (ansible-core devel) requires Python ≥ 3.13 ([ansible/ansible#87057](https://github.com/ansible/ansible/pull/87057)). Integration tests still pair it with 3.12, so `pip` fails before any tests run. Unit tests were already fixed upstream in [ansible-network/github_actions#200](https://github.com/ansible-network/github_actions/pull/200); integration tests are local and weren’t updated.