### PR TITLE
Merge `stable-5` branch changes back into `main` after `5.4.3` release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -123,6 +123,21 @@ Breaking Changes / Porting Guide
 - Remove deprecated ``k8s`` invetory plugin (https://github.com/ansible-collections/kubernetes.core/pull/867).
 - Remove support for ``ansible-core<2.16`` (https://github.com/ansible-collections/kubernetes.core/pull/867).
 
+v5.4.3
+======
+
+Release Summary
+---------------
+
+This release contains bugfixes such as improved idempotency for helm repository URLs with trailing slashes.
+
+Bugfixes
+--------
+
+- ee - Add ``meta/execution-environment.yml`` to decouple ansible-builder EE builds from the ``openshift-clients`` system dependency declared in ``bindep.txt``, which is not available in standard UBI repositories and caused builds to fail with ``No package matches 'openshift-clients'`` (https://github.com/ansible-collections/kubernetes.core/issues/1141).
+- helm_repository - Correct handling of repository URLs with trailing slashes (https://github.com/ansible-collections/kubernetes.core/pull/1121).
+- k8s_drain - Fix logic for handling pods with local storage to correctly check for ``empty_dir`` volumes in replicated pods and pods managed by DaemonSets (https://github.com/ansible-collections/kubernetes.core/pull/1095).
+
 v5.4.2
 ======
 
@@ -134,8 +149,8 @@ This release includes bugfixes such as replacing the passing of ``warnings`` to 
 Minor Changes
 -------------
 
-- helm - add ``release_values`` key to ``status`` return value that can be accessed using Jinja2 dot notation (https://github.com/ansible-collections/kubernetes.core/pull/1056).
-- helm_info - add ``release_values`` key to ``status`` return value that can be accessed using Jinja2 dot notation (https://github.com/ansible-collections/kubernetes.core/pull/1056).
+- helm - Add ``release_values`` key to ``status`` return value that can be accessed using Jinja2 dot notation (https://github.com/ansible-collections/kubernetes.core/pull/1056).
+- helm_info - Add ``release_values`` key to ``status`` return value that can be accessed using Jinja2 dot notation (https://github.com/ansible-collections/kubernetes.core/pull/1056).
 
 Deprecated Features
 -------------------
@@ -197,15 +212,15 @@ This release includes minor changes, bug fixes and also bumps ``ansible-lint`` v
 Minor Changes
 -------------
 
-- Bump version of ``ansible-lint`` to 25.1.2 (https://github.com/ansible-collections/kubernetes.core/pull/919).
 - action/k8s_info - update templating mechanism with changes from ``ansible-core 2.19`` (https://github.com/ansible-collections/kubernetes.core/pull/888).
 - helm - add ``reset_then_reuse_values`` support to helm module (https://github.com/ansible-collections/kubernetes.core/issues/803).
-- helm - add support for ``insecure_skip_tls_verify`` option to helm and helm_repository(https://github.com/ansible-collections/kubernetes.core/issues/694).
+- helm - add support for ``insecure_skip_tls_verify`` option to helm and ``helm_repository`` (https://github.com/ansible-collections/kubernetes.core/issues/694).
+- kubernetes.core - Bump version of ``ansible-lint`` to ``25.1.2`` (https://github.com/ansible-collections/kubernetes.core/pull/919).
 
 Bugfixes
 --------
 
-- module_utils/k8s/service - fix issue when trying to delete resource using ``delete_options`` and ``check_mode=true`` (https://github.com/ansible-collections/kubernetes.core/issues/892).
+- module_utils/k8s/service - fix issue when trying to delete resource using `delete_options` and `check_mode=true` (https://github.com/ansible-collections/kubernetes.core/issues/892).
 
 v5.2.0
 ======

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1096,13 +1096,13 @@ releases:
         be removed in a release after 2027-01-08. Use ``status.release_values`` instead
         (https://github.com/ansible-collections/kubernetes.core/pull/1056).
       minor_changes:
-      - helm - added ``release_values`` key to ``status`` return value that can be
+      - helm - Add ``release_values`` key to ``status`` return value that can be
         accessed using Jinja2 dot notation (https://github.com/ansible-collections/kubernetes.core/pull/1056).
-      - helm_info - added ``release_values`` key to ``status`` return value that can
+      - helm_info - Add ``release_values`` key to ``status`` return value that can
         be accessed using Jinja2 dot notation (https://github.com/ansible-collections/kubernetes.core/pull/1056).
-      release_summary: This release includes various bugfixes such as replacing the
-        passing of ``warnings`` to ``exit_json`` with ``AnsibleModule.warn`` as well
-        as security updates for selectively redacting sensitive information from kubeconfig.
+      release_summary: This release includes bugfixes such as replacing the passing of ``warnings`` to ``exit_json``
+        with ``AnsibleModule.warn`` as well as a security update for selectively redacting sensitive information
+        from kubeconfig, and adds a new ``release_values`` key to the ``status`` return value.
       security_fixes:
       - Selectively redact sensitive info from kubeconfig instead of applying blanket
         ``no_log=True`` (https://github.com/ansible-collections/kubernetes.core/pull/1014).
@@ -1116,6 +1116,26 @@ releases:
     - 20260108-fix-sanity-failures.yml
     - 5-4-2.yaml
     release_date: '2026-02-03'
+  5.4.3:
+    changes:
+      bugfixes:
+      - ee - Add ``meta/execution-environment.yml`` to decouple ansible-builder EE
+        builds from the ``openshift-clients`` system dependency declared in ``bindep.txt``,
+        which is not available in standard UBI repositories and caused builds to fail
+        with ``No package matches 'openshift-clients'`` (https://github.com/ansible-collections/kubernetes.core/issues/1141).
+      - helm_repository - Correct handling of repository URLs with trailing slashes
+        (https://github.com/ansible-collections/kubernetes.core/pull/1121).
+      - k8s_drain - Fix logic for handling pods with local storage to correctly check
+        for empty_dir volumes in replicated pods and pods managed by DaemonSets (https://github.com/ansible-collections/kubernetes.core/pull/1095).
+      release_summary: This release contains bugfixes such as improved idempotency
+        for helm repository URLs with trailing slashes.
+    fragments:
+    - 1173-security-check-workflow.yml
+    - 20260306-k8s_drain-delete-logic-fixes-for-daemonsets.yaml
+    - 20260506-improve_idempotency_for_helm_repository.yaml
+    - 5-4-3.yml
+    - fix-openshift-clients-ee-dependency.yaml
+    release_date: '2026-07-08'
   6.0.0:
     changes:
       breaking_changes:

--- a/changelogs/fragments/1173-security-check-workflow.yml
+++ b/changelogs/fragments/1173-security-check-workflow.yml
@@ -1,2 +1,0 @@
-trivial:
-  - ci - add security check workflow to block PRs containing ``.claude/`` or ``.vscode/`` directories (https://github.com/ansible-collections/kubernetes.core/pull/1173).

--- a/changelogs/fragments/20260306-k8s_drain-delete-logic-fixes-for-daemonsets.yaml
+++ b/changelogs/fragments/20260306-k8s_drain-delete-logic-fixes-for-daemonsets.yaml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - k8s_drain - Fix logic for handling pods with local storage to correctly check for empty_dir volumes in replicated pods and pods managed by DaemonSets (https://github.com/ansible-collections/kubernetes.core/pull/1095).

--- a/changelogs/fragments/20260506-improve_idempotency_for_helm_repository.yaml
+++ b/changelogs/fragments/20260506-improve_idempotency_for_helm_repository.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-  - helm_repository - correct handling of repository URLs with trailing slashes (https://github.com/ansible-collections/kubernetes.core/pull/1121).

--- a/changelogs/fragments/fix-openshift-clients-ee-dependency.yaml
+++ b/changelogs/fragments/fix-openshift-clients-ee-dependency.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-  - ee - added ``meta/execution-environment.yml`` to decouple ansible-builder EE builds from the ``openshift-clients`` system dependency declared in ``bindep.txt``, which is not available in standard UBI repositories and caused builds to fail with ``No package matches 'openshift-clients'`` (https://github.com/ansible-collections/kubernetes.core/issues/1141).


### PR DESCRIPTION
##### SUMMARY

Merging changes from `stable-5` back into `main` after [5.4.3 release](https://github.com/ansible-collections/kubernetes.core/releases/tag/5.4.3).