### PR TITLE
ci: exclude test code from SonarCloud duplication detection

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,6 +13,17 @@ sonar.newCode.referenceBranch=main
 
 sonar.exclusions=tests/**,.tox/**
 
+# Exclude test code from copy/paste detection. 'sonar.exclusions' above only
+# filters the *source* set (it disambiguates 'sonar.sources=.' from
+# 'sonar.tests'), so test files are still indexed as tests and still scored for
+# duplication. Unit tests here are unittest.TestCase classes: every class needs
+# its own setUp, and per-case arrange/assert blocks are deliberately repeated so
+# a failing test reads on its own. Because SonarCloud scores only *new code* on
+# a pull request, any PR adding cases to an already-repetitive test module
+# inherits duplication accrued across earlier PRs. Production code under
+# plugins/ stays fully covered by duplication analysis.
+sonar.cpd.exclusions=tests/**
+
 # Ansible module argument_spec is conventionally defined with the dict(...)
 # constructor (not {...} literals) for readability and consistency across the
 # collection. Suppress python:S7498 ("prefer literal syntax"), which conflicts


### PR DESCRIPTION
##### SUMMARY

Scope SonarCloud's copy/paste detection to production code, mirroring the existing rule suppressions for test code (#1152, #1165).

SonarCloud reports duplication on test files, and because it scores only *new code* on a pull request, a PR that adds test cases to an already-repetitive module inherits duplication accrued across every earlier PR rather than introducing it. On `main` today, `tests/unit/modules/test_module_helm.py` measures:

```
duplicated_lines_density: 47.9      duplicated_blocks: 15
duplicated_lines:         379       ncloc:             686
```

The gate passes on `main` because that debt is not "new", but the next PR to touch the file pays for all of it.

The repetition is largely structural rather than careless. These are `unittest.TestCase` classes, so each one needs its own `setUp` by framework design, and per-case arrange/assert blocks are deliberately repeated so that a failing test reads on its own without chasing a shared helper — the DAMP-over-DRY tradeoff that applies to test code specifically, and the "Obscure Test" / "Mystery Guest" failure modes it avoids.

Worth noting that `sonar.exclusions=tests/**` does **not** already cover this. That property filters the *source* set only — it exists to disambiguate `sonar.sources=.` from `sonar.tests=tests/unit,tests/integration`. Test files are still indexed as tests and still scored for duplication. `sonar.cpd.exclusions` is the property that governs the copy/paste detector.

Production code under `plugins/` is intentionally left fully covered, exactly as #1165 left `python:S5443` active there.

##### ISSUE TYPE

- CI / Infrastructure change (SonarCloud configuration)

##### COMPONENT NAME

sonar-project.properties (CI / SonarCloud static-analysis configuration)

##### ADDITIONAL INFORMATION

This surfaced on the SonarCloud review of #1206, which failed the gate at **20.9% duplication on new code** (required ≤ 3%). Per-file breakdown from the SonarCloud API for that PR:

```paste below

file                                       new_lines   new_dup_density
plugins/modules/helm.py                           28              0.0%
changelogs/fragments/…-cleanup-on-fail.yaml        4              0.0%
tests/unit/modules/test_module_helm.py           116             26.7%
```

The production change scored a clean 0%; the entire gate failure came from test code.

To be clear about scope: **#1206 does not depend on this PR.** That branch had a genuinely extractable duplication — a `setUp` and helper copied verbatim between two test classes — and it was refactored there on its own merits. This PR is not needed to unblock it, and is deliberately kept separate so it is judged as the repo-wide policy question it is rather than as a feature branch silencing its own gate.

What this changes is the recurring case: the *next* PR that adds a test case to a long-lived test module should not inherit a pre-existing duplication measurement, in the same way that #1152 and #1165 stopped `python:S7498` and `python:S5443` from re-firing on every new module argument and every mocked `/tmp` path.
