### PR TITLE
stable-5: use the pinned helm binary in helm_registry_auth and helm_diff tests

### DIFF
--- a/tests/integration/targets/helm_diff/tasks/main.yml
+++ b/tests/integration/targets/helm_diff/tasks/main.yml
@@ -239,6 +239,7 @@
           vars:
             chart_local_path: '{{ _tmpd.path }}/test-chart-deployment-time'
             chart_repo_path: 'testing'
+            helm_binary_path: "{{ helm_binary }}"
       always:
         - name: Delete temporary directory
           ansible.builtin.file:

--- a/tests/integration/targets/helm_registry_auth/defaults/main.yaml
+++ b/tests/integration/targets/helm_registry_auth/defaults/main.yaml
@@ -4,6 +4,9 @@
 username: testuser
 password: testpassword
 wrong_password: 'WrongPassword'
+# Use the helm binary installed by the install_helm role rather than the one
+# shipped with the CI image, whose version is outside of our control.
+helm_binary: "/tmp/helm/{{ ansible_system | lower }}-amd64/helm"
 registry_name: oci_registry
 registry_port: 5000
 test_chart: https://github.com/grafana/helm-charts/releases/download/k8s-monitoring-1.6.8/k8s-monitoring-1.6.8.tgz

--- a/tests/integration/targets/helm_registry_auth/tasks/main.yaml
+++ b/tests/integration/targets/helm_registry_auth/tasks/main.yaml
@@ -4,7 +4,7 @@
   # and it allow to not install any additional dependencies
   block:
     - name: Ensure that helm is installed
-      ansible.builtin.shell: helm version --client --short | grep v3
+      ansible.builtin.shell: "{{ helm_binary }} version --client --short | grep v3"
       register: _helm_version
       failed_when: _helm_version.rc != 0
 
@@ -44,14 +44,14 @@
 
     - name: Test the registry with correct credentials to ensure that the registry is running
       ansible.builtin.shell: >-
-        echo {{ password | quote }} | helm registry login localhost:{{ registry_port }}
+        echo {{ password | quote }} | {{ helm_binary }} registry login localhost:{{ registry_port }}
         -u {{ username }} --password-stdin
       register: _login_correct
       failed_when: _login_correct.rc != 0
 
     - name: Clean up credentials to run test on clean environment
       ansible.builtin.shell: >-
-        helm registry logout localhost:{{ registry_port }}
+        {{ helm_binary }} registry logout localhost:{{ registry_port }}
       register: _logout
       failed_when: _logout.rc != 0
 
@@ -70,6 +70,7 @@
 
     - name: Test module helm_registry_auth with correct credentials
       helm_registry_auth:
+        binary_path: "{{ helm_binary }}"
         username: "{{ username }}"
         password: "{{ password }}"
         host: localhost:{{ registry_port }}
@@ -87,7 +88,7 @@
 
     - name: Ensure that push to the registry is working
       ansible.builtin.shell: >-
-        helm push "{{ _destination.path }}/k8s-monitoring-1.6.8.tgz"  oci://localhost:{{ registry_port }}/test/
+        {{ helm_binary }} push "{{ _destination.path }}/k8s-monitoring-1.6.8.tgz"  oci://localhost:{{ registry_port }}/test/
       register: _save_chart
       failed_when: _save_chart.rc != 0
 
@@ -99,6 +100,7 @@
 
     - name: Test logout
       helm_registry_auth:
+        binary_path: "{{ helm_binary }}"
         host: localhost:{{ registry_port }}
         state: absent
       register: _helm_registry_auth_logout
@@ -114,6 +116,7 @@
 
         - name: Test logout idempotency
           helm_registry_auth:
+            binary_path: "{{ helm_binary }}"
             host: localhost:{{ registry_port }}
             state: absent
           register: _helm_registry_auth_logout_idempotency
@@ -124,7 +127,7 @@
 
     - name: Ensure that not able to push to the registry
       ansible.builtin.shell: >-
-        helm push "{{ _destination.path }}/k8s-monitoring-1.6.8.tgz"  oci://localhost:{{ registry_port }}/test/
+        {{ helm_binary }} push "{{ _destination.path }}/k8s-monitoring-1.6.8.tgz"  oci://localhost:{{ registry_port }}/test/
       register: _save_chart
       failed_when: _save_chart.rc == 0
 
@@ -143,6 +146,7 @@
 
     - name: Test module helm_registry_auth with wrong credentials
       helm_registry_auth:
+        binary_path: "{{ helm_binary }}"
         username: "{{ username }}"
         password: "{{ wrong_password }}"
         host: localhost:{{ registry_port }}


### PR DESCRIPTION
##### SUMMARY

Fixes #1218.

`helm_registry_auth` and `helm_diff` resolved `helm` from `PATH` instead of the binary installed by the `install_helm` role. The runner image now ships helm `v3.21.3`, which returns `401 Unauthorized` when pushing to the plain-HTTP test registry, while `install_helm` pins `v3.16.4`.

* `helm_registry_auth` — added `helm_binary` to the target defaults and used it in the shell tasks and as `binary_path` for the module calls. The target already depended on `install_helm`, it just never used the result.
* `helm_diff` — pass `helm_binary_path: "{{ helm_binary }}"` when including `push_to_helm_registry`. Without it the role used its own default of `helm`, so the target was mixing two helm binaries: the pinned one for `Log into Helm registry` and the one from `PATH` for the push.

This is the `stable-5` counterpart of what #1090 did on `main`, limited to the test files. `main` and `stable-6` additionally rewrote `helm_registry_auth` to run against several pinned helm versions with `--plain-http`, which depends on the `plain_http` module option that does not exist on `stable-5`. Pinning the binary keeps this to a test-only change, so `stable-5` continues to be tested against helm 3.16.4 while newer helm coverage stays on `main`/`stable-6`.

No changelog fragment: `tests/` only.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

tests/integration/targets/helm_registry_auth, tests/integration/targets/helm_diff

##### ADDITIONAL INFORMATION

Before, on #1199 (all four matrix combinations of shards 4 and 8):

```
TASK [helm_registry_auth : Test module helm_registry_auth with correct credentials] ***
changed: [localhost] => {"command": "/usr/local/bin/helm registry login localhost:5000 --username=testuser --password-stdin", "stderr": "Login Succeeded\n", ...}

TASK [helm_registry_auth : Ensure that push to the registry is working] ********
fatal: [localhost]: FAILED! => {
    "cmd": "helm push \"/tmp/ansible.poej0iam.helm/k8s-monitoring-1.6.8.tgz\"  oci://localhost:5000/test/",
    "rc": 1,
    "stderr": "Error: failed to perform \"Exists\" on destination: HEAD \"http://localhost:5000/v2/test/k8s-monitoring/manifests/sha256:fea90b12...\": response status code 401: Unauthorized"
}

FATAL: The 1 integration test(s) listed below (out of 3) failed. See error output above for details:
helm_registry_auth
```

```
TASK [push_to_helm_registry : Helm push chart to the registry] *****************
fatal: [localhost]: FAILED! => {
    "cmd": ["helm", "push", "/tmp/ansible._h27f4p0.chart/test-chart-deployment-time-0.1.0.tgz", "oci://localhost:6035/testing"],
    "rc": 1,
    "stderr": "Error: failed to perform \"Exists\" on destination: HEAD \"http://localhost:6035/v2/testing/test-chart-deployment-time/manifests/sha256:1de6f019...\": response status code 401: Unauthorized"
}

FATAL: The 1 integration test(s) listed below (out of 9) failed. See error output above for details:
helm_diff
```

Note that with the pinned 3.16.4 the `Test idempotency of logout with helm < 3.18.0` block in `helm_registry_auth` runs again; it was being skipped while the newer binary from `PATH` was in use.
