### PR TITLE
Merge `stable-5` back into `main`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -153,6 +153,16 @@ Breaking Changes / Porting Guide
 - Remove deprecated ``k8s`` invetory plugin (https://github.com/ansible-collections/kubernetes.core/pull/867).
 - Remove support for ``ansible-core<2.16`` (https://github.com/ansible-collections/kubernetes.core/pull/867).
 
+v5.4.4
+======
+
+This release corrects the documented and enforced minimum ``ansible-core`` version to ``>=2.16.0``.
+
+Bugfixes
+--------
+
+- meta - Update ``requires_ansible`` in ``runtime.yml`` and README to ``>=2.16.0`` to match the actual minimum supported ``ansible-core`` version (https://github.com/ansible-collections/kubernetes.core/pull/1193).
+
 v5.4.3
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1136,6 +1136,12 @@ releases:
     - 5-4-3.yml
     - fix-openshift-clients-ee-dependency.yaml
     release_date: '2026-07-08'
+  5.4.4:
+    changes:
+      bugfixes:
+      - meta - Update ``requires_ansible`` in ``runtime.yml`` and README to ``>=2.16.0`` to match the actual minimum supported ``ansible-core`` version (https://github.com/ansible-collections/kubernetes.core/pull/1193).
+      release_summary: This release corrects the documented and enforced minimum ``ansible-core`` version to ``>=2.16.0``.
+    release_date: '2026-07-09'
   6.0.0:
     changes:
       breaking_changes:


### PR DESCRIPTION
##### SUMMARY

Merging changes from `stable-5` back into `main` after [5.4.4 release](https://github.com/ansible-collections/kubernetes.core/releases/tag/5.4.4).