### PR TITLE
Prep `5.4.4` release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,19 @@ Kubernetes Collection Release Notes
 
 .. contents:: Topics
 
+v5.4.4
+======
+
+Release Summary
+---------------
+
+This release corrects the documented and enforced minimum ``ansible-core`` version to ``>=2.16.0``.
+
+Bugfixes
+--------
+
+- meta - Update ``requires_ansible`` in ``runtime.yml`` and README to ``>=2.16.0`` to match the actual minimum supported ``ansible-core`` version (https://github.com/ansible-collections/kubernetes.core/pull/1193).
+
 v5.4.3
 ======
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Also needs to be updated in galaxy.yml
-VERSION = 5.4.3
+VERSION = 5.4.4
 
 TEST_ARGS ?= ""
 PYTHON_VERSION ?= `python -c 'import platform; print(".".join(platform.python_version_tuple()[0:2]))'`

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ You can also include it in a `requirements.yml` file and install it via `ansible
 ---
 collections:
   - name: kubernetes.core
-    version: 5.4.3
+    version: 5.4.4
 ```
 
 ### Installing the Kubernetes Python Library

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Name | Description
 <!--start requires_ansible-->
 ### Ansible version compatibility
 
-This collection has been tested against the following Ansible versions: **>=2.15.0**.
+This collection has been tested against the following Ansible versions: **>=2.16.0**.
 
 For collections that support Ansible 2.9, please ensure you update your `network_os` to use the
 fully qualified collection name (for example, `cisco.ios.ios`).

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1137,3 +1137,9 @@ releases:
     - 5-4-3.yml
     - fix-openshift-clients-ee-dependency.yaml
     release_date: '2026-07-08'
+  5.4.4:
+    changes:
+      bugfixes:
+      - meta - Update ``requires_ansible`` in ``runtime.yml`` and README to ``>=2.16.0`` to match the actual minimum supported ``ansible-core`` version (https://github.com/ansible-collections/kubernetes.core/pull/1193).
+      release_summary: This release corrects the documented and enforced minimum ``ansible-core`` version to ``>=2.16.0``.
+    release_date: '2026-07-09'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -25,7 +25,7 @@ tags:
   - openshift
   - okd
   - cluster
-version: 5.4.3
+version: 5.4.4
 build_ignore:
   - .DS_Store
   - "*.tar.gz"

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: '>=2.15.0'
+requires_ansible: '>=2.16.0'
 
 action_groups:
   helm:


### PR DESCRIPTION
##### SUMMARY
The collection's `meta/runtime.yml` contains `requires_ansible: >=2.15.0` and the minimum requirement is now `>=2.16.0`. Fixing this discrepancy and re-releasing as `5.4.4`.