### PR TITLE
feat(waiter): add native wait support for Job resources

### DIFF
--- a/changelogs/fragments/20260805-add-job-wait-condition.yaml
+++ b/changelogs/fragments/20260805-add-job-wait-condition.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - "waiter - Add ``job_complete`` predicate to support waiting for Job resources
+    to reach ``Complete`` or ``Failed`` condition (https://github.com/ansible-collections/kubernetes.core/issues/1201)."

--- a/plugins/module_utils/k8s/waiter.py
+++ b/plugins/module_utils/k8s/waiter.py
@@ -47,6 +47,18 @@ def pod_ready(pod: ResourceInstance) -> bool:
     )
 
 
+def job_complete(job: ResourceInstance) -> bool:
+    return bool(
+        job.status
+        and job.status.conditions
+        and any(
+            condition["type"] in ("Complete", "Failed")
+            and boolean(condition["status"], strict=False)
+            for condition in job.status.conditions
+        )
+    )
+
+
 def daemonset_ready(daemonset: ResourceInstance) -> bool:
     return bool(
         daemonset.status
@@ -89,18 +101,18 @@ def custom_condition(condition: Dict, resource: ResourceInstance) -> bool:
     if not matches:
         return False
     # There should never be more than one condition of a specific type
-    match: ResourceField = matches[0]
-    if match.status == "Unknown":
-        if match.status == condition["status"]:
+    match_condition: ResourceField = matches[0]
+    if match_condition.status == "Unknown":
+        if match_condition.status == condition["status"]:
             if "reason" not in condition:
                 return True
             if condition["reason"]:
-                return match.reason == condition["reason"]
+                return match_condition.reason == condition["reason"]
         return False
-    status = True if match.status == "True" else False
+    status = True if match_condition.status == "True" else False
     if status == boolean(condition["status"], strict=False):
         if condition.get("reason"):
-            return match.reason == condition["reason"]
+            return match_condition.reason == condition["reason"]
         return True
     return False
 
@@ -143,6 +155,7 @@ RESOURCE_PREDICATES = {
     "DaemonSet": daemonset_ready,
     "Deployment": deployment_ready,
     "Pod": pod_ready,
+    "Job": job_complete,
     "StatefulSet": statefulset_ready,
     "ClusterOperator": cluster_operator_ready,
 }


### PR DESCRIPTION
##### SUMMARY

- Add a `job_complete` predicate to natively support waiting for `Job` resources to reach either `Complete` or `Failed` condition, eliminating the need for custom `wait_condition` workarounds.

- Also rename shadowed `match` variable to `match_condition` in `custom_condition` to avoid masking the Python built-in.

Fixes #1201

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`plugins/module_utils/k8s/waiter.py`

##### ADDITIONAL INFORMATION

Before this change, waiting on a `Job` required a custom `wait_condition` that could only match one condition type (e.g., `Complete`). If the Job failed, the task would hang until timeout since there was no way to match both `Complete` and `Failed`.

Now, `Job` is a natively supported resource type in `RESOURCE_PREDICATES`, and `wait: true` will correctly return as soon as the Job reaches either terminal state.

```yaml
kubernetes.core.k8s:
  definition:
    apiVersion: batch/v1
    kind: Job
    metadata:
      name: my-job
    spec:
      template:
        spec:
          restartPolicy: Never
          containers:
            - name: worker
              image: busybox
              command: ["sh", "-c", "echo done"]
  wait: true
  wait_timeout: 120
```