### PR TITLE
Fix ansible-lint no-changed-when and execution-environment schema warnings

### DIFF
--- a/changelogs/fragments/fix-ansible-lint-warnings.yaml
+++ b/changelogs/fragments/fix-ansible-lint-warnings.yaml
@@ -1,0 +1,3 @@
+trivial:
+  - kubectl connection plugin - added ``changed_when: false`` to example ``ansible.builtin.command`` tasks to resolve ansible-lint ``no-changed-when`` warnings.
+  - ee - added ``version: 3`` to ``meta/execution-environment.yml`` to resolve ansible-lint ``schema[execution-environment]`` warning.

--- a/changelogs/fragments/fix-ansible-lint-warnings.yaml
+++ b/changelogs/fragments/fix-ansible-lint-warnings.yaml
@@ -1,3 +1,3 @@
 trivial:
-  - kubectl connection plugin - added ``changed_when: false`` to example ``ansible.builtin.command`` tasks to resolve ansible-lint ``no-changed-when`` warnings.
-  - ee - added ``version: 3`` to ``meta/execution-environment.yml`` to resolve ansible-lint ``schema[execution-environment]`` warning.
+  - "kubectl connection plugin - added ``changed_when: false`` to example ``ansible.builtin.command`` tasks to resolve ansible-lint ``no-changed-when`` warnings."
+  - "ee - added ``version: 3`` to ``meta/execution-environment.yml`` to resolve ansible-lint ``schema[execution-environment]`` warning."

--- a/meta/execution-environment.yml
+++ b/meta/execution-environment.yml
@@ -1,4 +1,5 @@
 ---
+version: 3
 dependencies:
   python: requirements.txt
   system: meta/ee-bindep.txt

--- a/plugins/connection/kubectl.py
+++ b/plugins/connection/kubectl.py
@@ -196,6 +196,7 @@ EXAMPLES = r"""
     # and requires python to be installed in the image
     - name: Run a command in a pod
       ansible.builtin.command: echo "Hello, World!"
+      changed_when: false
 
 - name: Run a command in a pod using local kubectl with inventory variables
   # Example inventory:
@@ -220,6 +221,7 @@ EXAMPLES = r"""
     # and requires python to be installed in the image
     - name: Run a command in a pod
       ansible.builtin.command: echo "Hello, World!"
+      changed_when: false
 
 - name: Run a command in a pod using dynamic inventory
   hosts: localhost
@@ -253,6 +255,7 @@ EXAMPLES = r"""
       # be aware that the command is executed as the user that started the container
       # and requires python to be installed in the image
       ansible.builtin.command: echo "Hello, World!"
+      changed_when: false
       delegate_to: "{{ my_app_pod_name }}"
 """
 


### PR DESCRIPTION
## Summary

- Add `changed_when: false` to the three example `ansible.builtin.command` tasks in the `kubectl` connection plugin EXAMPLES block to resolve `no-changed-when` warnings from ansible-lint
- Add `version: 3` to `meta/execution-environment.yml` to satisfy the `schema[execution-environment]` rule which requires the `version` property (see [ansible-builder docs](https://ansible-builder.readthedocs.io/en/latest/definition/))

## Test plan

- [x] Verified with `ansible-lint 24.12.2` (ansible-core 2.16) that both `no-changed-when` and `schema[execution-environment]` warnings are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)