### PR TITLE
ci: add the PE certification checker workflow

### DIFF
--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -6,7 +6,9 @@ permissions:
 
 on:
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - stable-*
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -1,0 +1,18 @@
+---
+name: Run collection certification checks
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: cert-ver-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  call:
+    uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@f4bf7ba4d3f008b2db8fc6a812fa3f89fdf42c2e # v4.1.0


### PR DESCRIPTION
##### SUMMARY

This change adds the [Red Hat partner certification checker](https://github.com/ansible-collections/partner-certification-checker#red-hat-partner-certification-checker) workflow that runs checks that match the Automation Hub import process.

Tracked in Jira via `ACA-5380`.

##### ISSUE TYPE

- Feature Pull Request