### PR TITLE
Add lint ignore entry

### DIFF
--- a/.ansible-lint-ignore
+++ b/.ansible-lint-ignore
@@ -4,3 +4,5 @@ plugins/connection/kubectl.py no-changed-when
 # false positive result
 plugins/connection/kubectl.py var-naming[no-reserved]
 plugins/connection/kubectl.py jinja[invalid]
+# collection EE metadata is not an ansible-builder definition file
+meta/execution-environment.yml schema[execution-environment]


### PR DESCRIPTION
##### SUMMARY
Adds an `ansible-lint` ignore entry for `meta/execution-environment.yml` so collection EE metadata is not validated against the ansible-builder definition schema (which requires version:).

This fixes the linters / ansible-lint failure on the #1142 backports ([#1182](https://github.com/ansible-collections/kubernetes.core/pull/1182), [#1183](https://github.com/ansible-collections/kubernetes.core/pull/1183)) and prevents the same failure on future PRs to `main`.