### PR TITLE
fix: add default to k8s_copy init-pod until conditional

### DIFF
--- a/tests/integration/targets/k8s_copy/tasks/main.yml
+++ b/tests/integration/targets/k8s_copy/tasks/main.yml
@@ -33,7 +33,7 @@
         init_pod_status.resources|length > 0
         and 'initContainerStatuses' in init_pod_status.resources.0.status
         and init_pod_status.resources.0.status.initContainerStatuses|length > 0
-        and init_pod_status.resources.0.status.initContainerStatuses.0.started|bool
+        and init_pod_status.resources.0.status.initContainerStatuses.0.started|default(false)|bool
 
     - include_tasks: test_copy_errors.yml
     - include_tasks: test_check_mode.yml


### PR DESCRIPTION
##### SUMMARY

This change adds a default value of false to the init-pod until conditional in `tests/integration/targets/k8s_copy/tasks/main.yml`

I noticed this in https://github.com/ansible-collections/cloud.common/pull/203 You can see the `kubernetes.core-4` integration tests are failing with `object of type 'dict' has no attribute 'started`. I believe it's related to the templating changes that happened in core 2.19 / Ansible 12. From the porting guide at: https://docs.ansible.com/projects/ansible/latest/porting_guides/porting_guide_12.html#improved-handling-of-undefined

"Undefined handling has been improved to avoid situations where a Jinja plugin silently ignores undefined values. This commonly occurs when a Jinja plugin, such as a filter or test, checks the type of a variable without accounting for the possibility of an undefined value being present."

##### ISSUE TYPE

- Bugfix Pull Request