### PR TITLE
fix: avoid deprecated `Templar.environment` access when rendering `template`

### DIFF
--- a/changelogs/fragments/20260808-k8s-templar-environment-deprecation.yaml
+++ b/changelogs/fragments/20260808-k8s-templar-environment-deprecation.yaml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - k8s - Avoid direct access to ``Templar.environment`` when rendering the ``template``
+    parameter, which is deprecated in ansible-core 2.19 and removed in 2.23
+    (https://github.com/ansible-collections/kubernetes.core/issues/1208).

--- a/changelogs/fragments/20260808-k8s-templar-environment-deprecation.yaml
+++ b/changelogs/fragments/20260808-k8s-templar-environment-deprecation.yaml
@@ -1,5 +1,8 @@
 ---
 minor_changes:
   - k8s - Avoid direct access to ``Templar.environment`` when rendering the ``template``
-    parameter, which is deprecated in ansible-core 2.19 and removed in 2.23
+    parameter, which is deprecated in ansible-core 2.19 and removed in 2.23. Jinja2
+    environment options such as ``variable_start_string`` are now applied as templating
+    overrides on every supported ansible-core version, so custom delimiters behave
+    consistently across versions
     (https://github.com/ansible-collections/kubernetes.core/issues/1208).

--- a/plugins/action/k8s_info.py
+++ b/plugins/action/k8s_info.py
@@ -44,6 +44,19 @@ def _from_yaml_to_definition(buffer):
 
 ENV_KUBECONFIG_PATH_SEPARATOR = ";" if platform.system() == "Windows" else ":"
 
+# Jinja2 environment options accepted by the 'template' parameter. Kept as a static
+# tuple rather than probing Templar.environment, direct access to which is deprecated
+# in ansible-core 2.19 and removed in 2.23.
+TEMPLATE_ENVIRONMENT_OPTIONS = (
+    "newline_sequence",
+    "variable_start_string",
+    "variable_end_string",
+    "block_start_string",
+    "block_end_string",
+    "trim_blocks",
+    "lstrip_blocks",
+)
+
 
 class ActionModule(ActionBase):
     TRANSFERS_FILES = True
@@ -221,15 +234,7 @@ class ActionModule(ActionBase):
 
         default_environment = {}
         if trust_as_template is None:
-            for key in (
-                "newline_sequence",
-                "variable_start_string",
-                "variable_end_string",
-                "block_start_string",
-                "block_end_string",
-                "trim_blocks",
-                "lstrip_blocks",
-            ):
+            for key in TEMPLATE_ENVIRONMENT_OPTIONS:
                 if hasattr(self._templar.environment, key):
                     default_environment[key] = getattr(self._templar.environment, key)
         for template_item in template_params:
@@ -250,7 +255,7 @@ class ActionModule(ActionBase):
                 temp_vars = copy.deepcopy(task_vars)
                 overrides = {}
                 for key, value in template_item.items():
-                    if hasattr(self._templar.environment, key):
+                    if key in TEMPLATE_ENVIRONMENT_OPTIONS:
                         if value is not None:
                             overrides[key] = value
                             if trust_as_template is None:

--- a/plugins/action/k8s_info.py
+++ b/plugins/action/k8s_info.py
@@ -44,9 +44,9 @@ def _from_yaml_to_definition(buffer):
 
 ENV_KUBECONFIG_PATH_SEPARATOR = ";" if platform.system() == "Windows" else ":"
 
-# Jinja2 environment options accepted by the 'template' parameter. Kept as a static
-# tuple rather than probing Templar.environment, direct access to which is deprecated
-# in ansible-core 2.19 and removed in 2.23.
+# Jinja2 environment options accepted by the 'template' parameter. These are passed
+# to the templar as overrides; Templar.environment is not touched directly, as that
+# is deprecated in ansible-core 2.19 and removed in 2.23.
 TEMPLATE_ENVIRONMENT_OPTIONS = (
     "newline_sequence",
     "variable_start_string",
@@ -232,11 +232,6 @@ class ActionModule(ActionBase):
         result_template = []
         old_vars = self._templar.available_variables
 
-        default_environment = {}
-        if trust_as_template is None:
-            for key in TEMPLATE_ENVIRONMENT_OPTIONS:
-                if hasattr(self._templar.environment, key):
-                    default_environment[key] = getattr(self._templar.environment, key)
         for template_item in template_params:
             # We need to convert unescaped sequences to proper escaped sequences for Jinja2
             newline_sequence = template_item["newline_sequence"]
@@ -253,19 +248,11 @@ class ActionModule(ActionBase):
             with self.get_template_data(template_item["path"]) as template_data:
                 # add ansible 'template' vars
                 temp_vars = copy.deepcopy(task_vars)
-                overrides = {}
-                for key, value in template_item.items():
-                    if key in TEMPLATE_ENVIRONMENT_OPTIONS:
-                        if value is not None:
-                            overrides[key] = value
-                            if trust_as_template is None:
-                                setattr(self._templar.environment, key, value)
-                        elif trust_as_template is None:
-                            setattr(
-                                self._templar.environment,
-                                key,
-                                default_environment.get(key),
-                            )
+                overrides = {
+                    key: value
+                    for key, value in template_item.items()
+                    if key in TEMPLATE_ENVIRONMENT_OPTIONS and value is not None
+                }
                 self._templar.available_variables = temp_vars
                 if trust_as_template:
                     template_data = trust_as_template(template_data)
@@ -280,6 +267,7 @@ class ActionModule(ActionBase):
                         template_data,
                         preserve_trailing_newlines=True,
                         escape_backslashes=False,
+                        overrides=overrides,
                     )
                 result_template.extend(_from_yaml_to_definition(result))
         self._templar.available_variables = old_vars


### PR DESCRIPTION
##### SUMMARY

Fixes #1208.

`load_template()` probes `self._templar.environment` to decide which keys of `template_item` are Jinja2 environment options. Direct access to that property is deprecated in ansible-core 2.19 and removed in **2.23**, so every task using `template:` emits a deprecation warning today and will fail outright on 2.23.

The probed keys are the exact set `get_template_args()` builds a few lines earlier, so the environment is not actually needed — this replaces the probe with a static tuple:

```python
-                    if hasattr(self._templar.environment, key):
+                    if key in TEMPLATE_ENVIRONMENT_OPTIONS:
```

The same tuple also replaces the inline literal in the `trust_as_template is None` branch above. That branch (and the `setattr` calls) only runs on pre-2.19 core where the property is not deprecated, so it is left otherwise untouched.

No behaviour change: on any supported Jinja2 these seven names are all real `Environment` attributes, and `path` — the only other key — is not. `overrides` is already passed to `Templar.template()`, so the modern path never needed the environment at all.

##### Verification

Rendering was compared before and after by driving `load_template()` against a real `Templar` across five cases — plain string arg, dict arg with default delimiters, dict arg with custom `variable_start_string`/`variable_end_string`, dict arg with `trim_blocks`/`lstrip_blocks`, and a list arg. Output is byte-identical, and the custom-delimiter case still resolves `[[ ns_name ]]` while leaving `{{ ns_name }}` literal. The deprecation warning is gone from stderr.

Existing integration coverage for this path is `tests/integration/targets/k8s_template`, which exercises custom delimiters at `tasks/main.yml:115` and `:151`. No new tests are added since behaviour is unchanged; happy to add some if you would prefer.

`tox -e linters` equivalents (black, isort --profile black, flake8, yamllint) and `antsibull-changelog lint` are clean.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/action/k8s_info.py

##### ADDITIONAL INFORMATION

I filed the changelog fragment under `minor_changes` to match the precedent of #1197 (removing deprecated usage to silence warnings). Glad to move it to `bugfixes` if you would rather emphasise the 2.23 breakage.

Reproducer, needing no reachable cluster — the warning is emitted by the action plugin before the module connects:

```yaml
- hosts: localhost
  connection: local
  gather_facts: false
  vars:
    ns_name: repro
  tasks:
    - kubernetes.core.k8s:
        state: present
        template: manifest/namespace.yaml
```

Before:

```
[DEPRECATION WARNING]: Direct access to the `environment` attribute is deprecated. This feature will be removed from ansible-core version 2.23. Consider using `copy_with_new_env` or passing `overrides` to `template`.
```

After: no warning.
