### PR TITLE
helm - add install_only option to skip upgrades on existing releases

### DIFF
--- a/changelogs/fragments/helm-install-only.yml
+++ b/changelogs/fragments/helm-install-only.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - helm - add the ``install_only`` option to install a chart only when it is not already present, without ever upgrading or downgrading an existing release.

--- a/plugins/modules/helm.py
+++ b/plugins/modules/helm.py
@@ -82,6 +82,13 @@ options:
     default: present
     aliases: [ state ]
     type: str
+  install_only:
+    description:
+      - When the release is already installed, do not upgrade or downgrade it.
+      - Only performs the initial install when the release is not present, and leaves an existing release untouched.
+    default: False
+    type: bool
+    version_added: 7.0.0
   release_values:
     description:
         - Value to pass to chart.
@@ -329,6 +336,14 @@ EXAMPLES = r"""
     release_namespace: monitoring
     values_files:
       - /path/to/values.yaml
+
+- name: Deploy Grafana chart only if not already installed, never upgrade or downgrade it
+  kubernetes.core.helm:
+    name: test
+    chart_ref: stable/grafana
+    chart_version: 5.0.12
+    release_namespace: monitoring
+    install_only: true
 
 - name: Remove test release and waiting suppression ending
   kubernetes.core.helm:
@@ -952,6 +967,7 @@ def argument_spec():
             release_state=dict(
                 default="present", choices=["present", "absent"], aliases=["state"]
             ),
+            install_only=dict(type="bool", default=False),
             release_values=dict(type="dict", default={}, aliases=["values"]),
             values_files=dict(type="list", default=[], elements="str"),
             update_repo_cache=dict(type="bool", default=False),
@@ -1016,6 +1032,7 @@ def main():
     dependency_update = module.params.get("dependency_update")
     release_name = module.params.get("release_name")
     release_state = module.params.get("release_state")
+    install_only = module.params.get("install_only")
     release_values = module.params.get("release_values")
     values_files = module.params.get("values_files")
     update_repo_cache = module.params.get("update_repo_cache")
@@ -1099,138 +1116,58 @@ def main():
             )
             changed = True
     elif release_state == "present":
-        if chart_version is not None:
-            helm_cmd += " --version=" + chart_version
-
-        if chart_repo_url is not None:
-            helm_cmd += " --repo=" + chart_repo_url
-
-        # Fetch chart info to have real version and real name for chart_ref from archive, folder or url
-        chart_info = fetch_chart_info(
-            module, helm_cmd, chart_ref, insecure_skip_tls_verify, plain_http
-        )
-
-        if dependency_update:
-            if chart_info.get("dependencies"):
-                # Can't use '--dependency-update' with 'helm upgrade' that is the
-                # default chart install method, so if chart_repo_url is defined
-                # we can't use the dependency update command. But, in the near future
-                # we can get rid of this method and use only '--dependency-update'
-                # option. Please see https://github.com/helm/helm/pull/8810
-                if not chart_repo_url and not re.fullmatch(
-                    r"^http[s]*://[\w.:/?&=-]+$", chart_ref
-                ):
-                    run_dep_update(module, chart_ref)
-
-                    # To not add --dependency-update option in the deploy function
-                    dependency_update = False
-                else:
-                    module.warn(
-                        "This is a not stable feature with 'chart_repo_url'. Please consider to use dependency update with on-disk charts"
-                    )
-                    if not replace:
-                        msg_fail = (
-                            "'--dependency-update' hasn't been supported yet with 'helm upgrade'. "
-                            "Please use 'helm install' instead by adding 'replace' option"
-                        )
-                        module.fail_json(msg=msg_fail)
-            else:
-                module.warn(
-                    "There is no dependencies block defined in Chart.yaml. Dependency update will not be performed. "
-                    "Please consider add dependencies block or disable dependency_update to remove this warning."
-                )
-
-        set_value_args = None
-        if set_values:
-            set_value_args = module.get_helm_set_values_args(set_values)
-
-        if release_status is None:  # Not installed
-            helm_cmd = deploy(
-                module,
-                helm_cmd,
-                release_name,
-                release_values,
-                chart_ref,
-                wait,
-                wait_timeout,
-                disable_hook,
-                False,
-                values_files=values_files,
-                atomic=atomic,
-                server_side=server_side,
-                force_conflicts=force_conflicts,
-                create_namespace=create_namespace,
-                post_renderer=post_renderer,
-                replace=replace,
-                dependency_update=dependency_update,
-                skip_crds=skip_crds,
-                history_max=history_max,
-                timeout=timeout,
-                set_value_args=set_value_args,
-                reuse_values=reuse_values,
-                reset_values=reset_values,
-                reset_then_reuse_values=reset_then_reuse_values,
-                insecure_skip_tls_verify=insecure_skip_tls_verify,
-                plain_http=plain_http,
-                take_ownership=take_ownership,
-                skip_schema_validation=skip_schema_validation,
+        if install_only and release_status is not None:
+            module.warn(
+                "Release '%s' is already installed and 'install_only' is set to True. "
+                "Skipping upgrade/downgrade." % release_name
             )
-            changed = True
-
         else:
-            helm_diff_version = get_plugin_version("diff")
-            helm_version_compatible = module.is_helm_version_compatible_with_helm_diff(
-                helm_diff_version
+            if chart_version is not None:
+                helm_cmd += " --version=" + chart_version
+
+            if chart_repo_url is not None:
+                helm_cmd += " --repo=" + chart_repo_url
+
+            # Fetch chart info to have real version and real name for chart_ref from archive, folder or url
+            chart_info = fetch_chart_info(
+                module, helm_cmd, chart_ref, insecure_skip_tls_verify, plain_http
             )
-            if (
-                helm_diff_version
-                and helm_version_compatible
-                and (
-                    not chart_repo_url
-                    or (
-                        chart_repo_url
-                        and LooseVersion(helm_diff_version) >= LooseVersion("3.4.1")
-                    )
-                )
-            ):
-                would_change, prepared = helmdiff_check(
-                    module,
-                    release_name,
-                    chart_ref,
-                    release_values,
-                    values_files,
-                    chart_version,
-                    replace,
-                    chart_repo_url,
-                    post_renderer,
-                    set_value_args,
-                    reuse_values=reuse_values,
-                    reset_values=reset_values,
-                    reset_then_reuse_values=reset_then_reuse_values,
-                    insecure_skip_tls_verify=insecure_skip_tls_verify,
-                    plain_http=plain_http,
-                    skip_schema_validation=skip_schema_validation,
-                )
-                if would_change and module._diff:
-                    opt_result["diff"] = {"prepared": prepared}
-            else:
-                if helm_diff_version and not helm_version_compatible:
-                    module.warn(
-                        "Idempotency checks are currently disabled due to a version mismatch."
-                        f" Helm version {module.get_helm_version()} requires helm-diff >= 3.14.0,"
-                        f" but the environment is currently running {helm_diff_version}."
-                        " Please align the plugin versions to restore standard behavior."
-                    )
+
+            if dependency_update:
+                if chart_info.get("dependencies"):
+                    # Can't use '--dependency-update' with 'helm upgrade' that is the
+                    # default chart install method, so if chart_repo_url is defined
+                    # we can't use the dependency update command. But, in the near future
+                    # we can get rid of this method and use only '--dependency-update'
+                    # option. Please see https://github.com/helm/helm/pull/8810
+                    if not chart_repo_url and not re.fullmatch(
+                        r"^http[s]*://[\w.:/?&=-]+$", chart_ref
+                    ):
+                        run_dep_update(module, chart_ref)
+
+                        # To not add --dependency-update option in the deploy function
+                        dependency_update = False
+                    else:
+                        module.warn(
+                            "This is a not stable feature with 'chart_repo_url'. Please consider to use dependency update with on-disk charts"
+                        )
+                        if not replace:
+                            msg_fail = (
+                                "'--dependency-update' hasn't been supported yet with 'helm upgrade'. "
+                                "Please use 'helm install' instead by adding 'replace' option"
+                            )
+                            module.fail_json(msg=msg_fail)
                 else:
                     module.warn(
-                        "The default idempotency check can fail to report changes in certain cases. "
-                        "Install helm diff >= 3.4.1 for better results."
+                        "There is no dependencies block defined in Chart.yaml. Dependency update will not be performed. "
+                        "Please consider add dependencies block or disable dependency_update to remove this warning."
                     )
-                would_change = default_check(
-                    release_status, chart_info, release_values, values_files
-                )
 
-            if force or would_change:
+            set_value_args = None
+            if set_values:
+                set_value_args = module.get_helm_set_values_args(set_values)
+
+            if release_status is None:  # Not installed
                 helm_cmd = deploy(
                     module,
                     helm_cmd,
@@ -1240,7 +1177,7 @@ def main():
                     wait,
                     wait_timeout,
                     disable_hook,
-                    force,
+                    False,
                     values_files=values_files,
                     atomic=atomic,
                     server_side=server_side,
@@ -1248,10 +1185,10 @@ def main():
                     create_namespace=create_namespace,
                     post_renderer=post_renderer,
                     replace=replace,
+                    dependency_update=dependency_update,
                     skip_crds=skip_crds,
                     history_max=history_max,
                     timeout=timeout,
-                    dependency_update=dependency_update,
                     set_value_args=set_value_args,
                     reuse_values=reuse_values,
                     reset_values=reset_values,
@@ -1262,6 +1199,92 @@ def main():
                     skip_schema_validation=skip_schema_validation,
                 )
                 changed = True
+
+            else:
+                helm_diff_version = get_plugin_version("diff")
+                helm_version_compatible = module.is_helm_version_compatible_with_helm_diff(
+                    helm_diff_version
+                )
+                if (
+                    helm_diff_version
+                    and helm_version_compatible
+                    and (
+                        not chart_repo_url
+                        or (
+                            chart_repo_url
+                            and LooseVersion(helm_diff_version) >= LooseVersion("3.4.1")
+                        )
+                    )
+                ):
+                    would_change, prepared = helmdiff_check(
+                        module,
+                        release_name,
+                        chart_ref,
+                        release_values,
+                        values_files,
+                        chart_version,
+                        replace,
+                        chart_repo_url,
+                        post_renderer,
+                        set_value_args,
+                        reuse_values=reuse_values,
+                        reset_values=reset_values,
+                        reset_then_reuse_values=reset_then_reuse_values,
+                        insecure_skip_tls_verify=insecure_skip_tls_verify,
+                        plain_http=plain_http,
+                        skip_schema_validation=skip_schema_validation,
+                    )
+                    if would_change and module._diff:
+                        opt_result["diff"] = {"prepared": prepared}
+                else:
+                    if helm_diff_version and not helm_version_compatible:
+                        module.warn(
+                            "Idempotency checks are currently disabled due to a version mismatch."
+                            f" Helm version {module.get_helm_version()} requires helm-diff >= 3.14.0,"
+                            f" but the environment is currently running {helm_diff_version}."
+                            " Please align the plugin versions to restore standard behavior."
+                        )
+                    else:
+                        module.warn(
+                            "The default idempotency check can fail to report changes in certain cases. "
+                            "Install helm diff >= 3.4.1 for better results."
+                        )
+                    would_change = default_check(
+                        release_status, chart_info, release_values, values_files
+                    )
+
+                if force or would_change:
+                    helm_cmd = deploy(
+                        module,
+                        helm_cmd,
+                        release_name,
+                        release_values,
+                        chart_ref,
+                        wait,
+                        wait_timeout,
+                        disable_hook,
+                        force,
+                        values_files=values_files,
+                        atomic=atomic,
+                        server_side=server_side,
+                        force_conflicts=force_conflicts,
+                        create_namespace=create_namespace,
+                        post_renderer=post_renderer,
+                        replace=replace,
+                        skip_crds=skip_crds,
+                        history_max=history_max,
+                        timeout=timeout,
+                        dependency_update=dependency_update,
+                        set_value_args=set_value_args,
+                        reuse_values=reuse_values,
+                        reset_values=reset_values,
+                        reset_then_reuse_values=reset_then_reuse_values,
+                        insecure_skip_tls_verify=insecure_skip_tls_verify,
+                        plain_http=plain_http,
+                        take_ownership=take_ownership,
+                        skip_schema_validation=skip_schema_validation,
+                    )
+                    changed = True
 
     if module.check_mode:
         check_status = {

--- a/tests/integration/targets/helm_v3_15_4/aliases
+++ b/tests/integration/targets/helm_v3_15_4/aliases
@@ -2,3 +2,5 @@ helm
 helm_template
 helm_info
 helm_repository
+needs/target/helm
+needs/target/install_helm

--- a/tests/integration/targets/helm_v3_16_0/aliases
+++ b/tests/integration/targets/helm_v3_16_0/aliases
@@ -2,3 +2,5 @@ helm
 helm_template
 helm_info
 helm_repository
+needs/target/helm
+needs/target/install_helm

--- a/tests/integration/targets/helm_v3_17_0/aliases
+++ b/tests/integration/targets/helm_v3_17_0/aliases
@@ -2,3 +2,5 @@ helm
 helm_template
 helm_info
 helm_repository
+needs/target/helm
+needs/target/install_helm

--- a/tests/integration/targets/helm_v4_0_0/aliases
+++ b/tests/integration/targets/helm_v4_0_0/aliases
@@ -2,3 +2,5 @@ helm
 helm_template
 helm_info
 helm_repository
+needs/target/helm
+needs/target/install_helm

--- a/tests/unit/modules/test_module_helm.py
+++ b/tests/unit/modules/test_module_helm.py
@@ -788,3 +788,77 @@ class TestAtomicFlagHelmVersion(unittest.TestCase):
         assert " install " in command
         assert "--rollback-on-failure" in command
         assert "--atomic" not in command
+
+
+class TestInstallOnlyOption(unittest.TestCase):
+    def setUp(self):
+        self.mock_module_helper = patch.multiple(
+            basic.AnsibleModule,
+            exit_json=exit_json,
+            fail_json=fail_json,
+            get_bin_path=get_bin_path,
+        )
+        self.mock_module_helper.start()
+        self.addCleanup(self.mock_module_helper.stop)
+
+        self.chart_info = {
+            "apiVersion": "v2",
+            "appVersion": "default",
+            "description": "A chart used in molecule tests",
+            "name": "test-chart",
+            "type": "application",
+            "version": "0.1.0",
+        }
+
+    def test_install_only_skips_upgrade_when_already_installed(self):
+        set_module_args(
+            {
+                "release_name": "test",
+                "release_namespace": "test",
+                "chart_ref": "/tmp/path",
+                "install_only": True,
+            }
+        )
+        helm.get_release_status = MagicMock(
+            return_value={
+                "status": "deployed",
+                "chart": "test-chart-9.9.9",
+                "app_version": "other",
+                "values": {},
+                "release_values": {},
+            }
+        )
+        helm.fetch_chart_info = MagicMock(return_value=self.chart_info)
+        with patch.object(
+            AnsibleHelmModule, "get_helm_version", return_value="3.10.0"
+        ):
+            with patch.object(basic.AnsibleModule, "run_command") as mock_run_command:
+                mock_run_command.return_value = (0, "deployed", "")
+                with self.assertRaises(AnsibleExitJson) as result:
+                    helm.main()
+        helm.fetch_chart_info.assert_not_called()
+        assert result.exception.args[0]["changed"] is False
+
+    def test_install_only_still_installs_when_not_present(self):
+        set_module_args(
+            {
+                "release_name": "test",
+                "release_namespace": "test",
+                "chart_ref": "/tmp/path",
+                "install_only": True,
+            }
+        )
+        helm.get_release_status = MagicMock(return_value=None)
+        helm.fetch_chart_info = MagicMock(return_value=self.chart_info)
+        with patch.object(
+            AnsibleHelmModule, "get_helm_version", return_value="3.10.0"
+        ):
+            with patch.object(basic.AnsibleModule, "run_command") as mock_run_command:
+                mock_run_command.return_value = (0, "deployed", "")
+                with self.assertRaises(AnsibleExitJson) as result:
+                    helm.main()
+        assert (
+            result.exception.args[0]["command"]
+            == "/usr/bin/helm upgrade -i --reset-values test '/tmp/path'"
+        )
+        assert result.exception.args[0]["changed"] is True


### PR DESCRIPTION
Adds an install_only option to the helm module so it only installs a chart when the release is absent, leaving an already-installed release untouched instead of upgrading or downgrading it.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->



```console 

$ cat test_install_only.yml

---
- name: Test the helm 'install_only' option
  hosts: localhost
  connection: local
  gather_facts: false
  vars:
    ansible_python_interpreter: /home/badams/venv/bin/python3
    release_name: install-only-demo
    release_namespace: test-install-only
    chart_v1: /home/badams/.ansible/collections/ansible_collections/kubernetes/core/tests/integration/targets/helm/files/test-chart
    chart_v2: /home/badams/.ansible/collections/ansible_collections/kubernetes/core/tests/integration/targets/helm/files/test-chart-v2

  tasks:
    - name: Create the namespace
      kubernetes.core.k8s:
        api_version: v1
        kind: Namespace
        name: "{{ release_namespace }}"
        state: present

    - name: "Step 1: Install chart v0.1.0 (release does not exist yet, install_only=true)"
      kubernetes.core.helm:
        name: "{{ release_name }}"
        release_namespace: "{{ release_namespace }}"
        chart_ref: "{{ chart_v1 }}"
        install_only: true
      register: step1

    - name: "Step 2: Re-run same install (already present, install_only=true) - expect no change"
      kubernetes.core.helm:
        name: "{{ release_name }}"
        release_namespace: "{{ release_namespace }}"
        chart_ref: "{{ chart_v1 }}"
        install_only: true
      register: step2

    - name: "Step 3: Attempt upgrade to v0.2.0 with install_only=true - expect upgrade to be SKIPPED"
      kubernetes.core.helm:
        name: "{{ release_name }}"
        release_namespace: "{{ release_namespace }}"
        chart_ref: "{{ chart_v2 }}"
        install_only: true
      register: step3

    - name: Fetch release info after step 3
      kubernetes.core.helm_info:
        name: "{{ release_name }}"
        release_namespace: "{{ release_namespace }}"
      register: info_after_step3

    - name: "Step 4: Same upgrade to v0.2.0 WITHOUT install_only - expect a normal upgrade"
      kubernetes.core.helm:
        name: "{{ release_name }}"
        release_namespace: "{{ release_namespace }}"
        chart_ref: "{{ chart_v2 }}"
      register: step4

    - name: Fetch release info after step 4
      kubernetes.core.helm_info:
        name: "{{ release_name }}"
        release_namespace: "{{ release_namespace }}"
      register: info_after_step4

    - name: Summarize results
      ansible.builtin.debug:
        msg:
          - "Step 1 (fresh install, install_only=true):        changed={{ step1.changed }}"
          - "Step 2 (already installed, install_only=true):    changed={{ step2.changed }} (expect false)"
          - "Step 3 (v0.2.0 attempt, install_only=true):       changed={{ step3.changed }} (expect false, upgrade skipped)"
          - "  -> chart version still deployed: {{ info_after_step3.status.chart }} (expect test-chart-0.1.0)"
          - "Step 4 (v0.2.0 attempt, install_only NOT set):     changed={{ step4.changed }} (expect true, upgrade applied)"
          - "  -> chart version now deployed:   {{ info_after_step4.status.chart }} (expect test-chart-0.2.0)"

    - name: Cleanup - uninstall release
      kubernetes.core.helm:
        name: "{{ release_name }}"
        release_namespace: "{{ release_namespace }}"
        release_state: absent

    - name: Cleanup - delete namespace
      kubernetes.core.k8s:
        api_version: v1
        kind: Namespace
        name: "{{ release_namespace }}"
        state: absent

```
``` console

PLAY [Test the helm 'install_only' option] ***********************************************************************************************************

TASK [Create the namespace] **************************************************************************************************************************
changed: [localhost]

TASK [Step 1: Install chart v0.1.0 (release does not exist yet, install_only=true)] ******************************************************************
changed: [localhost]

TASK [Step 2: Re-run same install (already present, install_only=true) - expect no change] ***********************************************************
[WARNING]: Release 'install-only-demo' is already installed and 'install_only' is set to True. Skipping upgrade/downgrade.
ok: [localhost]

TASK [Step 3: Attempt upgrade to v0.2.0 with install_only=true - expect upgrade to be SKIPPED] *******************************************************
ok: [localhost]

TASK [Fetch release info after step 3] ***************************************************************************************************************
ok: [localhost]

TASK [Step 4: Same upgrade to v0.2.0 WITHOUT install_only - expect a normal upgrade] *****************************************************************
[WARNING]: The default idempotency check can fail to report changes in certain cases. Install helm diff >= 3.4.1 for better results.
changed: [localhost]

TASK [Fetch release info after step 4] ***************************************************************************************************************
ok: [localhost]

TASK [Summarize results] *****************************************************************************************************************************
ok: [localhost] => {
    "msg": [
        "Step 1 (fresh install, install_only=true):        changed=True",
        "Step 2 (already installed, install_only=true):    changed=False (expect false)",
        "Step 3 (v0.2.0 attempt, install_only=true):       changed=False (expect false, upgrade skipped)",
        "  -> chart version still deployed: test-chart-0.1.0 (expect test-chart-0.1.0)",
        "Step 4 (v0.2.0 attempt, install_only NOT set):     changed=True (expect true, upgrade applied)",
        "  -> chart version now deployed:   test-chart-0.2.0 (expect test-chart-0.2.0)"
    ]
}

TASK [Cleanup - uninstall release] *******************************************************************************************************************
changed: [localhost]

TASK [Cleanup - delete namespace] ********************************************************************************************************************
changed: [localhost]

PLAY RECAP *******************************************************************************************************************************************
localhost                  : ok=10   changed=5    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0 

```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #871 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### TESTS
```console
$ ansible-test units tests/unit/modules/test_module_helm.py --python 3.12 --venv
Installing requirements for Python 3.12 [venv]
Unit test controller with Python 3.12
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.1.1, pluggy-1.6.0
rootdir: /home/badams/.ansible/collections/ansible_collections/kubernetes/core
configfile: ../../../../../../../tmp/ansible-test-c86f8oqx/ansible_test/_data/pytest/config/default.ini
plugins: xdist-3.8.0, mock-3.15.1, cov-7.1.0
created: 8/8 workers
8 workers [28 items]

..........................F.                                             [100%]
=================================== FAILURES ===================================
_ TestDependencyUpdateWithoutChartRepoUrlOption.test_dependency_update_option_true _
[gw1] linux -- Python 3.12.3 /home/badams/.ansible/collections/ansible_collections/kubernetes/core/tests/output/.tmp/delegation/python3.12/bin/python

self = <ansible_collections.kubernetes.core.tests.unit.modules.test_module_helm.TestDependencyUpdateWithoutChartRepoUrlOption testMethod=test_dependency_update_option_true>

    def test_dependency_update_option_true(self):
        set_module_args(
            {
                "release_name": "test",
                "release_namespace": "test",
                "chart_ref": "/tmp/path",
                "dependency_update": True,
            }
        )
        helm.get_release_status = MagicMock(return_value=None)
        helm.fetch_chart_info = MagicMock(return_value=self.chart_info_with_dep)
    
        with patch.object(basic.AnsibleModule, "run_command") as mock_run_command:
            # Mock responses: first call is helm version, second is the actual command
            mock_run_command.side_effect = [
                (
                    0,
                    'version.BuildInfo{Version:"v3.10.0", GitCommit:"", GoVersion:"go1.18"}',
                    "",
                ),
                (0, "configuration updated", ""),
            ]
            with patch.object(basic.AnsibleModule, "warn") as mock_warn:
                with self.assertRaises(AnsibleExitJson) as result:
>                   helm.main()

tests/unit/modules/test_module_helm.py:164: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
plugins/modules/helm.py:1318: in main
    rc, out, err = module.run_helm_command(helm_cmd)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
plugins/module_utils/helm.py:179: in run_helm_command
    rc, out, err = self.run_command(
/usr/lib/python3.12/unittest/mock.py:1134: in __call__
    return self._mock_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/lib/python3.12/unittest/mock.py:1138: in _mock_call
    return self._execute_mock_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    def _execute_mock_call(self, /, *args, **kwargs):
        # separate from _increment_mock_call so that awaited functions are
        # executed separately from their call, also AsyncMock overrides this method
    
        effect = self.side_effect
        if effect is not None:
            if _is_exception(effect):
                raise effect
            elif not _callable(effect):
>               result = next(effect)
                         ^^^^^^^^^^^^
E               StopIteration

/usr/lib/python3.12/unittest/mock.py:1195: StopIteration
- generated xml file: /home/badams/.ansible/collections/ansible_collections/kubernetes/core/tests/output/junit/python3.12-controller-units.xml -
=========================== short test summary info ============================
FAILED tests/unit/modules/test_module_helm.py::TestDependencyUpdateWithoutChartRepoUrlOption::test_dependency_update_option_true - StopIteration
========================= 1 failed, 27 passed in 0.94s =========================
FATAL: Command "pytest -r a -n auto --color yes -p no:cacheprovider -c /tmp/ansible-test-c86f8oqx/ansible_test/_data/pytest/config/default.ini --junit-xml /home/badams/.ansible/collections/ansible_collections/kubernetes/core/tests/output/junit/python3.12-controller-units.xml --strict-markers --rootdir /home/badams/.ansible/collections/ansible_collections/kubernetes/core tests/unit/modules/test_module_helm.py" returned exit status 1.
FATAL: Command "/usr/bin/env ANSIBLE_TEST_CONTENT_ROOT=/home/badams/.ansible/collections/ansible_collections/kubernetes/core PYTHONPATH=/tmp/ansible-test-c86f8oqx /home/badams/.ansible/collections/ansible_collections/kubernetes/core/tests/output/.tmp/delegation/python3.12/bin/python /tmp/ansible-test-nuy3xpf8-bin/ansible-test units tests/unit/modules/test_module_helm.py --containers '{}' --truncate 150 --color yes --host-path tests/output/.tmp/host-k9toel2e --metadata tests/output/.tmp/metadata-vt3xxh6a.json" returned exit status 1.
```
