### PR TITLE
chore(test): add ansible 2.21 to integration tests matrix

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -61,6 +61,9 @@ jobs:
         enable-turbo-mode: [true, false]
         python-version: ["3.12", "3.13"]
         exclude:
+          # stable-2.18 is used mainly because turbo mode, no reason to test it with turbo mode disabled
+          - ansible-version: "stable-2.18"
+            enable-turbo-mode: false
           # turbo mode is supported only by ansible<2.19
           - ansible-version: "milestone"
             enable-turbo-mode: true

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -56,15 +56,21 @@ jobs:
       fail-fast: false
       matrix:
         # Ref must match a branch/tag on github.com/ansible/ansible (e.g. stable-2.18, not 2.18).
-        ansible-version: ["stable-2.18", "milestone"]
+        #
+        ansible-version: ["stable-2.18", "stable-2.21", "milestone"]
         enable-turbo-mode: [true, false]
         python-version: ["3.12", "3.13"]
         exclude:
+          # turbo mode is supported only by ansible<2.19
           - ansible-version: "milestone"
             enable-turbo-mode: true
-          # stable-2.18 supports 3.12; milestone (devel) requires >=3.13
+          - ansible-version: "stable-2.21"
+            enable-turbo-mode: true
+          # stable-2.18 supports 3.12
           - ansible-version: "stable-2.18"
             python-version: "3.13"
+          - ansible-version: "stable-2.21"
+            python-version: "3.12"
           - ansible-version: "milestone"
             python-version: "3.12"
         workflow-id: ${{ fromJson(needs.splitter.outputs.test_jobs) }}


### PR DESCRIPTION

##### SUMMARY

The current version of Ansible (at the time of this PR) is 2.21, which is included in the Ansible 14 release.

To ensure testing coverage for the actual version of Ansible, version 2.21 should be included in the integration test matrix.

So, the updated matrix includes:
| version | reson | notes |
| --- | --- | --- |
| stable-2.18 | the latest version supporting turbo mode | Python 3.12 as 3.13 is not supported |
| stable-2.21 | the actual stable version | No turbo mode, only 3.13 to decrease CI cost |
| milestone | the development version |  No turbo mode, only 3.13 to decrease CI cost |
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- CI/Testing

##### COMPONENT NAME
.github/workflows/integration-tests.yaml

##### ADDITIONAL INFORMATION
This PR slightly increases the cost and time of CI test execution, and probably worth adding a label `test-all-the-targets` and `skip-changelog`

PR is a result of a conversation with @oraNod