### PR TITLE
Remove remaining `ansible.module_utils.six` import from kubectl connection plugin

### DIFF
--- a/changelogs/fragments/20260723-remove-module-utils-six.yaml
+++ b/changelogs/fragments/20260723-remove-module-utils-six.yaml
@@ -1,4 +1,4 @@
 ---
 minor_changes:
   - Remove the remaining ``ansible.module_utils.six`` import to avoid deprecation
-    warnings, replacing it with the Python standard library equivalent.
+    warnings, replacing it with the Python standard library equivalent (https://github.com/ansible-collections/kubernetes.core/pull/1197).

--- a/changelogs/fragments/20260723-remove-module-utils-six.yaml
+++ b/changelogs/fragments/20260723-remove-module-utils-six.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Remove the remaining ``ansible.module_utils.six`` import to avoid deprecation
+    warnings, replacing it with the Python standard library equivalent.

--- a/plugins/connection/kubectl.py
+++ b/plugins/connection/kubectl.py
@@ -262,11 +262,11 @@ import os.path
 import shutil
 import subprocess
 import tempfile
+from shlex import quote as shlex_quote
 
 from ansible.errors import AnsibleError, AnsibleFileNotFound
 from ansible.module_utils.common.text.converters import to_bytes
 from ansible.module_utils.parsing.convert_bool import boolean
-from ansible.module_utils.six.moves import shlex_quote
 from ansible.parsing.yaml.loader import AnsibleLoader
 from ansible.plugins.connection import BUFSIZE, ConnectionBase
 from ansible.utils.display import Display


### PR DESCRIPTION
##### SUMMARY

#998 removed the `ansible.module_utils.six` imports, but `plugins/connection/kubectl.py` was missed and still imports the shim. This replaces it with the stdlib equivalent:

```python
-from ansible.module_utils.six.moves import shlex_quote
+from shlex import quote as shlex_quote
```

On Python 3 `six.moves.shlex_quote` is already `shlex.quote` (the same function object), so there is no behaviour change at the single call site in `put_file()`. The import is placed in the stdlib group to keep `tox -e linters` clean.

`ansible.module_utils.six` is deprecated in ansible-core 2.21 and scheduled for removal in 2.24.

##### ISSUE TYPE

- Refactoring Pull Request

##### COMPONENT NAME

plugins/connection/kubectl.py
