### PR TITLE
fix(helm_repository): normalize both sides of the repo URL comparison

### DIFF
--- a/changelogs/fragments/20260908-helm-repository-trailing-slash.yaml
+++ b/changelogs/fragments/20260908-helm-repository-trailing-slash.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - helm_repository - normalize both sides of the repository URL comparison, so that a repository already registered with a trailing slash is recognized as matching instead of failing with ``Repository already have a repository named <name>`` (https://github.com/ansible-collections/kubernetes.core/pull/1236).

--- a/plugins/modules/helm_repository.py
+++ b/plugins/modules/helm_repository.py
@@ -331,7 +331,7 @@ def main():
                 insecure_skip_tls_verify,
             )
             changed = True
-        elif repository_status["url"] != repo_url:
+        elif repository_status["url"].rstrip("/") != repo_url:
             module.fail_json(
                 msg="Repository already have a repository named {0}".format(repo_name)
             )

--- a/tests/integration/targets/helm_repository/tasks/run_tests.yml
+++ b/tests/integration/targets/helm_repository/tasks/run_tests.yml
@@ -103,3 +103,81 @@
     binary_path: "{{ helm_binary }}"
     name: test_helm_repo
     state: absent
+
+# https://github.com/ansible-collections/kubernetes.core/issues/1235
+- name: Ensure the trailing slash test repositories don't exist
+  helm_repository:
+    binary_path: "{{ helm_binary }}"
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - test_helm_repo_slash
+    - test_helm_repo_noslash
+
+- name: Register test_helm_repo_slash directly through helm, keeping the trailing slash
+  ansible.builtin.command: "{{ helm_binary }} repo add test_helm_repo_slash {{ chart_test_repo }}/"
+  changed_when: true
+
+- name: Add test_helm_repo_noslash chart repository without a trailing slash
+  helm_repository:
+    binary_path: "{{ helm_binary }}"
+    name: test_helm_repo_noslash
+    repo_url: "{{ chart_test_repo }}"
+
+- name: Check idempotency when the stored and the requested URL both have a trailing slash
+  helm_repository:
+    binary_path: "{{ helm_binary }}"
+    name: test_helm_repo_slash
+    repo_url: "{{ chart_test_repo }}/"
+  register: repository
+
+- name: Assert idempotency when the stored and the requested URL both have a trailing slash
+  assert:
+    that:
+      - repository is not changed
+
+- name: Check idempotency when only the stored URL has a trailing slash
+  helm_repository:
+    binary_path: "{{ helm_binary }}"
+    name: test_helm_repo_slash
+    repo_url: "{{ chart_test_repo }}"
+  register: repository
+
+- name: Assert idempotency when only the stored URL has a trailing slash
+  assert:
+    that:
+      - repository is not changed
+
+- name: Check idempotency when only the requested URL has a trailing slash
+  helm_repository:
+    binary_path: "{{ helm_binary }}"
+    name: test_helm_repo_noslash
+    repo_url: "{{ chart_test_repo }}/"
+  register: repository
+
+- name: Assert idempotency when only the requested URL has a trailing slash
+  assert:
+    that:
+      - repository is not changed
+
+- name: Failed to add repository with the same name and a different URL, trailing slash aside
+  helm_repository:
+    binary_path: "{{ helm_binary }}"
+    name: test_helm_repo_slash
+    repo_url: "https://other-charts.url/"
+  register: repository_errors
+  ignore_errors: true
+
+- name: Assert that adding repository with the same name and a different URL failed
+  assert:
+    that:
+      - repository_errors is failed
+
+- name: Clean the trailing slash test repositories
+  helm_repository:
+    binary_path: "{{ helm_binary }}"
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - test_helm_repo_slash
+    - test_helm_repo_noslash


### PR DESCRIPTION
##### SUMMARY
helm stores repository URLs verbatim, so a repository registered with a trailing slash keeps it in `repositories.yaml`.  #1121 normalized only the URL coming from the task, leaving the comparison asymmetric, so a repository that already matched was reported as a name conflict. Normalize both sides.

Fixes #1235

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
helm_repository

##### ADDITIONAL INFORMATION
The integration target only covered "stored without slash / requested without slash". Added the three remaining combinations, plus a negative case asserting a genuinely different URL still fails. `test_helm_repo_slash` is registered by calling `helm repo add` directly, since the module can no longer produce a stored URL with a trailing slash.
